### PR TITLE
Feature: recommend popular phrases

### DIFF
--- a/src/components/flash-card-review-session.tsx
+++ b/src/components/flash-card-review-session.tsx
@@ -69,11 +69,11 @@ export function FlashCardReviewSession({
 	const isComplete = currentCardIndex === pids.length
 
 	return (
-		<>
+		<div className="flex-col items-center justify-center gap-2 py-2">
 			<div
-				className={`${isComplete ? 'flex' : 'hidden'} flex-col items-center justify-center gap-4`}
+				className={`${isComplete ? 'flex' : 'hidden'} flex-col items-center justify-center gap-2`}
 			>
-				<div className="flex min-h-10 flex-row items-center justify-center">
+				<div className={`flex min-h-10 flex-row items-center justify-center`}>
 					<Button
 						size="sm"
 						variant="ghost"
@@ -95,9 +95,11 @@ export function FlashCardReviewSession({
 				</Card>
 			</div>
 			<div
-				className={`${isComplete ? 'hidden' : 'flex'} flex-col items-center justify-center gap-4`}
+				className={`${isComplete ? 'hidden' : 'flex'} flex-col items-center justify-center gap-2`}
 			>
-				<div className="flex min-h-10 flex-row items-center justify-center gap-4">
+				<div
+					className={`flex min-h-10 flex-row items-center justify-center gap-4`}
+				>
 					<Button
 						size="icon-sm"
 						variant="default"
@@ -120,8 +122,11 @@ export function FlashCardReviewSession({
 						<ChevronRight className="size-4" />
 					</Button>
 				</div>
+
 				{pids.map((pid, i) => {
 					const phrase = phrasesMap[pid]
+					const card = cardsMap[pid]
+
 					return (
 						<Card
 							key={i}
@@ -181,7 +186,7 @@ export function FlashCardReviewSession({
 								dailyCacheKey={dailyCacheKey}
 								// lang={lang}
 								pid={pid}
-								user_card_id={cardsMap[pid].id!}
+								user_card_id={card.id!}
 								isButtonsShown={showTranslation}
 								showTheButtons={() => setShowTranslation(true)}
 								proceed={() => {
@@ -192,7 +197,7 @@ export function FlashCardReviewSession({
 					)
 				})}
 			</div>
-		</>
+		</div>
 	)
 }
 

--- a/src/components/phrase-card.tsx
+++ b/src/components/phrase-card.tsx
@@ -1,22 +1,24 @@
 import { cn } from '@/lib/utils'
 import { PhraseStub } from '@/types/main'
 import { buttonVariants } from '@/components/ui/button-variants'
+import { Link } from '@tanstack/react-router'
 
 type PhraseCardProps = {
 	phrase: PhraseStub
 }
 
 export const PhraseCard = ({ phrase }: PhraseCardProps) => (
-	<a
+	<Link
 		className={cn(
 			buttonVariants({ variant: 'link' }),
 			`s-link rounded border p-3`
 		)}
-		href="google.com?search=id"
+		to="/learn/$lang/$id"
+		params={{ lang: phrase.lang, id: phrase.id }}
 	>
 		<span className="font-semibold">{phrase.text}</span>{' '}
 		<span className="text-muted-foreground text-sm">
-			{phrase.translation.text}
+			{phrase.translation[0].text}
 		</span>
-	</a>
+	</Link>
 )

--- a/src/components/phrase-card.tsx
+++ b/src/components/phrase-card.tsx
@@ -1,24 +1,24 @@
 import { cn } from '@/lib/utils'
-import { PhraseStub } from '@/types/main'
+import { PhraseFull } from '@/types/main'
 import { buttonVariants } from '@/components/ui/button-variants'
 import { Link } from '@tanstack/react-router'
 
 type PhraseCardProps = {
-	phrase: PhraseStub
+	phrase: PhraseFull
 }
 
 export const PhraseCard = ({ phrase }: PhraseCardProps) => (
 	<Link
 		className={cn(
 			buttonVariants({ variant: 'link' }),
-			`s-link rounded border p-3`
+			`s-link m-1 rounded border p-3`
 		)}
 		to="/learn/$lang/$id"
-		params={{ lang: phrase.lang, id: phrase.id }}
+		params={{ lang: phrase.lang!, id: phrase.id! }}
 	>
 		<span className="font-semibold">{phrase.text}</span>{' '}
 		<span className="text-muted-foreground text-sm">
-			{phrase.translation[0].text}
+			{phrase.translations[0].text}
 		</span>
 	</Link>
 )

--- a/src/components/recommended-phrases.tsx
+++ b/src/components/recommended-phrases.tsx
@@ -1,0 +1,75 @@
+import languages from '@/lib/languages'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+import { ProcessedPids } from '@/lib/process-pids'
+import { Brain, Carrot, LucideIcon, TrendingUp } from 'lucide-react'
+import { LangOnlyComponentProps, pids } from '@/types/main'
+import { useLanguagePhrasesMap } from '@/lib/use-language'
+import { PhraseCard } from './phrase-card'
+
+type PhraseSectionProps = {
+	description: string
+	pids: pids
+	lang: string
+	Icon: LucideIcon
+}
+
+const PhraseSection = ({
+	description,
+	pids,
+	lang,
+	Icon,
+}: PhraseSectionProps) => {
+	const { data: phrasesMap } = useLanguagePhrasesMap(lang)
+	if (!phrasesMap) return null
+	return (
+		<div>
+			<p className="my-1 text-lg">
+				<Icon className="inline size-6" /> {description}
+			</p>
+			{pids?.length > 0 ?
+				<div className="flex flex-row flex-wrap gap-2">
+					{pids.map((pid) => {
+						console.log(`in this loop! pid and phrase`, pid, phrasesMap)
+						return !(pid in phrasesMap) ? null : (
+								<PhraseCard key={pid} phrase={phrasesMap[pid]} />
+							)
+					})}
+				</div>
+			:	<p className="text-muted-foreground text-center">No phrases available</p>
+			}
+		</div>
+	)
+}
+
+export function RecommendedPhrases({
+	lang,
+	pids,
+}: LangOnlyComponentProps & { pids: ProcessedPids }) {
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Recommended For You</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				<PhraseSection
+					description={`Popular among all ${languages[lang]} learners`}
+					pids={pids.recommended.popular.slice(0, 4)}
+					lang={lang}
+					Icon={TrendingUp}
+				/>
+				<PhraseSection
+					description="Newly added"
+					pids={pids.recommended.newest.slice(0, 4)}
+					lang={lang}
+					Icon={Brain}
+				/>
+				<PhraseSection
+					description="Broaden your vocabulary"
+					pids={pids.recommended.easiest.slice(0, 4)}
+					lang={lang}
+					Icon={Carrot}
+				/>
+			</CardContent>
+		</Card>
+	)
+}

--- a/src/lib/dayjs.ts
+++ b/src/lib/dayjs.ts
@@ -23,7 +23,7 @@ dayjs.updateLocale('en', {
 	},
 })
 
-const ago = (dbstring: string) => dayjs(dbstring).fromNow()
+const ago = (dbstring: string | null) => dayjs(dbstring).fromNow()
 
 const inLastWeek = (dbstring: string) =>
 	dayjs(dbstring).isAfter(dayjs().subtract(7, 'days'))

--- a/src/lib/process-pids.ts
+++ b/src/lib/process-pids.ts
@@ -1,0 +1,41 @@
+import { DeckPids, PhrasesMap, pids } from '@/types/main'
+
+export type ProcessedPids = ReturnType<typeof processPids>
+
+export function processPids(
+	phrasesMap: PhrasesMap,
+	languagePids: pids,
+	deckPids: DeckPids
+) {
+	const not_in_deck = languagePids.filter(
+		(pid) => deckPids.all.indexOf(pid) === -1
+	)
+	return {
+		language: languagePids,
+		deck: deckPids.all,
+		reviewed_last_7d: deckPids.reviewed_last_7d,
+		not_in_deck,
+		recommended: {
+			by_friends: [],
+			easiest: not_in_deck.toSorted(
+				(pid1, pid2) =>
+					// prioritize LOWER values
+					phrasesMap[pid1].avg_difficulty! - phrasesMap[pid2].avg_difficulty!
+			),
+			popular: not_in_deck.toSorted(
+				(pid1, pid2) =>
+					// prioritize HIGHER values
+					phrasesMap[pid2].count_cards! - phrasesMap[pid1].count_cards!
+			),
+			newest: not_in_deck.toSorted((pid1, pid2) =>
+				phrasesMap[pid2].created_at! === phrasesMap[pid1].created_at! ? 0
+				: (
+					// prioritize HIGHER values
+					phrasesMap[pid2].created_at! > phrasesMap[pid1].created_at!
+				) ?
+					1
+				:	-1
+			),
+		},
+	}
+}

--- a/src/lib/use-language.ts
+++ b/src/lib/use-language.ts
@@ -17,7 +17,8 @@ import { mapArray } from '@/lib/utils'
 
 const qs = {
 	phrase_full: () => `*, translations:phrase_translation(*)` as const,
-	language_full: () => `*, phrases:phrase_plus(${qs.phrase_full()})` as const,
+	language_full: () =>
+		`*, phrases:meta_phrase_info(${qs.phrase_full()})` as const,
 }
 
 export async function fetchLanguage(lang: string): Promise<LanguageLoaded> {

--- a/src/routes/_user/learn.$lang.library.tsx
+++ b/src/routes/_user/learn.$lang.library.tsx
@@ -2,18 +2,16 @@ import { useMemo, useState } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import languages from '@/lib/languages'
-import type { LangOnlyComponentProps, PhraseStub } from '@/types/main'
+import type { LangOnlyComponentProps } from '@/types/main'
 import { useDeck } from '@/lib/use-deck'
 import { useLanguage } from '@/lib/use-language'
 import { LanguagePhrasesAccordionComponent } from '@/components/language-phrases-accordion'
 import Callout from '@/components/ui/callout'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
-import { PhraseCard } from '@/components/phrase-card'
-import { Skeleton } from '@/components/ui/skeleton'
-import { Brain, Carrot, LucideIcon, Plus, TrendingUp } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { buttonVariants } from '@/components/ui/button-variants'
-import Flagged from '@/components/flagged'
+import { ProcessedPids, processPids } from '@/lib/process-pids'
 
 export const Route = createFileRoute('/_user/learn/$lang/library')({
 	component: DeckLibraryPage,
@@ -21,166 +19,30 @@ export const Route = createFileRoute('/_user/learn/$lang/library')({
 
 function DeckLibraryPage() {
 	const { lang } = Route.useParams()
-	return (
-		<div className="space-y-4 px-2">
-			<Flagged name="smart_recommendations">
-				<PopularPhrases lang={lang} />
-			</Flagged>
-			<DeckContents lang={lang} />
-		</div>
-	)
-}
-
-type PhraseSectionProps = {
-	description: string
-	phrases: Array<PhraseStub> | undefined
-	isLoading: boolean
-	Icon: LucideIcon
-}
-
-const PhraseSection = ({
-	description,
-	phrases,
-	isLoading,
-	Icon,
-}: PhraseSectionProps) => (
-	<div>
-		<p className="my-1 text-sm">
-			<Icon className="inline size-4" /> {description}
-		</p>
-		{isLoading ?
-			<div className="flex flex-row gap-2 overflow-x-auto">
-				{[...Array(2 + Math.round(Math.random() * 3))].map((_, i) => (
-					<Skeleton
-						key={i}
-						style={{ width: 100 + Math.round(Math.random() * 80) }}
-						className={`h-[60px] shrink-0`}
-					/>
-				))}
-			</div>
-		: phrases && phrases.length > 0 ?
-			<div className="flex flex-row gap-2 overflow-x-auto">
-				{phrases.map((phrase) => (
-					<PhraseCard key={phrase.id} phrase={phrase} />
-				))}
-			</div>
-		:	<p className="text-muted-foreground text-center">No phrases available</p>}
-	</div>
-)
-
-const recommendedPhrases: Record<string, PhraseStub[]> = {
-	trending: [
-		{
-			id: '1',
-			lang: 'tam',
-			text: 'vanakkam',
-			translation: [{ text: 'Hello', lang: 'eng' }],
-		},
-		{
-			id: '2',
-			lang: 'tam',
-			text: 'நன்றி',
-			translation: [{ text: 'Thank you', lang: 'eng' }],
-		},
-		{
-			id: '3',
-			lang: 'tam',
-			text: 'en peyar?',
-			translation: [{ text: 'What is your name?', lang: 'eng' }],
-		},
-	],
-	challenging: [
-		{
-			id: '4',
-			lang: 'tam',
-			text: 'Tamil teriyum',
-			translation: [{ text: 'I am learning Tamil', lang: 'eng' }],
-		},
-		{
-			id: '5',
-			lang: 'tam',
-			text: 'Unga peyar enna?',
-			translation: [{ text: 'What is your name?', lang: 'eng' }],
-		},
-	],
-	easy: [
-		{
-			id: '6',
-			lang: 'tam',
-			text: 'Sari',
-			translation: [{ text: 'Yes', lang: 'eng' }],
-		},
-		{
-			id: '7',
-			lang: 'tam',
-			text: 'Illai',
-			translation: [{ text: 'No', lang: 'eng' }],
-		},
-		{
-			id: '8',
-			lang: 'tam',
-			text: 'Sari',
-			translation: [{ text: 'Okay', lang: 'eng' }],
-		},
-	],
-}
-
-function PopularPhrases({ lang }: LangOnlyComponentProps) {
-	console.log(`Pretend I'm fetching recommendations for ${lang}`)
-	return (
-		<Card>
-			<CardHeader>
-				<CardTitle>Recommended Phrases For You</CardTitle>
-			</CardHeader>
-			<CardContent className="space-y-4">
-				<PhraseSection
-					description="Popular phrases among all Tamil learners"
-					phrases={recommendedPhrases.trending}
-					isLoading={false}
-					Icon={TrendingUp}
-				/>
-				<PhraseSection
-					description="More advanced, but in reach"
-					phrases={recommendedPhrases.challenging}
-					isLoading={false}
-					Icon={Brain}
-				/>
-				<PhraseSection
-					description="Broaden your vocabulary"
-					phrases={recommendedPhrases.easy}
-					isLoading={false}
-					Icon={Carrot}
-				/>
-			</CardContent>
-		</Card>
-	)
-}
-
-type FilterEnum =
-	| 'language'
-	| 'deck'
-	| 'reviewed_last_7d'
-	| 'not_in_deck'
-	| 'recommended'
-
-function DeckContents({ lang }: LangOnlyComponentProps) {
 	const { data: deck } = useDeck(lang)
 	const { data: language } = useLanguage(lang)
 	if (!language) throw new Error("Could not load this language's data")
 	if (!deck) throw new Error("Could not load this deck's data")
-	const [filter, setFilter] = useState<FilterEnum>('not_in_deck')
-	const pids = useMemo(
-		() => ({
-			language: language.pids,
-			deck: deck.pids.all,
-			reviewed_last_7d: deck.pids.reviewed_last_7d,
-			not_in_deck: language.pids.filter(
-				(pid) => deck.pids.all.indexOf(pid) === -1
-			),
-			recommended: [],
-		}),
-		[language.pids, deck.pids.all, deck.pids.reviewed_last_7d]
+
+	const processedPids = useMemo(
+		() => processPids(language.phrasesMap, language.pids, deck.pids),
+		[language.pids, deck.pids, language.phrasesMap]
 	)
+	return (
+		<div className="space-y-4 px-2">
+			<DeckContents lang={lang} pids={processedPids} />
+		</div>
+	)
+}
+
+type FilterEnum = 'language' | 'deck' | 'reviewed_last_7d' | 'not_in_deck'
+// | 'recommended'
+
+function DeckContents({
+	lang,
+	pids,
+}: LangOnlyComponentProps & { pids: ProcessedPids }) {
+	const [filter, setFilter] = useState<FilterEnum>('not_in_deck')
 
 	const filteredPids = pids[filter!]
 	return (
@@ -220,13 +82,13 @@ function DeckContents({ lang }: LangOnlyComponentProps) {
 						text="In your deck"
 						count={pids.deck?.length}
 					/>
-					<BadgeFilter
+					{/*<BadgeFilter
 						name="recommended"
 						setFilter={setFilter}
 						filter={filter}
 						text="Recommended"
 						count={pids.recommended?.length}
-					/>
+					/>*/}
 					<BadgeFilter
 						name="not_in_deck"
 						setFilter={setFilter}

--- a/src/routes/_user/learn.$lang.library.tsx
+++ b/src/routes/_user/learn.$lang.library.tsx
@@ -9,7 +9,6 @@ import { LanguagePhrasesAccordionComponent } from '@/components/language-phrases
 import Callout from '@/components/ui/callout'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
-import { inLastWeek } from '@/lib/dayjs'
 import { PhraseCard } from '@/components/phrase-card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Brain, Carrot, LucideIcon, Plus, TrendingUp } from 'lucide-react'
@@ -69,32 +68,60 @@ const PhraseSection = ({
 	</div>
 )
 
-const samplePhrases: Record<string, PhraseStub[]> = {
+const recommendedPhrases: Record<string, PhraseStub[]> = {
 	trending: [
-		{ id: '1', text: 'vanakkam', translation: { text: 'Hello', lang: 'eng' } },
-		{ id: '2', text: 'நன்றி', translation: { text: 'Thank you', lang: 'eng' } },
+		{
+			id: '1',
+			lang: 'tam',
+			text: 'vanakkam',
+			translation: [{ text: 'Hello', lang: 'eng' }],
+		},
+		{
+			id: '2',
+			lang: 'tam',
+			text: 'நன்றி',
+			translation: [{ text: 'Thank you', lang: 'eng' }],
+		},
 		{
 			id: '3',
+			lang: 'tam',
 			text: 'en peyar?',
-			translation: { text: 'What is your name?', lang: 'eng' },
+			translation: [{ text: 'What is your name?', lang: 'eng' }],
 		},
 	],
 	challenging: [
 		{
 			id: '4',
+			lang: 'tam',
 			text: 'Tamil teriyum',
-			translation: { text: 'I am learning Tamil', lang: 'eng' },
+			translation: [{ text: 'I am learning Tamil', lang: 'eng' }],
 		},
 		{
 			id: '5',
+			lang: 'tam',
 			text: 'Unga peyar enna?',
-			translation: { text: 'What is your name?', lang: 'eng' },
+			translation: [{ text: 'What is your name?', lang: 'eng' }],
 		},
 	],
 	easy: [
-		{ id: '6', text: 'Sari', translation: { text: 'Yes', lang: 'eng' } },
-		{ id: '7', text: 'Illai', translation: { text: 'No', lang: 'eng' } },
-		{ id: '8', text: 'Sari', translation: { text: 'Okay', lang: 'eng' } },
+		{
+			id: '6',
+			lang: 'tam',
+			text: 'Sari',
+			translation: [{ text: 'Yes', lang: 'eng' }],
+		},
+		{
+			id: '7',
+			lang: 'tam',
+			text: 'Illai',
+			translation: [{ text: 'No', lang: 'eng' }],
+		},
+		{
+			id: '8',
+			lang: 'tam',
+			text: 'Sari',
+			translation: [{ text: 'Okay', lang: 'eng' }],
+		},
 	],
 }
 
@@ -108,19 +135,19 @@ function PopularPhrases({ lang }: LangOnlyComponentProps) {
 			<CardContent className="space-y-4">
 				<PhraseSection
 					description="Popular phrases among all Tamil learners"
-					phrases={samplePhrases.trending}
+					phrases={recommendedPhrases.trending}
 					isLoading={false}
 					Icon={TrendingUp}
 				/>
 				<PhraseSection
 					description="More advanced, but in reach"
-					phrases={samplePhrases.challenging}
+					phrases={recommendedPhrases.challenging}
 					isLoading={false}
 					Icon={Brain}
 				/>
 				<PhraseSection
 					description="Broaden your vocabulary"
-					phrases={samplePhrases.easy}
+					phrases={recommendedPhrases.easy}
 					isLoading={false}
 					Icon={Carrot}
 				/>

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -79,7 +79,7 @@ export type TranslationInsert = TablesInsert<'phrase_translation'>
 export type RelationRow = Tables<'phrase_relation'>
 export type RelationInsert = TablesInsert<'phrase_relation'>
 
-export type PhraseMeta = Tables<'phrase_plus'>
+export type PhraseMeta = Tables<'meta_phrase_info'>
 export type PhraseFull = PhraseMeta & {
 	translations: Array<TranslationRow>
 }

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -50,9 +50,10 @@ export type LanguageFetched = LanguageMeta & {
 	phrases: Array<PhraseFull>
 }
 export type PhraseStub = {
+	lang: string
 	id: string
 	text: string
-	translation: { text: string; lang: string }
+	translation: Array<{ text: string; lang: string }>
 }
 
 export type PhrasesMap = {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -211,6 +211,13 @@ export type Database = {
             foreignKeyName: "phrase_see_also_from_phrase_id_fkey"
             columns: ["from_phrase_id"]
             isOneToOne: false
+            referencedRelation: "meta_phrase_info"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "phrase_see_also_from_phrase_id_fkey"
+            columns: ["from_phrase_id"]
+            isOneToOne: false
             referencedRelation: "phrase"
             referencedColumns: ["id"]
           },
@@ -219,6 +226,13 @@ export type Database = {
             columns: ["from_phrase_id"]
             isOneToOne: false
             referencedRelation: "phrase_plus"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "phrase_see_also_to_phrase_id_fkey"
+            columns: ["to_phrase_id"]
+            isOneToOne: false
+            referencedRelation: "meta_phrase_info"
             referencedColumns: ["id"]
           },
           {
@@ -295,6 +309,13 @@ export type Database = {
             foreignKeyName: "phrase_translation_phrase_id_fkey"
             columns: ["phrase_id"]
             isOneToOne: false
+            referencedRelation: "meta_phrase_info"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "phrase_translation_phrase_id_fkey"
+            columns: ["phrase_id"]
+            isOneToOne: false
             referencedRelation: "phrase"
             referencedColumns: ["id"]
           },
@@ -336,6 +357,13 @@ export type Database = {
           user_deck_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "user_card_phrase_id_fkey"
+            columns: ["phrase_id"]
+            isOneToOne: false
+            referencedRelation: "meta_phrase_info"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "user_card_phrase_id_fkey"
             columns: ["phrase_id"]
@@ -633,6 +661,44 @@ export type Database = {
         }
         Relationships: []
       }
+      meta_phrase_info: {
+        Row: {
+          avg_difficulty: number | null
+          avg_stability: number | null
+          count_active: number | null
+          count_cards: number | null
+          count_learned: number | null
+          count_skipped: number | null
+          created_at: string | null
+          id: string | null
+          lang: string | null
+          percent_active: number | null
+          percent_learned: number | null
+          percent_skipped: number | null
+          rank_least_difficult: number | null
+          rank_least_skipped: number | null
+          rank_most_learned: number | null
+          rank_most_stable: number | null
+          rank_newest: number | null
+          text: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "phrase_lang_fkey"
+            columns: ["lang"]
+            isOneToOne: false
+            referencedRelation: "language"
+            referencedColumns: ["lang"]
+          },
+          {
+            foreignKeyName: "phrase_lang_fkey"
+            columns: ["lang"]
+            isOneToOne: false
+            referencedRelation: "language_plus"
+            referencedColumns: ["lang"]
+          },
+        ]
+      }
       phrase_plus: {
         Row: {
           added_by: string | null
@@ -724,6 +790,13 @@ export type Database = {
           user_deck_id: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "user_card_phrase_id_fkey"
+            columns: ["phrase_id"]
+            isOneToOne: false
+            referencedRelation: "meta_phrase_info"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "user_card_phrase_id_fkey"
             columns: ["phrase_id"]

--- a/supabase/migrations/20250501135860_create_view_meta_phrase_info.sql
+++ b/supabase/migrations/20250501135860_create_view_meta_phrase_info.sql
@@ -44,8 +44,8 @@ with
 			),
 			results as (
 				select
-					p.id as phrase_id,
-					p.created_at as phrase_created_at,
+					p.id,
+					p.created_at,
 					p.lang,
 					p.text,
 					avg(c.difficulty) as avg_difficulty,
@@ -80,8 +80,8 @@ with
 					p.text
 			)
 		select
-			results.phrase_id,
-			results.phrase_created_at,
+			results.id,
+			results.created_at,
 			results.lang,
 			results.text,
 			results.avg_difficulty,
@@ -134,7 +134,7 @@ with
 				partition by
 					lang
 				order by
-					phrase_created_at desc
+					created_at desc
 			) as rank_newest
 		from
 			results

--- a/supabase/migrations/20250501135860_create_view_meta_phrase_info.sql
+++ b/supabase/migrations/20250501135860_create_view_meta_phrase_info.sql
@@ -1,0 +1,141 @@
+create or replace view
+	"public"."meta_phrase_info"
+with
+	(security_invoker = false) as (
+		with
+			recent_review as (
+				select
+					r1.id,
+					r1.uid,
+					r1.user_card_id,
+					r1.score,
+					r1.difficulty,
+					r1.stability,
+					r1.review_time_retrievability,
+					r1.created_at,
+					r1.updated_at,
+					r1.user_deck_id
+				from
+					(
+						user_card_review r1
+						left join user_card_review r2 on (
+							(
+								(r1.user_card_id = r2.user_card_id)
+								and (r1.created_at < r2.created_at)
+							)
+						)
+					)
+				where
+					(r2.created_at is null)
+			),
+			card_with_recentest_review as (
+				select distinct
+					c.id,
+					c.phrase_id,
+					c.status,
+					r.difficulty,
+					r.stability,
+					r.created_at as recentest_review_at
+				from
+					(
+						user_card c
+						join recent_review r on ((c.id = r.user_card_id))
+					)
+			),
+			results as (
+				select
+					p.id as phrase_id,
+					p.created_at as phrase_created_at,
+					p.lang,
+					p.text,
+					avg(c.difficulty) as avg_difficulty,
+					avg(c.stability) as avg_stability,
+					count(distinct c.id) as count_cards,
+					sum(
+						case
+							when (c.status = 'active'::card_status) then 1
+							else 0
+						end
+					) as count_active,
+					sum(
+						case
+							when (c.status = 'learned'::card_status) then 1
+							else 0
+						end
+					) as count_learned,
+					sum(
+						case
+							when (c.status = 'skipped'::card_status) then 1
+							else 0
+						end
+					) as count_skipped
+				from
+					(
+						phrase p
+						left join card_with_recentest_review c on ((c.phrase_id = p.id))
+					)
+				group by
+					p.id,
+					p.lang,
+					p.text
+			)
+		select
+			results.phrase_id,
+			results.phrase_created_at,
+			results.lang,
+			results.text,
+			results.avg_difficulty,
+			results.avg_stability,
+			results.count_cards,
+			results.count_active,
+			results.count_learned,
+			results.count_skipped,
+			case
+				when (results.count_cards = 0) then null::numeric
+				else round(((results.count_active / results.count_cards))::numeric, 2)
+			end as percent_active,
+			case
+				when (results.count_cards = 0) then null::numeric
+				else round(((results.count_learned / results.count_cards))::numeric, 2)
+			end as percent_learned,
+			case
+				when (results.count_cards = 0) then null::numeric
+				else round(((results.count_skipped / results.count_cards))::numeric, 2)
+			end as percent_skipped,
+			rank() over (
+				partition by
+					lang
+				order by
+					avg_difficulty asc nulls last
+			) as rank_least_difficult,
+			rank() over (
+				partition by
+					lang
+				order by
+					avg_stability desc nulls last
+			) as rank_most_stable,
+			rank() over (
+				partition by
+					lang
+				order by
+					case
+						when count_cards > 0 then (count_skipped::numeric / count_cards::numeric)
+					end asc nulls last
+			) as rank_least_skipped,
+			rank() over (
+				partition by
+					lang
+				order by
+					case
+						when count_cards > 0 then (count_learned::numeric / count_cards::numeric)
+					end desc nulls last
+			) as rank_most_learned,
+			rank() over (
+				partition by
+					lang
+				order by
+					phrase_created_at desc
+			) as rank_newest
+		from
+			results
+	);


### PR DESCRIPTION
This PR creates the `meta_phrase_info` view which contains average difficulty scores for this phrase across all cards/users, as well as total card counts (previously available on `phrase_plus`) and card age, and shows them in the card recommendations section on the deck index page: showing top 4 cards sorted by low difficulty, high popularity, and recent creation date.

We do not (yet) integrate the feature into other areas where it makes sense, like completing the "customise my session" feature, or the library's browse-by-filters, which should come next/later.

Note on naming/security conventions: This PR replaces `phrase_plus` with `meta_phrase_info` which signals a change in naming conventions. Our user-protected info all starts with `user_` and our public info does not, so it's named like `language` or `phrase_translation`, but this `meta_` prefix signifies a publically query-able view created to query and assembling metadata based on private user information. These views must be written with `security_invoker=false` and they must be audited carefully to ensure that user information never leaks. Some of the motivation for this approach to conventions (with public data, auth-required, user-specific data, and publishable metadata that mixes the two) may be better or more wholistically approached by using the API schema convention that is perhaps becoming standard for Supabase projects; and this approach may lead us into that one, but for now it seems solid as is.

