### PR TITLE
Feature: "preflight" review index page

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"react-hook-form": "^7.55.0",
 		"react-hot-toast": "^2.5.2",
 		"tailwindcss-animate": "^1.0.7",
+		"vaul": "^1.1.2",
 		"zod": "^3.24.2"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.1.3)
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -2835,6 +2838,12 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+
   vite-tsconfig-paths@5.1.4:
     resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
     peerDependencies:
@@ -5345,6 +5354,15 @@ snapshots:
       react: 19.1.0
 
   util-deprecate@1.0.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.7(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@5.4.18(@types/node@22.14.0)(lightningcss@1.29.2)):
     dependencies:

--- a/src/components/auth-context.tsx
+++ b/src/components/auth-context.tsx
@@ -22,7 +22,7 @@ export const AuthContext = createContext<AuthState>(undefined)
 
 export function AuthProvider({ children }: PropsWithChildren) {
 	const queryClient = useQueryClient()
-	const [sessionState, setSessionState] = useState<Session>(null)
+	const [sessionState, setSessionState] = useState<Session | null>(null)
 	const [isLoaded, setIsLoaded] = useState(false)
 	const setLoaded = () => setIsLoaded(true)
 
@@ -62,8 +62,8 @@ export function AuthProvider({ children }: PropsWithChildren) {
 
 	const value = {
 		isAuth: sessionState?.user.role === 'authenticated',
-		userId: sessionState?.user.id,
-		userEmail: sessionState?.user.email,
+		userId: sessionState?.user.id ?? null,
+		userEmail: sessionState?.user.email ?? null,
 		userRole: (sessionState?.user?.user_metadata?.role as RolesEnum) ?? null,
 	}
 

--- a/src/components/one-sidebar-menu.tsx
+++ b/src/components/one-sidebar-menu.tsx
@@ -23,7 +23,9 @@ export default function OneSidebarMenu({
 					<SidebarMenuItem key={item.name}>
 						<SidebarMenuButton asChild>
 							<Link {...item.link}>
-								<item.Icon />
+								{typeof item.Icon === 'function' ?
+									<item.Icon />
+								:	null}
 								<span>{item.title ?? item.name}</span>
 							</Link>
 						</SidebarMenuButton>

--- a/src/components/ui/badge-variants.tsx
+++ b/src/components/ui/badge-variants.tsx
@@ -12,7 +12,7 @@ const badgeVariants = cva(
 					'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
 				destructive:
 					'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
-				outline: 'text-foreground font-normal',
+				outline: 'text-foreground font-normal border-primary/50',
 			},
 		},
 		defaultVariants: {

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react'
+import { Drawer as DrawerPrimitive } from 'vaul'
+
+import { cn } from '@/lib/utils'
+
+function Drawer({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+	return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+}
+
+function DrawerTrigger({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+	return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
+}
+
+function DrawerPortal({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+	return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
+}
+
+function DrawerClose({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+	return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+}
+
+function DrawerOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+	return (
+		<DrawerPrimitive.Overlay
+			data-slot="drawer-overlay"
+			className={cn(
+				'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+				className
+			)}
+			{...props}
+		/>
+	)
+}
+
+function DrawerContent({
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+	return (
+		<DrawerPortal data-slot="drawer-portal">
+			<DrawerOverlay />
+			<DrawerPrimitive.Content
+				data-slot="drawer-content"
+				className={cn(
+					'group/drawer-content bg-background fixed z-50 flex h-auto flex-col',
+					'data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b',
+					'data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t',
+					'data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm',
+					'data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm',
+					className
+				)}
+				{...props}
+			>
+				<div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+				{children}
+			</DrawerPrimitive.Content>
+		</DrawerPortal>
+	)
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
+	return (
+		<div
+			data-slot="drawer-header"
+			className={cn('flex flex-col gap-1.5 p-4', className)}
+			{...props}
+		/>
+	)
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
+	return (
+		<div
+			data-slot="drawer-footer"
+			className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+			{...props}
+		/>
+	)
+}
+
+function DrawerTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+	return (
+		<DrawerPrimitive.Title
+			data-slot="drawer-title"
+			className={cn('text-foreground font-semibold', className)}
+			{...props}
+		/>
+	)
+}
+
+function DrawerDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+	return (
+		<DrawerPrimitive.Description
+			data-slot="drawer-description"
+			className={cn('text-muted-foreground text-sm', className)}
+			{...props}
+		/>
+	)
+}
+
+export {
+	Drawer,
+	DrawerPortal,
+	DrawerOverlay,
+	DrawerTrigger,
+	DrawerClose,
+	DrawerContent,
+	DrawerHeader,
+	DrawerFooter,
+	DrawerTitle,
+	DrawerDescription,
+}

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -11,9 +11,11 @@ type FlagMap = {
 }
 export const flags: FlagMap = {
 	smart_recommendations: { enabled: false },
+	friend_recommendations: { enabled: false },
 	friends_activity: { enabled: false },
 	learning_goals: { enabled: false },
 	text_to_speech: { enabled: false },
 	cards_schedule_metadata: { enabled: false },
 	deck_metadata_on_cards: { enabled: false },
+	routines_goals: { enabled: false },
 }

--- a/src/lib/use-deck.ts
+++ b/src/lib/use-deck.ts
@@ -29,8 +29,12 @@ async function fetchDeck(lang: string): Promise<DeckLoaded> {
 		.eq('lang', lang)
 		.maybeSingle()
 		.throwOnError()
+	if (!data)
+		throw Error(
+			`This deck was not found in your profile. Perhaps it's just a bad URL? Please double check the language code in your URL; it should be 3 characters long, like "eng" or "hin". ${lang.length > 3 ? `Maybe you meant "${lang.substring(0, 3)}"?` : ''}`
+		)
 	const { cards: cardsArray, ...meta }: DeckFetched = data
-	const pids: pids = cardsArray?.map((c) => c.phrase_id)
+	const pids: pids = cardsArray?.map((c) => c.phrase_id!)
 	const cardsMap: CardsMap = mapArray(cardsArray, 'phrase_id')
 	return {
 		meta,
@@ -39,7 +43,7 @@ async function fetchDeck(lang: string): Promise<DeckLoaded> {
 	}
 }
 
-export const deckQueryOptions = (lang: string, userId: uuid) =>
+export const deckQueryOptions = (lang: string, userId: uuid | null) =>
 	queryOptions({
 		queryKey: ['user', lang],
 		queryFn: async ({ queryKey }) => fetchDeck(queryKey[1]),

--- a/src/lib/use-language.ts
+++ b/src/lib/use-language.ts
@@ -27,8 +27,12 @@ export async function fetchLanguage(lang: string): Promise<LanguageLoaded> {
 		.eq('lang', lang)
 		.maybeSingle()
 		.throwOnError()
+	if (!data)
+		throw Error(
+			`This language was not found in the database. Please double check the language code in your URL or report a bug to an admin. (The language code provided: ${lang}. This should be a 3-character string like "eng" or "hin".) ${lang.length > 3 ? `Maybe you meant "${lang.substring(0, 3)}"?` : ''}`
+		)
 	const { phrases: phrasesArray, ...meta }: LanguageFetched = data
-	const pids: pids = phrasesArray?.map((p) => p.id)
+	const pids: pids = phrasesArray?.map((p) => p.id!)
 	const phrasesMap: PhrasesMap = mapArray(phrasesArray, 'id')
 	return {
 		meta,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -46,6 +46,8 @@ import { Route as UserLearnLangDeckSettingsImport } from './routes/_user/learn.$
 import { Route as UserLearnLangAddPhraseImport } from './routes/_user/learn.$lang.add-phrase'
 import { Route as UserLearnLangIdImport } from './routes/_user/learn.$lang.$id'
 import { Route as UserFriendsSearchUidImport } from './routes/_user/friends.search.$uid'
+import { Route as UserLearnLangReviewIndexImport } from './routes/_user/learn.$lang.review.index'
+import { Route as UserLearnLangReviewGoImport } from './routes/_user/learn.$lang.review.go'
 
 // Create Virtual Routes
 
@@ -279,6 +281,18 @@ const UserFriendsSearchUidRoute = UserFriendsSearchUidImport.update({
   id: '/$uid',
   path: '/$uid',
   getParentRoute: () => UserFriendsSearchRoute,
+} as any)
+
+const UserLearnLangReviewIndexRoute = UserLearnLangReviewIndexImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => UserLearnLangReviewRoute,
+} as any)
+
+const UserLearnLangReviewGoRoute = UserLearnLangReviewGoImport.update({
+  id: '/go',
+  path: '/go',
+  getParentRoute: () => UserLearnLangReviewRoute,
 } as any)
 
 // Populate the FileRoutesByPath interface
@@ -544,6 +558,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UserLearnLangIndexImport
       parentRoute: typeof UserLearnLangImport
     }
+    '/_user/learn/$lang/review/go': {
+      id: '/_user/learn/$lang/review/go'
+      path: '/go'
+      fullPath: '/learn/$lang/review/go'
+      preLoaderRoute: typeof UserLearnLangReviewGoImport
+      parentRoute: typeof UserLearnLangReviewImport
+    }
+    '/_user/learn/$lang/review/': {
+      id: '/_user/learn/$lang/review/'
+      path: '/'
+      fullPath: '/learn/$lang/review/'
+      preLoaderRoute: typeof UserLearnLangReviewIndexImport
+      parentRoute: typeof UserLearnLangReviewImport
+    }
   }
 }
 
@@ -596,12 +624,25 @@ const UserFriendsRouteWithChildren = UserFriendsRoute._addFileChildren(
   UserFriendsRouteChildren,
 )
 
+interface UserLearnLangReviewRouteChildren {
+  UserLearnLangReviewGoRoute: typeof UserLearnLangReviewGoRoute
+  UserLearnLangReviewIndexRoute: typeof UserLearnLangReviewIndexRoute
+}
+
+const UserLearnLangReviewRouteChildren: UserLearnLangReviewRouteChildren = {
+  UserLearnLangReviewGoRoute: UserLearnLangReviewGoRoute,
+  UserLearnLangReviewIndexRoute: UserLearnLangReviewIndexRoute,
+}
+
+const UserLearnLangReviewRouteWithChildren =
+  UserLearnLangReviewRoute._addFileChildren(UserLearnLangReviewRouteChildren)
+
 interface UserLearnLangRouteChildren {
   UserLearnLangIdRoute: typeof UserLearnLangIdRoute
   UserLearnLangAddPhraseRoute: typeof UserLearnLangAddPhraseRoute
   UserLearnLangDeckSettingsRoute: typeof UserLearnLangDeckSettingsRoute
   UserLearnLangLibraryRoute: typeof UserLearnLangLibraryRoute
-  UserLearnLangReviewRoute: typeof UserLearnLangReviewRoute
+  UserLearnLangReviewRoute: typeof UserLearnLangReviewRouteWithChildren
   UserLearnLangSearchRoute: typeof UserLearnLangSearchRoute
   UserLearnLangIndexRoute: typeof UserLearnLangIndexRoute
 }
@@ -611,7 +652,7 @@ const UserLearnLangRouteChildren: UserLearnLangRouteChildren = {
   UserLearnLangAddPhraseRoute: UserLearnLangAddPhraseRoute,
   UserLearnLangDeckSettingsRoute: UserLearnLangDeckSettingsRoute,
   UserLearnLangLibraryRoute: UserLearnLangLibraryRoute,
-  UserLearnLangReviewRoute: UserLearnLangReviewRoute,
+  UserLearnLangReviewRoute: UserLearnLangReviewRouteWithChildren,
   UserLearnLangSearchRoute: UserLearnLangSearchRoute,
   UserLearnLangIndexRoute: UserLearnLangIndexRoute,
 }
@@ -708,9 +749,11 @@ export interface FileRoutesByFullPath {
   '/learn/$lang/add-phrase': typeof UserLearnLangAddPhraseRoute
   '/learn/$lang/deck-settings': typeof UserLearnLangDeckSettingsRoute
   '/learn/$lang/library': typeof UserLearnLangLibraryRoute
-  '/learn/$lang/review': typeof UserLearnLangReviewRoute
+  '/learn/$lang/review': typeof UserLearnLangReviewRouteWithChildren
   '/learn/$lang/search': typeof UserLearnLangSearchRoute
   '/learn/$lang/': typeof UserLearnLangIndexRoute
+  '/learn/$lang/review/go': typeof UserLearnLangReviewGoRoute
+  '/learn/$lang/review/': typeof UserLearnLangReviewIndexRoute
 }
 
 export interface FileRoutesByTo {
@@ -743,9 +786,10 @@ export interface FileRoutesByTo {
   '/learn/$lang/add-phrase': typeof UserLearnLangAddPhraseRoute
   '/learn/$lang/deck-settings': typeof UserLearnLangDeckSettingsRoute
   '/learn/$lang/library': typeof UserLearnLangLibraryRoute
-  '/learn/$lang/review': typeof UserLearnLangReviewRoute
   '/learn/$lang/search': typeof UserLearnLangSearchRoute
   '/learn/$lang': typeof UserLearnLangIndexRoute
+  '/learn/$lang/review/go': typeof UserLearnLangReviewGoRoute
+  '/learn/$lang/review': typeof UserLearnLangReviewIndexRoute
 }
 
 export interface FileRoutesById {
@@ -784,9 +828,11 @@ export interface FileRoutesById {
   '/_user/learn/$lang/add-phrase': typeof UserLearnLangAddPhraseRoute
   '/_user/learn/$lang/deck-settings': typeof UserLearnLangDeckSettingsRoute
   '/_user/learn/$lang/library': typeof UserLearnLangLibraryRoute
-  '/_user/learn/$lang/review': typeof UserLearnLangReviewRoute
+  '/_user/learn/$lang/review': typeof UserLearnLangReviewRouteWithChildren
   '/_user/learn/$lang/search': typeof UserLearnLangSearchRoute
   '/_user/learn/$lang/': typeof UserLearnLangIndexRoute
+  '/_user/learn/$lang/review/go': typeof UserLearnLangReviewGoRoute
+  '/_user/learn/$lang/review/': typeof UserLearnLangReviewIndexRoute
 }
 
 export interface FileRouteTypes {
@@ -828,6 +874,8 @@ export interface FileRouteTypes {
     | '/learn/$lang/review'
     | '/learn/$lang/search'
     | '/learn/$lang/'
+    | '/learn/$lang/review/go'
+    | '/learn/$lang/review/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -859,9 +907,10 @@ export interface FileRouteTypes {
     | '/learn/$lang/add-phrase'
     | '/learn/$lang/deck-settings'
     | '/learn/$lang/library'
-    | '/learn/$lang/review'
     | '/learn/$lang/search'
     | '/learn/$lang'
+    | '/learn/$lang/review/go'
+    | '/learn/$lang/review'
   id:
     | '__root__'
     | '/'
@@ -901,6 +950,8 @@ export interface FileRouteTypes {
     | '/_user/learn/$lang/review'
     | '/_user/learn/$lang/search'
     | '/_user/learn/$lang/'
+    | '/_user/learn/$lang/review/go'
+    | '/_user/learn/$lang/review/'
   fileRoutesById: FileRoutesById
 }
 
@@ -1118,7 +1169,11 @@ export const routeTree = rootRoute
     },
     "/_user/learn/$lang/review": {
       "filePath": "_user/learn.$lang.review.tsx",
-      "parent": "/_user/learn/$lang"
+      "parent": "/_user/learn/$lang",
+      "children": [
+        "/_user/learn/$lang/review/go",
+        "/_user/learn/$lang/review/"
+      ]
     },
     "/_user/learn/$lang/search": {
       "filePath": "_user/learn.$lang.search.tsx",
@@ -1127,6 +1182,14 @@ export const routeTree = rootRoute
     "/_user/learn/$lang/": {
       "filePath": "_user/learn.$lang.index.tsx",
       "parent": "/_user/learn/$lang"
+    },
+    "/_user/learn/$lang/review/go": {
+      "filePath": "_user/learn.$lang.review.go.tsx",
+      "parent": "/_user/learn/$lang/review"
+    },
+    "/_user/learn/$lang/review/": {
+      "filePath": "_user/learn.$lang.review.index.tsx",
+      "parent": "/_user/learn/$lang/review"
     }
   }
 }

--- a/src/routes/_user/learn.$lang.index.tsx
+++ b/src/routes/_user/learn.$lang.index.tsx
@@ -103,6 +103,7 @@ function FriendsSection({ lang }: LangOnlyComponentProps) {
 
 function DeckOverview({ lang }: LangOnlyComponentProps) {
 	const { data } = useDeckMeta(lang)
+	if (!data) throw Error('This deck does not exist, sorry 🧄☹️🥦')
 	return (
 		<Card>
 			<CardHeader>
@@ -137,7 +138,9 @@ function DeckOverview({ lang }: LangOnlyComponentProps) {
 			</CardHeader>
 			<CardContent className="text-sm">
 				<p>Your last review was {ago(data.most_recent_review_at)}</p>
-				<p>You've kept up with your routine 4 out of 5 days this week</p>
+				<Flagged name="routines_goals">
+					<p>You've kept up with your routine 4 out of 5 days this week</p>
+				</Flagged>
 				<p>34 active cards are scheduled for today, along with 15 new ones</p>
 			</CardContent>
 			<CardFooter>

--- a/src/routes/_user/learn.$lang.review.go.tsx
+++ b/src/routes/_user/learn.$lang.review.go.tsx
@@ -1,53 +1,21 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, useLoaderData } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
-import { TitleBar } from '@/types/main'
 import { FlashCardReviewSession } from '@/components/flash-card-review-session'
 import languages from '@/lib/languages'
-import { deckQueryOptions } from '@/lib/use-deck'
-import { reviewablesQueryOptions } from '@/lib/use-reviewables'
-import { BookHeart } from 'lucide-react'
 
 export const Route = createFileRoute('/_user/learn/$lang/review/go')({
 	component: ReviewPage,
-	loader: async ({
-		params: { lang },
-		context: {
-			queryClient,
-			auth: { userId },
-		},
-	}) => {
-		if (!userId) throw new Error('No userId present, for some reason')
-		const promise1 = queryClient.fetchQuery(deckQueryOptions(lang, userId))
-		const promise2 = queryClient.fetchQuery(
-			reviewablesQueryOptions(lang, userId)
-		)
-		const data = {
-			deck: await promise1,
-			reviewables: await promise2,
-		}
-		console.log(`preparing today's review`, data)
+	loader: () => {
 		return {
-			reviewableCards: data.reviewables.map(
-				(r) => data.deck.cardsMap[r.phrase_id!]
-			),
 			appnav: [],
-			contextMenu: [
-				'/learn/$lang/search',
-				'/learn/$lang/add-phrase',
-				'/learn/$lang/deck-settings',
-			],
-			titleBar: {
-				title: `Review ${languages[lang]} cards`,
-				Icon: BookHeart,
-			} as TitleBar,
 		}
 	},
 })
 
 function ReviewPage() {
 	const { lang } = Route.useParams()
-	const { reviewableCards } = Route.useLoaderData()
+	const { reviewableCards } = useLoaderData({ from: '/_user/learn/$lang' })
 	return reviewableCards.length === 0 ?
 			<Empty lang={lang} />
 		:	<FlashCardReviewSession cards={reviewableCards} lang={lang} />

--- a/src/routes/_user/learn.$lang.review.go.tsx
+++ b/src/routes/_user/learn.$lang.review.go.tsx
@@ -1,0 +1,89 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+import { TitleBar } from '@/types/main'
+import { FlashCardReviewSession } from '@/components/flash-card-review-session'
+import languages from '@/lib/languages'
+import { deckQueryOptions } from '@/lib/use-deck'
+import { reviewablesQueryOptions } from '@/lib/use-reviewables'
+import { BookHeart } from 'lucide-react'
+
+export const Route = createFileRoute('/_user/learn/$lang/review/go')({
+	component: ReviewPage,
+	loader: async ({
+		params: { lang },
+		context: {
+			queryClient,
+			auth: { userId },
+		},
+	}) => {
+		if (!userId) throw new Error('No userId present, for some reason')
+		const promise1 = queryClient.fetchQuery(deckQueryOptions(lang, userId))
+		const promise2 = queryClient.fetchQuery(
+			reviewablesQueryOptions(lang, userId)
+		)
+		const data = {
+			deck: await promise1,
+			reviewables: await promise2,
+		}
+		console.log(`preparing today's review`, data)
+		return {
+			reviewableCards: data.reviewables.map(
+				(r) => data.deck.cardsMap[r.phrase_id!]
+			),
+			appnav: [],
+			contextMenu: [
+				'/learn/$lang/search',
+				'/learn/$lang/add-phrase',
+				'/learn/$lang/deck-settings',
+			],
+			titleBar: {
+				title: `Review ${languages[lang]} cards`,
+				Icon: BookHeart,
+			} as TitleBar,
+		}
+	},
+})
+
+function ReviewPage() {
+	const { lang } = Route.useParams()
+	const { reviewableCards } = Route.useLoaderData()
+	return reviewableCards.length === 0 ?
+			<Empty lang={lang} />
+		:	<FlashCardReviewSession cards={reviewableCards} lang={lang} />
+}
+
+const Empty = ({ lang }: { lang: string }) => (
+	<Card className="px-[5%] py-6">
+		<CardHeader className="my-6 opacity-70">
+			<CardTitle>No cards to review</CardTitle>
+		</CardHeader>
+		<CardContent className="mb-6 space-y-4">
+			<p>
+				This is empty because there are no active cards in your{' '}
+				{languages[lang]} deck.
+			</p>
+			<p>
+				You can{' '}
+				<Link
+					className="s-link"
+					to="/learn/$lang/library"
+					params={{ lang }}
+					from={Route.fullPath}
+				>
+					browse the library
+				</Link>{' '}
+				to find new phrases to learn, or{' '}
+				<Link
+					className="s-link"
+					to="/learn/$lang/add-phrase"
+					params={{ lang }}
+					from={Route.fullPath}
+				>
+					add your own
+				</Link>
+				!
+			</p>
+		</CardContent>
+	</Card>
+)

--- a/src/routes/_user/learn.$lang.review.index.todo.md
+++ b/src/routes/_user/learn.$lang.review.index.todo.md
@@ -1,0 +1,8 @@
+1. The new card selector uses its own kind of styles: `card.selected ? 'border-primary bg-primary/10' : ''`
+   perhaps re-use the styles from the signup page or the deck options page?
+   1. Actually please standardise this across these different kinds of selectors,
+      and maybe even include the simple select and the highlighting its option elements.
+      e.g. ``className={`option-all ${ el.selected ? 'option-selected' : 'option-unselected'}`}``
+   1. Actually it might be nice to use this pattern for a bunch of shadcn things too... for
+      daisy-style markup improvements / readability of the DOM, but it would make it more difficult
+      to review updates to shadcn markup (we ignore most of them anyway, but mindfully)

--- a/src/routes/_user/learn.$lang.review.index.todo.md
+++ b/src/routes/_user/learn.$lang.review.index.todo.md
@@ -1,8 +1,0 @@
-1. The new card selector uses its own kind of styles: `card.selected ? 'border-primary bg-primary/10' : ''`
-   perhaps re-use the styles from the signup page or the deck options page?
-   1. Actually please standardise this across these different kinds of selectors,
-      and maybe even include the simple select and the highlighting its option elements.
-      e.g. ``className={`option-all ${ el.selected ? 'option-selected' : 'option-unselected'}`}``
-   1. Actually it might be nice to use this pattern for a bunch of shadcn things too... for
-      daisy-style markup improvements / readability of the DOM, but it would make it more difficult
-      to review updates to shadcn markup (we ignore most of them anyway, but mindfully)

--- a/src/routes/_user/learn.$lang.review.index.tsx
+++ b/src/routes/_user/learn.$lang.review.index.tsx
@@ -1,0 +1,133 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+import languages from '@/lib/languages'
+import { deckQueryOptions } from '@/lib/use-deck'
+import { reviewablesQueryOptions } from '@/lib/use-reviewables'
+import { BookOpen, ChevronRight, Shuffle, Users } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { buttonVariants } from '@/components/ui/button-variants'
+
+export const Route = createFileRoute('/_user/learn/$lang/review/')({
+	component: ReviewPage,
+	loader: async ({
+		params: { lang },
+		context: {
+			queryClient,
+			auth: { userId },
+		},
+	}) => {
+		if (!userId) throw new Error('No userId present, for some reason')
+		const promise1 = queryClient.fetchQuery(deckQueryOptions(lang, userId))
+		const promise2 = queryClient.fetchQuery(
+			reviewablesQueryOptions(lang, userId)
+		)
+		const data = {
+			deck: await promise1,
+			reviewables: await promise2,
+		}
+		console.log(`preparing today's review`, data)
+		return {
+			reviewableCards: data.reviewables.map(
+				(r) => data.deck.cardsMap[r.phrase_id!]
+			),
+		}
+	},
+})
+
+function ReviewPage() {
+	const { lang } = Route.useParams()
+	const { reviewableCards } = Route.useLoaderData()
+
+	const reviewStats = {
+		totalScheduled: reviewableCards?.length,
+		totalNewCards: 15,
+		fromFriends: 3,
+		fromOwnDeck: 5,
+		fromPublicLibrary: 17,
+	}
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Get Ready to review your {languages[lang]} cards</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<p className="text-muted-foreground mb-4 max-w-2xl text-lg">
+					Your personalized review session is prepared and waiting for you.
+					Here's what to expect:
+				</p>
+				<div className="mb-8 grid gap-6 md:grid-cols-3">
+					<Card>
+						<CardHeader className="pb-2">
+							<CardTitle className="flex items-center gap-2 text-xl">
+								Total Cards
+							</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<p className="flex flex-row items-center justify-start gap-2 text-4xl font-bold text-orange-500">
+								<BookOpen />
+								{reviewStats.totalScheduled + reviewStats.totalNewCards}
+							</p>
+							<p className="text-muted-foreground">
+								cards scheduled for review today
+							</p>
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader className="pb-2">
+							<CardTitle className="text-xl">New Cards</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<p className="flex flex-row items-center justify-start gap-2 text-4xl font-bold text-green-500">
+								<Shuffle />
+								<span>{reviewStats.totalNewCards}</span>
+							</p>
+							<p className="text-muted-foreground">
+								new cards will be introduced
+							</p>
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader className="pb-2">
+							<CardTitle className="flex items-center gap-2 text-xl">
+								<Users className="h-5 w-5 text-purple-500" />
+								Sources
+							</CardTitle>
+						</CardHeader>
+						<CardContent className="space-y-2">
+							<div className="flex items-center justify-between">
+								<span className="text-muted-foreground">Friend recs:</span>
+								<Badge variant="outline">{reviewStats.fromFriends}</Badge>
+							</div>
+							<div className="flex items-center justify-between">
+								<span className="text-muted-foreground">Your deck:</span>
+								<Badge variant="outline">{reviewStats.fromOwnDeck}</Badge>
+							</div>
+							<div className="flex items-center justify-between">
+								<span className="text-muted-foreground">Public library:</span>
+								<Badge variant="outline">{reviewStats.fromPublicLibrary}</Badge>
+							</div>
+						</CardContent>
+					</Card>
+				</div>
+
+				<div className="flex flex-col justify-center gap-4 @lg:flex-row">
+					<Link
+						to="/learn/$lang/review/go"
+						params={{ lang }}
+						className={buttonVariants({ size: 'lg' })}
+					>
+						Okay, let's get started <ChevronRight className="ml-2 h-5 w-5" />
+					</Link>
+					<Button variant="outline" size="lg">
+						Customize my session
+					</Button>
+				</div>
+			</CardContent>
+		</Card>
+	)
+}

--- a/src/routes/_user/learn.$lang.review.index.tsx
+++ b/src/routes/_user/learn.$lang.review.index.tsx
@@ -1,13 +1,29 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardFooter,
+	CardHeader,
+	CardTitle,
+} from '@/components/ui/card'
 
+import type { ReviewableCard } from '@/types/main'
 import languages from '@/lib/languages'
 import { deckQueryOptions } from '@/lib/use-deck'
 import { reviewablesQueryOptions } from '@/lib/use-reviewables'
-import { BookOpen, ChevronRight, Shuffle, Users } from 'lucide-react'
+import {
+	BookOpen,
+	CheckCircle,
+	ChevronRight,
+	Shuffle,
+	Users,
+	XCircle,
+} from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { buttonVariants } from '@/components/ui/button-variants'
+import { useState } from 'react'
 
 export const Route = createFileRoute('/_user/learn/$lang/review/')({
 	component: ReviewPage,
@@ -25,7 +41,7 @@ export const Route = createFileRoute('/_user/learn/$lang/review/')({
 		)
 		const data = {
 			deck: await promise1,
-			reviewables: await promise2,
+			reviewables: (await promise2) as ReviewableCard[],
 		}
 		console.log(`preparing today's review`, data)
 		return {
@@ -36,16 +52,88 @@ export const Route = createFileRoute('/_user/learn/$lang/review/')({
 	},
 })
 
+const defaultRecs = [
+	{
+		pid: 1,
+		text: 'வணக்கம்',
+		translation: { text: 'Hello' },
+		selected: true,
+		source: 'friend',
+	},
+	{
+		pid: 2,
+		text: 'நன்றி',
+		translation: { text: 'Thank you' },
+		selected: true,
+		source: 'friend',
+	},
+	{
+		pid: 3,
+		text: 'எப்படி இருக்கிறீர்கள்',
+		translation: { text: 'How are you?' },
+		selected: true,
+		source: 'friend',
+	},
+	{
+		pid: 4,
+		text: 'என் பெயர்',
+		translation: { text: 'My name is' },
+		selected: true,
+		source: 'algo',
+	},
+	{
+		pid: 5,
+		text: 'சாப்பிட',
+		translation: { text: 'To eat' },
+		selected: true,
+		source: 'algo',
+	},
+	{
+		pid: 6,
+		text: 'தண்ணீர்',
+		translation: { text: 'Water' },
+		selected: true,
+		source: 'algo',
+	},
+	{
+		pid: 7,
+		text: 'நல்ல',
+		translation: { text: 'Good' },
+		selected: true,
+		source: 'algo',
+	},
+	{
+		pid: 8,
+		text: 'காலை வணக்கம்',
+		translation: { text: 'Good morning' },
+		selected: true,
+		source: 'algo',
+	},
+]
+
 function ReviewPage() {
 	const { lang } = Route.useParams()
 	const { reviewableCards } = Route.useLoaderData()
+	const [recs, setRecs] = useState(defaultRecs)
+	const [newCardsDesiredCount, setNewCardsDesiredCount] = useState<number>(15)
+	const recStats = {
+		fromFriends: recs.filter(
+			(r) => r.source === 'friend' && r.selected === true
+		).length,
+		fromAlgo: recs.filter((r) => r.source === 'algo' && r.selected === true)
+			.length,
+	}
 
 	const reviewStats = {
-		totalScheduled: reviewableCards?.length,
-		totalNewCards: 15,
-		fromFriends: 3,
-		fromOwnDeck: 5,
-		fromPublicLibrary: 17,
+		totalScheduled:
+			reviewableCards?.length +
+			Math.max(newCardsDesiredCount, recStats.fromFriends + recStats.fromAlgo),
+		totalNewCards: newCardsDesiredCount,
+		...recStats,
+		fromOwnDeck: Math.max(
+			newCardsDesiredCount - recStats.fromFriends - recStats.fromAlgo,
+			0
+		),
 	}
 
 	return (
@@ -104,17 +192,21 @@ function ReviewPage() {
 								<Badge variant="outline">{reviewStats.fromFriends}</Badge>
 							</div>
 							<div className="flex items-center justify-between">
-								<span className="text-muted-foreground">Your deck:</span>
-								<Badge variant="outline">{reviewStats.fromOwnDeck}</Badge>
+								<span className="text-muted-foreground">Public library:</span>
+								<Badge variant="outline">{reviewStats.fromAlgo}</Badge>
 							</div>
 							<div className="flex items-center justify-between">
-								<span className="text-muted-foreground">Public library:</span>
-								<Badge variant="outline">{reviewStats.fromPublicLibrary}</Badge>
+								<span className="text-muted-foreground">Your deck:</span>
+								<Badge variant="outline">{reviewStats.fromOwnDeck}</Badge>
 							</div>
 						</CardContent>
 					</Card>
 				</div>
-
+				<ReviewCardsToAddToDeck
+					recs={recs}
+					setRecs={setRecs}
+					reviewStats={reviewStats}
+				/>
 				<div className="flex flex-col justify-center gap-4 @lg:flex-row">
 					<Link
 						to="/learn/$lang/review/go"
@@ -126,6 +218,73 @@ function ReviewPage() {
 					<Button variant="outline" size="lg">
 						Customize my session
 					</Button>
+				</div>
+			</CardContent>
+		</Card>
+	)
+}
+
+function ReviewCardsToAddToDeck({
+	recs,
+	setRecs,
+	reviewStats,
+}: {
+	recs: typeof defaultRecs
+	setRecs: (recs: typeof defaultRecs) => void
+	reviewStats: any
+}) {
+	// Toggle card selection
+	const toggleCardSelection = (pid: number) => {
+		const updatedCards = recs.map((card) =>
+			card.pid === pid ? { ...card, selected: !card.selected } : card
+		)
+		setRecs(updatedCards)
+	}
+	return (
+		<Card className="mb-8">
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2 text-xl">
+					<Users className="h-5 w-5 text-purple-500" />
+					Recommended for you ({reviewStats.fromFriends} of{' '}
+					{recs.filter((r) => r.source === 'friends')} selected)
+				</CardTitle>
+				<CardDescription>
+					Review and select which recommended cards you want to include in your
+					session
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<div className="grid gap-3 @lg:grid-cols-2">
+					{recs.map((card) => (
+						<Card
+							key={card.pid}
+							className={`border-1 ${card.selected ? 'border-purple-400 bg-purple-600/10' : 'border-gray-200'}`}
+						>
+							<CardHeader className="p-3 pb-0">
+								<CardTitle className="text-base">{card.text}</CardTitle>
+								<CardDescription>{card.translation.text}</CardDescription>
+							</CardHeader>
+							<CardFooter className="flex justify-end p-3 pt-0">
+								<Button
+									variant={card.selected ? 'default' : 'outline'}
+									size="sm"
+									onClick={() => toggleCardSelection(card.pid)}
+									className={
+										card.selected ? 'bg-purple-600 hover:bg-purple-700' : ''
+									}
+								>
+									{card.selected ?
+										<>
+											<CheckCircle className="mr-1 h-4 w-4" /> Selected
+										</>
+									:	<>
+											<XCircle className="mr-1 h-4 w-4" /> Deselected
+										</>
+									}
+								</Button>
+							</CardFooter>
+						</Card>
+					))}
 				</div>
 			</CardContent>
 		</Card>

--- a/src/routes/_user/learn.$lang.review.index.tsx
+++ b/src/routes/_user/learn.$lang.review.index.tsx
@@ -24,6 +24,14 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { buttonVariants } from '@/components/ui/button-variants'
 import { useState } from 'react'
+import {
+	Drawer,
+	DrawerContent,
+	DrawerDescription,
+	DrawerHeader,
+	DrawerTitle,
+	DrawerTrigger,
+} from '@/components/ui/drawer'
 
 export const Route = createFileRoute('/_user/learn/$lang/review/')({
 	component: ReviewPage,
@@ -55,57 +63,57 @@ export const Route = createFileRoute('/_user/learn/$lang/review/')({
 const defaultRecs = [
 	{
 		pid: 1,
-		text: 'வணக்கம்',
-		translation: { text: 'Hello' },
+		text: 'Vanakkam, eppadi irukkinga?',
+		translation: { text: 'Hello, how are you?' },
 		selected: true,
 		source: 'friend',
 	},
 	{
 		pid: 2,
-		text: 'நன்றி',
-		translation: { text: 'Thank you' },
+		text: 'Enakku Tamil theriyum, aanal konjam mattum',
+		translation: { text: 'I know Tamil, but only a little' },
 		selected: true,
-		source: 'friend',
+		source: 'algo',
 	},
 	{
 		pid: 3,
-		text: 'எப்படி இருக்கிறீர்கள்',
-		translation: { text: 'How are you?' },
+		text: 'Neenga romba azhaga irukkinga',
+		translation: { text: 'You look very beautiful' },
 		selected: true,
 		source: 'friend',
 	},
 	{
 		pid: 4,
-		text: 'என் பெயர்',
-		translation: { text: 'My name is' },
+		text: 'Enakku Tamil saapadu romba pidikkum',
+		translation: { text: 'I really like Tamil food' },
 		selected: true,
 		source: 'algo',
 	},
 	{
 		pid: 5,
-		text: 'சாப்பிட',
-		translation: { text: 'To eat' },
+		text: 'Naan Chennai-il vaazhndhirukiren',
+		translation: { text: 'I have lived in Chennai' },
 		selected: true,
-		source: 'algo',
+		source: 'friend',
 	},
 	{
 		pid: 6,
-		text: 'தண்ணீர்',
-		translation: { text: 'Water' },
+		text: 'Indha pazham romba inippu',
+		translation: { text: 'This fruit is very sweet' },
 		selected: true,
 		source: 'algo',
 	},
 	{
 		pid: 7,
-		text: 'நல்ல',
-		translation: { text: 'Good' },
+		text: 'Naalai kaalaiyil sandhippom',
+		translation: { text: 'We will meet tomorrow morning' },
 		selected: true,
-		source: 'algo',
+		source: 'friend',
 	},
 	{
 		pid: 8,
-		text: 'காலை வணக்கம்',
-		translation: { text: 'Good morning' },
+		text: 'Ungalukku enna venum?',
+		translation: { text: 'What do you want?' },
 		selected: true,
 		source: 'algo',
 	},
@@ -202,12 +210,7 @@ function ReviewPage() {
 						</CardContent>
 					</Card>
 				</div>
-				<ReviewCardsToAddToDeck
-					recs={recs}
-					setRecs={setRecs}
-					reviewStats={reviewStats}
-				/>
-				<div className="flex flex-col justify-center gap-4 @lg:flex-row">
+				<div className="flex flex-col justify-center gap-4 @xl:flex-row">
 					<Link
 						to="/learn/$lang/review/go"
 						params={{ lang }}
@@ -215,9 +218,18 @@ function ReviewPage() {
 					>
 						Okay, let's get started <ChevronRight className="ml-2 h-5 w-5" />
 					</Link>
-					<Button variant="outline" size="lg">
-						Customize my session
-					</Button>
+					<Drawer>
+						<DrawerTrigger asChild>
+							<Button className="font-normal" variant="outline" size="lg">
+								Customize my session
+							</Button>
+						</DrawerTrigger>
+						<ReviewCardsToAddToDeck
+							recs={recs}
+							setRecs={setRecs}
+							reviewStats={reviewStats}
+						/>
+					</Drawer>
 				</div>
 			</CardContent>
 		</Card>
@@ -241,24 +253,25 @@ function ReviewCardsToAddToDeck({
 		setRecs(updatedCards)
 	}
 	return (
-		<Card className="mb-8">
-			<CardHeader>
-				<CardTitle className="flex items-center gap-2 text-xl">
-					<Users className="h-5 w-5 text-purple-500" />
-					Recommended for you ({reviewStats.fromFriends} of{' '}
-					{recs.filter((r) => r.source === 'friends')} selected)
-				</CardTitle>
-				<CardDescription>
-					Review and select which recommended cards you want to include in your
-					session
-				</CardDescription>
-			</CardHeader>
-			<CardContent>
-				<div className="grid gap-3 @lg:grid-cols-2">
+		<DrawerContent>
+			<div className="mx-auto w-full max-w-prose">
+				<DrawerHeader>
+					<DrawerTitle className="flex items-center gap-2 text-xl">
+						<Users className="h-5 w-5 text-purple-500" />
+						Recommended for you ({reviewStats.fromFriends} of{' '}
+						{recs.filter((r) => r.source === 'friends')} selected)
+					</DrawerTitle>
+					<DrawerDescription>
+						Review and select which recommended cards you want to include in
+						your session
+					</DrawerDescription>
+				</DrawerHeader>
+				<div className="grid gap-3 p-4 @lg:grid-cols-2">
 					{recs.map((card) => (
 						<Card
+							onClick={() => toggleCardSelection(card.pid)}
 							key={card.pid}
-							className={`border-1 ${card.selected ? 'border-purple-400 bg-purple-600/10' : 'border-gray-200'}`}
+							className={`border-1 ${card.selected ? 'border-primary bg-primary/10' : ''}`}
 						>
 							<CardHeader className="p-3 pb-0">
 								<CardTitle className="text-base">{card.text}</CardTitle>
@@ -268,7 +281,6 @@ function ReviewCardsToAddToDeck({
 								<Button
 									variant={card.selected ? 'default' : 'outline'}
 									size="sm"
-									onClick={() => toggleCardSelection(card.pid)}
 									className={
 										card.selected ? 'bg-purple-600 hover:bg-purple-700' : ''
 									}
@@ -286,7 +298,7 @@ function ReviewCardsToAddToDeck({
 						</Card>
 					))}
 				</div>
-			</CardContent>
-		</Card>
+			</div>
+		</DrawerContent>
 	)
 }

--- a/src/routes/_user/learn.$lang.review.index.tsx
+++ b/src/routes/_user/learn.$lang.review.index.tsx
@@ -154,8 +154,8 @@ function ReviewPage() {
 					Your personalized review session is prepared and waiting for you.
 					Here's what to expect:
 				</p>
-				<div className="mb-8 grid gap-6 md:grid-cols-3">
-					<Card>
+				<div className="mb-8 flex flex-row flex-wrap gap-6 text-sm">
+					<Card className="grow basis-40">
 						<CardHeader className="pb-2">
 							<CardTitle className="flex items-center gap-2 text-xl">
 								Total Cards
@@ -172,7 +172,7 @@ function ReviewPage() {
 						</CardContent>
 					</Card>
 
-					<Card>
+					<Card className="grow basis-40">
 						<CardHeader className="pb-2">
 							<CardTitle className="text-xl">New Cards</CardTitle>
 						</CardHeader>
@@ -187,7 +187,7 @@ function ReviewPage() {
 						</CardContent>
 					</Card>
 
-					<Card>
+					<Card className="grow basis-40">
 						<CardHeader className="pb-2">
 							<CardTitle className="flex items-center gap-2 text-xl">
 								<Users className="h-5 w-5 text-purple-500" />
@@ -200,11 +200,11 @@ function ReviewPage() {
 								<Badge variant="outline">{reviewStats.fromFriends}</Badge>
 							</div>
 							<div className="flex items-center justify-between">
-								<span className="text-muted-foreground">Public library:</span>
+								<span className="text-muted-foreground">Sunlo's recs:</span>
 								<Badge variant="outline">{reviewStats.fromAlgo}</Badge>
 							</div>
 							<div className="flex items-center justify-between">
-								<span className="text-muted-foreground">Your deck:</span>
+								<span className="text-muted-foreground">From your deck:</span>
 								<Badge variant="outline">{reviewStats.fromOwnDeck}</Badge>
 							</div>
 						</CardContent>
@@ -271,29 +271,28 @@ function ReviewCardsToAddToDeck({
 						<Card
 							onClick={() => toggleCardSelection(card.pid)}
 							key={card.pid}
-							className={`border-1 ${card.selected ? 'border-primary bg-primary/10' : ''}`}
+							className={`hover:bg-primary/20 cursor-pointer border-1 transition-all ${card.selected ? 'border-primary bg-primary/10' : ''}`}
 						>
 							<CardHeader className="p-3 pb-0">
 								<CardTitle className="text-base">{card.text}</CardTitle>
 								<CardDescription>{card.translation.text}</CardDescription>
 							</CardHeader>
 							<CardFooter className="flex justify-end p-3 pt-0">
-								<Button
+								<Badge
 									variant={card.selected ? 'default' : 'outline'}
-									size="sm"
-									className={
-										card.selected ? 'bg-purple-600 hover:bg-purple-700' : ''
-									}
+									className="grid grid-cols-1 grid-rows-1 place-items-center font-normal [grid-template-areas:'stack']"
 								>
-									{card.selected ?
-										<>
-											<CheckCircle className="mr-1 h-4 w-4" /> Selected
-										</>
-									:	<>
-											<XCircle className="mr-1 h-4 w-4" /> Deselected
-										</>
-									}
-								</Button>
+									<span
+										className={`flex flex-row items-center gap-1 [grid-area:stack] ${card.selected ? '' : 'invisible'}`}
+									>
+										<CheckCircle className="mr-1 h-3 w-3" /> Selected
+									</span>
+									<span
+										className={`[grid-area:stack] ${card.selected ? 'invisible' : ''}`}
+									>
+										Tap to select
+									</span>
+								</Badge>
 							</CardFooter>
 						</Card>
 					))}

--- a/src/routes/_user/learn.$lang.review.tsx
+++ b/src/routes/_user/learn.$lang.review.tsx
@@ -1,36 +1,13 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { createFileRoute, Outlet } from '@tanstack/react-router'
 
 import { TitleBar } from '@/types/main'
-import { FlashCardReviewSession } from '@/components/flash-card-review-session'
 import languages from '@/lib/languages'
-import { deckQueryOptions } from '@/lib/use-deck'
-import { reviewablesQueryOptions } from '@/lib/use-reviewables'
 import { BookHeart } from 'lucide-react'
 
 export const Route = createFileRoute('/_user/learn/$lang/review')({
 	component: ReviewPage,
-	loader: async ({
-		params: { lang },
-		context: {
-			queryClient,
-			auth: { userId },
-		},
-	}) => {
-		const promise1 = queryClient.fetchQuery(deckQueryOptions(lang, userId))
-		const promise2 = queryClient.fetchQuery(
-			reviewablesQueryOptions(lang, userId)
-		)
-		const data = {
-			deck: await promise1,
-			reviewables: await promise2,
-		}
-		console.log(`preparing today's review`, data)
+	loader: async ({ params: { lang } }) => {
 		return {
-			reviewableCards: data.reviewables.map(
-				(r) => data.deck.cardsMap[r.phrase_id]
-			),
-			appnav: [],
 			contextMenu: [
 				'/learn/$lang/search',
 				'/learn/$lang/add-phrase',
@@ -45,44 +22,5 @@ export const Route = createFileRoute('/_user/learn/$lang/review')({
 })
 
 function ReviewPage() {
-	const { lang } = Route.useParams()
-	const { reviewableCards } = Route.useLoaderData()
-	return reviewableCards.length === 0 ?
-			<Empty lang={lang} />
-		:	<FlashCardReviewSession cards={reviewableCards} lang={lang} />
+	return <Outlet />
 }
-
-const Empty = ({ lang }: { lang: string }) => (
-	<Card className="px-[5%] py-6">
-		<CardHeader className="my-6 opacity-70">
-			<CardTitle>No cards to review</CardTitle>
-		</CardHeader>
-		<CardContent className="mb-6 space-y-4">
-			<p>
-				This is empty because there are no active cards in your{' '}
-				{languages[lang]} deck.
-			</p>
-			<p>
-				You can{' '}
-				<Link
-					className="s-link"
-					to="/learn/$lang/library"
-					params={{ lang }}
-					from={Route.fullPath}
-				>
-					browse the library
-				</Link>{' '}
-				to find new phrases to learn, or{' '}
-				<Link
-					className="s-link"
-					to="/learn/$lang/add-phrase"
-					params={{ lang }}
-					from={Route.fullPath}
-				>
-					add your own
-				</Link>
-				!
-			</p>
-		</CardContent>
-	</Card>
-)

--- a/src/routes/_user/learn.$lang.tsx
+++ b/src/routes/_user/learn.$lang.tsx
@@ -4,6 +4,7 @@ import languages from '@/lib/languages'
 import { languageQueryOptions } from '@/lib/use-language'
 import { deckQueryOptions } from '@/lib/use-deck'
 import { BookHeart } from 'lucide-react'
+import { reviewablesQueryOptions } from '@/lib/use-reviewables'
 
 export const Route = createFileRoute('/_user/learn/$lang')({
 	component: LanguageLayout,
@@ -18,11 +19,23 @@ export const Route = createFileRoute('/_user/learn/$lang')({
 			languageQueryOptions(lang)
 		)
 		const deckLoader = queryClient.ensureQueryData(
-			deckQueryOptions(lang, userId)
+			deckQueryOptions(lang, userId!)
+		)
+		const reviewablesLoader = queryClient.ensureQueryData(
+			reviewablesQueryOptions(lang, userId!)
 		)
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const both = { l: await languageLoader, d: await deckLoader }
+		const data = {
+			language: await languageLoader,
+			deck: await deckLoader,
+			reviewableCards: await reviewablesLoader,
+		}
 		return {
+			language: data.language,
+			deck: data.deck,
+			reviewableCards: data.reviewableCards.map(
+				(r) => data.deck.cardsMap[r.phrase_id!]
+			),
 			appnav: [
 				'/learn/$lang',
 				'/learn/$lang/review',

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -110,6 +110,7 @@ export type CardMeta = Tables<'user_card_plus'>
 export type CardInsert = TablesInsert<'user_card'>
 export type UserCardInsert = CardInsert // @TODO remove
 
+export type ReviewableCard = Tables<'user_card_review_today'>
 export type ReviewInsert =
 	Database['public']['Functions']['record_review_and_schedule']['Args']
 export type ReviewScheduled =

--- a/todo.txt
+++ b/todo.txt
@@ -2,7 +2,7 @@ USER TESTING FIXES
 1. when you have a pending friend request it should be visible from the friends home
 1. add a deck -- the "select one language" input should have a better type-to-search which includes the language name as well a the code
 1. when you go to the library and add cards to your deck, and then go to the review page, it's still loaded the empty-set that was returned before
-1. malformed link like /learn/undefined should 404, or at least say 'do you wanna start learning this?' 
+1. malformed link like /learn/undefined should 404, or at least say 'do you wanna start learning this?'
 	- at least we should validate this parameter has length === 3 to even match it
 1. When you try to sign up using existing creds you get an error and then get logged in. We
 	should handle this. (inspect and special-case the error before throwing, and toast accordingly)
@@ -16,7 +16,7 @@ EPIC: Postgres DX / Run Supabase Locally
 1. make the email stuff work with the local setup
 1. pgTap set up testing framework / run tests on the RPC functions: https://supabase.com/docs/guides/database/extensions/pgtap
 1. ✅ switch to v8
-	- test out pglinter? 
+	- test out pglinter?
 1. future:
 	- use postmark templates like [this](https://github.com/supabase/auth/issues/304#issuecomment-998029660)
 
@@ -60,7 +60,7 @@ MOCKS / Incompletes
 		- move the Quick Search link into the navbar??
 1. $lang/library needs a search bar added to filter in realtime
 1. ✅ The "new friend signup" screens -- what are we doing here? selecting which deck(s) we're helping with... and then what?
-1. Public Library is a special browsing experience that needs to be built!	
+1. Public Library is a special browsing experience that needs to be built!
 	1. $lang/library has this "recently reviewed" filter which probably should be a field on the user_card_plus view
 	1. $lang/index needs the review overview graph thing made
 1. ✅ Deck Settings: replace with the nicer radio: https://v0.dev/chat/PNg3tT-DSoC,


### PR DESCRIPTION
This PR should add an index page for the review interface that shows the user what they're about to get into and gives them a chance to approve the new cards being added to their deck by either friend recs or algorithm recs. Instead of making them respond to each one like a high-commitment thing (e.g. a friend request approval) they should be able to just take them on mostly in bulk, so this screen gives them a chance to do that without losing control.

It presents a nice friendly interface with some summary data and then when they proceed, it should go and create the new cards, and schedule them for right now, and then take them to the next page where the review happens (`/review/go`) where the app will retrieve the newly-scheduled and previously-scheduled cards all at once and present them to the user in a random order.

This PR is sort of prep and staging for #62. Resolves #87. Relates to #86. Makes #64 feel much less urgent/important. And gives #66 a sort of real-world condition to satisfy.