### PR TITLE
Refactor the Callout component's icon behavior

### DIFF
--- a/src/components/deck-switcher.tsx
+++ b/src/components/deck-switcher.tsx
@@ -43,12 +43,10 @@ const useDeckMenuData = () => {
 function NoDecks() {
 	return (
 		<Callout>
-			<div>
-				<p>It seems like you're not learning any languages yet! Get started.</p>
-				<Button className="mt-2 w-full" asChild>
-					<Link to="/learn/add-deck">Start Learning</Link>
-				</Button>
-			</div>
+			<p>It seems like you're not learning any languages yet! Get started.</p>
+			<Button className="mt-2 w-full" asChild>
+				<Link to="/learn/add-deck">Start Learning</Link>
+			</Button>
 		</Callout>
 	)
 }

--- a/src/components/errors.tsx
+++ b/src/components/errors.tsx
@@ -23,9 +23,15 @@ export function ShowError({
 	if (show === false) return null
 	if (show === null && !children) return null
 	return (
-		<Callout className={className} variant="problem" alert>
-			<CircleX className="text-destructive/50" aria-hidden={true} />
-			<div>{children || `An unknown error has occurred (sorry)`}</div>
+		<Callout
+			className={className}
+			variant="problem"
+			alert
+			Icon={() => (
+				<CircleX className="text-destructive/50" aria-hidden={true} />
+			)}
+		>
+			{children ?? `An unknown error has occurred (sorry)`}
 		</Callout>
 	)
 }

--- a/src/components/password-reset-form.tsx
+++ b/src/components/password-reset-form.tsx
@@ -52,17 +52,14 @@ export function PasswordResetForm() {
 	return (
 		<CardContent>
 			{changeMutation.isSuccess ?
-				<Callout>
-					<SuccessCheckmark className="bg-transparent" />
-					<div className="space-y-2">
-						<p>Success!</p>
-						<p>You've changed your password.</p>
-						<p>
-							<Link to="/profile" className="s-link">
-								Return to your profile page.
-							</Link>
-						</p>
-					</div>
+				<Callout Icon={() => <SuccessCheckmark className="bg-transparent" />}>
+					<p>Success!</p>
+					<p>You've changed your password.</p>
+					<p>
+						<Link to="/profile" className="s-link">
+							Return to your profile page.
+						</Link>
+					</p>
 				</Callout>
 			:	<form
 					role="form"

--- a/src/components/ui/callout.tsx
+++ b/src/components/ui/callout.tsx
@@ -1,10 +1,13 @@
 import { cn } from '@/lib/utils'
+import { ReactNode } from '@tanstack/react-router'
+import { LucideIcon } from 'lucide-react'
 import type { HTMLAttributes, PropsWithChildren } from 'react'
 
 type CalloutProps = PropsWithChildren & {
 	variant?: 'default' | 'problem' | 'ghost'
 	className?: string
 	alert?: boolean
+	Icon?: () => LucideIcon | ReactNode
 }
 
 const variants = {
@@ -16,6 +19,7 @@ const variants = {
 export default function Callout({
 	variant = 'default',
 	alert = false,
+	Icon,
 	className,
 	children,
 }: CalloutProps) {
@@ -25,12 +29,17 @@ export default function Callout({
 		<div
 			{...props}
 			className={cn(
-				'flex flex-row items-center gap-4 rounded border px-[4%] py-[3%]',
+				'flex flex-col items-center gap-4 rounded border px-[5%] py-[5%] @lg:flex-row @lg:py-[3%]',
 				variants[variant],
 				className
 			)}
 		>
-			{children}
+			{typeof Icon === 'function' ?
+				<div className="min-w-4vh aspect-square">
+					<Icon />
+				</div>
+			:	null}
+			<div className="space-y-2">{children}</div>
 		</div>
 	)
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -44,10 +44,14 @@ function NotFoundComponent() {
 	}, [navigate])
 	return (
 		<div className="flex h-full w-full items-center justify-center py-10">
-			<Callout variant="problem">
-				<Badge variant="destructive" className="p-2">
-					<OctagonMinus />
-				</Badge>
+			<Callout
+				variant="problem"
+				Icon={() => (
+					<Badge variant="destructive" className="p-2">
+						<OctagonMinus />
+					</Badge>
+				)}
+			>
 				<div className="flex flex-col gap-4">
 					<h1 className="text-2xl">404: Page not found</h1>
 					<p>We did not find a page matching that URL</p>

--- a/src/routes/_auth/forgot-password.tsx
+++ b/src/routes/_auth/forgot-password.tsx
@@ -67,16 +67,12 @@ function ForgotPasswordPage() {
 			</CardHeader>
 			<CardContent>
 				{recoveryMutation.isSuccess ?
-					<Callout>
-						<SuccessCheckmark className="bg-transparent" />
-						<div className="space-y-2">
-							<p>Almost done!</p>
-							<p>
-								Find the password reset link in your email to set a new
-								password.
-							</p>
-							<p>You can close this window.</p>
-						</div>
+					<Callout Icon={() => <SuccessCheckmark className="bg-transparent" />}>
+						<p>Almost done!</p>
+						<p>
+							Find the password reset link in your email to set a new password.
+						</p>
+						<p>You can close this window.</p>
 					</Callout>
 				:	<form
 						role="form"

--- a/src/routes/_auth/signup.tsx
+++ b/src/routes/_auth/signup.tsx
@@ -94,16 +94,12 @@ function SignUp() {
 			</CardHeader>
 			<CardContent>
 				{signupMutation.isSuccess ?
-					<Callout>
-						<SuccessCheckmark className="bg-transparent" />
-						<div className="space-y-2">
-							<p>Almost done!</p>
-							<p>
-								Find the confirmation link in your email to activate your
-								account.
-							</p>
-							<p>You can close this window.</p>
-						</div>
+					<Callout Icon={() => <SuccessCheckmark className="bg-transparent" />}>
+						<p>Almost done!</p>
+						<p>
+							Find the confirmation link in your email to activate your account.
+						</p>
+						<p>You can close this window.</p>
 					</Callout>
 				:	<form
 						role="form"

--- a/src/routes/_user/accept-invite.tsx
+++ b/src/routes/_user/accept-invite.tsx
@@ -149,20 +149,32 @@ function AcceptInvitePage() {
 	)
 }
 
-const ShowAccepted = () => (
-	<Callout>
-		<SuccessCheckmark />
-		<div>
-			<h2 className="h3">Okay! You're connected.</h2>
-			<p>
-				<Link className={buttonVariants({ variant: 'default' })}>
-					Maybe go look at their deck?
-				</Link>
-			</p>
-		</div>
-	</Callout>
-)
-
+const ShowAccepted = ({ friend }: { friend?: any }) => {
+	if (!friend)
+		throw new Error(
+			`Attempted to render the "success" message` +
+				` but the app isn't aware that the friend request has been accepted,` +
+				` or that the friend's public profile has even been loaded`
+		)
+	return (
+		<Callout Icon={() => <SuccessCheckmark />}>
+			<div>
+				<h2 className="h3">
+					Okay! You're now connected with {friend.username}.
+				</h2>
+				<p>
+					<Link
+						to="/friends/$uid"
+						params={{ uid: friend.uid }}
+						className={buttonVariants({ variant: 'default' })}
+					>
+						Check out their profile
+					</Link>
+				</p>
+			</div>
+		</Callout>
+	)
+}
 const ShowDeclined = () => (
 	<Callout variant="ghost">
 		<div>

--- a/src/routes/_user/friends.search.tsx
+++ b/src/routes/_user/friends.search.tsx
@@ -178,20 +178,17 @@ export default function SearchProfiles() {
 									<Loader />
 								</div>
 							: !(resultsToShow?.length > 0) ?
-								<Callout variant="ghost">
-									<Garlic size={32} />
-									<div className="ms-4 space-y-4">
-										<p>No users match that search.</p>
-										<p>
-											<Link
-												className={buttonVariants({ variant: 'secondary' })}
-												to="/friends/invite"
-												from={Route.fullPath}
-											>
-												Invite a friend to Sunlo
-											</Link>
-										</p>
-									</div>
+								<Callout variant="ghost" Icon={() => <Garlic size={32} />}>
+									<p>No users match that search.</p>
+									<p>
+										<Link
+											className={buttonVariants({ variant: 'outline' })}
+											to="/friends/invite"
+											from={Route.fullPath}
+										>
+											Invite a friend to Sunlo
+										</Link>
+									</p>
 								</Callout>
 							:	<div className="my-6 space-y-2">
 									{resultsToShow.map((profile) => (

--- a/src/routes/_user/learn.$lang.$id.tsx
+++ b/src/routes/_user/learn.$lang.$id.tsx
@@ -23,10 +23,14 @@ import { Calendar, OctagonMinus } from 'lucide-react'
 
 function PhraseNotFound() {
 	return (
-		<Callout variant="problem">
-			<Badge variant="destructive" className="p-2">
-				<OctagonMinus />
-			</Badge>
+		<Callout
+			variant="problem"
+			Icon={() => (
+				<Badge variant="destructive" className="p-2">
+					<OctagonMinus />
+				</Badge>
+			)}
+		>
 			<p>We couldn't find that phrase. Please check your link and try again.</p>
 		</Callout>
 	)

--- a/src/routes/_user/learn.$lang.review.index.tsx
+++ b/src/routes/_user/learn.$lang.review.index.tsx
@@ -209,12 +209,12 @@ function ReviewPage() {
 			<CardHeader>
 				<CardTitle>Get Ready to review your {languages[lang]} cards</CardTitle>
 			</CardHeader>
-			<CardContent>
-				<p className="text-muted-foreground mb-4 max-w-2xl text-lg">
+			<CardContent className="space-y-4">
+				<p className="text-muted-foreground max-w-2xl text-lg">
 					Your personalized review session is prepared and waiting for you.
 					Here's what to expect:
 				</p>
-				<div className="mb-8 flex flex-row flex-wrap gap-6 text-sm">
+				<div className="flex flex-row flex-wrap gap-4 text-sm">
 					<Card className="grow basis-40">
 						<CardHeader className="pb-2">
 							<CardTitle className="flex items-center gap-2 text-xl">
@@ -258,7 +258,7 @@ function ReviewPage() {
 							</p>
 						</CardContent>
 					</Card>
-					<Flagged name="smart_recommendations">
+					<Flagged name="smart_recommendations" className="hidden">
 						<Card className="grow basis-40">
 							<CardHeader className="pb-2">
 								<CardTitle className="flex items-center gap-2 text-xl">
@@ -301,36 +301,13 @@ function ReviewPage() {
 						</Card>
 					</Flagged>
 				</div>
-				{noCards ?
-					<Empty lang={lang} />
-				: !(newCardsDesiredCount > cardPidsAllNewToday.length) ?
-					null
-				:	<Callout className="my-4" variant="ghost">
-						<MessageCircleWarningIcon />
-						<div className="pt-1">
-							It looks like you don't have enough fresh cards in your deck to
-							meet your review goal for today ({newCardsDesiredCount}). You can
-							go ahead with the review like this, or you can add more.{' '}
-							<div className="my-2 flex flex-col gap-2 @lg:flex-row">
-								<Link
-									className={buttonVariants({ variant: 'outline' })}
-									to="/learn/$lang/library"
-									params={{ lang }}
-								>
-									Get more cards from Library
-								</Link>
-
-								<Link
-									className={buttonVariants({ variant: 'outline' })}
-									to="/learn/$lang/add-phrase"
-									params={{ lang }}
-								>
-									Add cards to Library
-								</Link>
-							</div>
-						</div>
-					</Callout>
-				}
+				{!(newCardsDesiredCount > cardPidsAllNewToday.length) ? null : (
+					<NotEnoughCards
+						lang={lang}
+						newCardsDesiredCount={newCardsDesiredCount}
+						newCardsCount={cardPidsAllNewToday.length}
+					/>
+				)}
 				<div className="flex flex-col justify-center gap-4 @xl:flex-row">
 					<Button
 						onClick={(e) => {
@@ -339,7 +316,7 @@ function ReviewPage() {
 							mutate()
 						}}
 						size="lg"
-						disabled={isPending}
+						disabled={isPending || cardPidsAllNewToday.length === 0}
 					>
 						Okay, let's get started <ChevronRight className="ml-2 h-5 w-5" />
 					</Button>
@@ -429,37 +406,54 @@ function ReviewCardsToAddToDeck({
 	)
 }
 
-const Empty = ({ lang }: { lang: string }) => (
-	<Card className="px-[5%] py-6">
-		<CardHeader className="my-6 opacity-70">
-			<CardTitle>No cards to review</CardTitle>
-		</CardHeader>
-		<CardContent className="mb-6 space-y-4">
+function NotEnoughCards({
+	lang,
+	newCardsDesiredCount,
+	newCardsCount,
+}: {
+	lang: string
+	newCardsDesiredCount: number
+	newCardsCount: number
+}) {
+	const isEmpty = newCardsCount === 0
+	return (
+		<Callout variant="ghost" Icon={() => <MessageCircleWarningIcon />}>
 			<p>
-				This is empty because there are no active cards in your{' '}
-				{languages[lang]} deck.
+				It looks like you don't have {isEmpty ? 'any' : 'enough'} new cards{' '}
+				{isEmpty ?
+					"to review. You'll have to add at least a few before you can proceed"
+				:	<>
+						in your deck to meet your goal of{' '}
+						<strong className="italic">
+							{newCardsDesiredCount} new cards a day
+						</strong>
+					</>
+				}
+				.
 			</p>
-			<p>
-				You can{' '}
+			<div className="my-2 flex flex-col gap-2 @lg:flex-row">
 				<Link
-					className="s-link"
+					className={buttonVariants({ variant: 'outline' })}
 					to="/learn/$lang/library"
 					params={{ lang }}
-					from={Route.fullPath}
 				>
-					browse the library
-				</Link>{' '}
-				to find new phrases to learn, or{' '}
+					Add cards from the Library
+				</Link>
+
 				<Link
-					className="s-link"
+					className={buttonVariants({ variant: 'outline' })}
 					to="/learn/$lang/add-phrase"
 					params={{ lang }}
-					from={Route.fullPath}
 				>
-					add your own
+					Create new cards
 				</Link>
-				!
-			</p>
-		</CardContent>
-	</Card>
-)
+			</div>
+			{isEmpty ? null : (
+				<>
+					Or click the big button below and get started with the {newCardsCount}{' '}
+					cards you have.
+				</>
+			)}
+		</Callout>
+	)
+}

--- a/src/routes/_user/learn.add-deck.tsx
+++ b/src/routes/_user/learn.add-deck.tsx
@@ -62,17 +62,14 @@ function NewDeckForm() {
 				className="space-y-4"
 			>
 				{showNewUserUI ?
-					<Callout>
-						<span>👋</span>
-						<div className="space-y-2">
-							<p>
-								Welcome <em>{data?.username}</em>!
-							</p>
-							<p>
-								Create a new deck to start learning, or go to your profile to
-								check for friend requests.
-							</p>
-						</div>
+					<Callout Icon={() => <span>👋</span>}>
+						<p>
+							Welcome <em>{data?.username}</em>!
+						</p>
+						<p>
+							Create a new deck to start learning, or go to your profile to
+							check for friend requests.
+						</p>
 					</Callout>
 				:	<p>
 						You're currently learning{' '}

--- a/src/routes/_user/profile.change-email-confirm.tsx
+++ b/src/routes/_user/profile.change-email-confirm.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute('/_user/profile/change-email-confirm')({
 	component: ChangeEmailConfirmPage,
 	loader: async ({ location }) => {
 		const hashParams = new URLSearchParams(location.hash)
-		console.log(`inside the loader`, location, hashParams)
+		// console.log(`inside the loader`, location, hashParams)
 		const {
 			data: { user },
 		} = await supabase.auth.getUser()
@@ -24,7 +24,7 @@ export const Route = createFileRoute('/_user/profile/change-email-confirm')({
 
 function ChangeEmailConfirmPage() {
 	const data = Route.useLoaderData()
-	console.log(`the loader data`, data)
+	// console.log(`the loader data`, data)
 	return (
 		<>
 			<CardHeader>
@@ -55,19 +55,16 @@ function ChangeEmailConfirmPage() {
 							</p>
 						</div>
 					</ShowError>
-				:	<Callout>
-						<SuccessCheckmark className="bg-transparent" />
-						<div className="space-y-2">
-							<p>Success!</p>
-							<p>
-								You've changed your email to <strong>{data.userEmail}</strong>.
-							</p>
-							<p>
-								<Link to="/profile" from={Route.fullPath} className="s-link">
-									Return to your profile page.
-								</Link>
-							</p>
-						</div>
+				:	<Callout Icon={() => <SuccessCheckmark className="bg-transparent" />}>
+						<p>Success!</p>
+						<p>
+							You've changed your email to <strong>{data.userEmail}</strong>.
+						</p>
+						<p>
+							<Link to="/profile" from={Route.fullPath} className="s-link">
+								Return to your profile page.
+							</Link>
+						</p>
 					</Callout>
 				}
 			</CardContent>

--- a/src/routes/_user/profile.change-email.tsx
+++ b/src/routes/_user/profile.change-email.tsx
@@ -68,19 +68,16 @@ function ChangeEmailPage() {
 			</CardHeader>
 			<CardContent>
 				{changeMutation.isSuccess ?
-					<Callout>
-						<SuccessCheckmark className="bg-transparent" />
-						<div className="space-y-2">
-							<p>Step 1 complete:</p>
-							<p>
-								You've requested to change your email to{' '}
-								<strong>{changeMutation.data?.email}</strong>.
-							</p>
-							<p>
-								Please check your new email for a confirmation link to confirm
-								the change.
-							</p>
-						</div>
+					<Callout Icon={() => <SuccessCheckmark className="bg-transparent" />}>
+						<p>Step 1 complete:</p>
+						<p>
+							You've requested to change your email to{' '}
+							<strong>{changeMutation.data?.email}</strong>.
+						</p>
+						<p>
+							Please check your new email for a confirmation link to confirm the
+							change.
+						</p>
 					</Callout>
 				:	<form
 						role="form"

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -97,13 +97,12 @@ function Index() {
 				)}
 			>
 				<p>
-					Sunlo is under development; some of the features you would expect may
-					not have been built yet, but what is here should be working. Please
-					get in touch on bluesky at{' '}
+					Sunlo is under development. It should be ready to use, but it's very
+					early days. Please get in touch on BlueSky at{' '}
 					<a className="s-link" href="https://bsky.app/profile/sunlo.app">
 						@sunlo.app
 					</a>{' '}
-					to let us know of any feedback.
+					to let us know of any thoughts, suggestions or feedback.
 				</p>
 			</Callout>
 			<section className="my-16 px-1 pt-4 pb-8 @lg:px-4 @lg:pt-10 @lg:pb-16">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -87,8 +87,15 @@ function Index() {
 				</div>
 			</main>
 
-			<Callout variant="ghost" className="mx-auto max-w-xl">
-				<WandSparkles size={40} />
+			<Callout
+				variant="ghost"
+				className="mx-auto max-w-xl"
+				Icon={() => (
+					<div className="bg-primary flex aspect-square items-center justify-center rounded-full text-white">
+						<WandSparkles size={20} className="m-4" />
+					</div>
+				)}
+			>
 				<p>
 					Sunlo is under development; some of the features you would expect may
 					not have been built yet, but what is here should be working. Please


### PR DESCRIPTION
Previously, we were setting up the Callout as a flex-row and left it as the caller's responsibility to make sure to pass the Icon and the Content in as 2 (and only 2!) children, or 1 child if no Icon. But this made for inconsistent rendering based on how the browser decided to flex shrink/grow the two pieces. 

This PR moves the Icon into an (optional) render prop for the Callout component, and no longer requires the children to be formatted in any particular way, it's just a block div with `space-y-2` applied. If the  caller wants more control, they can wrap it another div.

This also makes it easier for us to enhance the callout with better responsiveness for how to display the Icon (it now goes to the TOP if the screen is very narrow, instead of on the LEFT).