### PR TITLE
Fix/remove pgsodium

### DIFF
--- a/src/routes/_user/learn.index.tsx
+++ b/src/routes/_user/learn.index.tsx
@@ -1,9 +1,8 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { FolderPlus, Home, Search, Star, Users } from 'lucide-react'
+import { Star, Users } from 'lucide-react'
 import { Loader } from '@/components/ui/loader'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
-import type { TitleBar } from '@/types/main'
 import { useProfile } from '@/lib/use-profile'
 import { ago } from '@/lib/dayjs'
 
@@ -17,7 +16,7 @@ export default function Page() {
 		<main className="grid gap-4 @lg:grid-cols-2">
 			{isPending ?
 				<Loader />
-			:	Object.entries(profile?.decksMap).map(([key, deck]) => (
+			:	Object.entries(profile?.decksMap ?? []).map(([key, deck]) => (
 					<Link
 						key={key}
 						to="/learn/$lang"

--- a/supabase/migrations/20250120114937_remote_schema.sql
+++ b/supabase/migrations/20250120114937_remote_schema.sql
@@ -12,7 +12,7 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 
-CREATE EXTENSION IF NOT EXISTS "pgsodium" WITH SCHEMA "pgsodium";
+-- CREATE EXTENSION IF NOT EXISTS "pgsodium" WITH SCHEMA "pgsodium";
 
 
 

--- a/supabase/schemas/base.sql
+++ b/supabase/schemas/base.sql
@@ -9,7 +9,7 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
-CREATE EXTENSION IF NOT EXISTS "pgsodium" WITH SCHEMA "pgsodium";
+-- CREATE EXTENSION IF NOT EXISTS "pgsodium" WITH SCHEMA "pgsodium";
 
 ALTER SCHEMA "public" OWNER TO "postgres";
 

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -834,7 +834,7 @@ SELECT pg_catalog.setval('"auth"."refresh_tokens_id_seq"', 2801, true);
 -- Name: key_key_id_seq; Type: SEQUENCE SET; Schema: pgsodium; Owner: supabase_admin
 --
 
-SELECT pg_catalog.setval('"pgsodium"."key_key_id_seq"', 1, false);
+-- SELECT pg_catalog.setval('"pgsodium"."key_key_id_seq"', 1, false);
 
 
 


### PR DESCRIPTION
PGSodium is no longer included in the base Postgres build, so enabling the extension on that schema creates an error (in the very first migration). We could manually create the schema beforehand, but it gets created later as a part of the vault extension, and Supabase's guidance is to just comment out these references (even in the old, previously-applied migrations!) and then fix up the production database's migration tables using the CLI's `migration repair` command.