### PR TITLE
Feature: confirm auto recommendations

### DIFF
--- a/src/components/extra-info.tsx
+++ b/src/components/extra-info.tsx
@@ -1,0 +1,42 @@
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from './ui/dialog'
+import { Button } from './ui/button'
+import { Ellipsis } from 'lucide-react'
+import { ReactNode } from '@tanstack/react-router'
+
+export default function ExtraInfo({
+	title,
+	description,
+	className,
+	children,
+}: {
+	title?: string
+	description?: string
+	children: ReactNode
+	className?: string
+}) {
+	return (
+		<Dialog>
+			<DialogTrigger className={className} asChild>
+				<Button variant="ghost" size="icon-sm">
+					<Ellipsis className="size-4" />
+					<span className="sr-only">Show more</span>
+				</Button>
+			</DialogTrigger>
+
+			<DialogContent className="max-h-[90vh] max-w-[90vw] overflow-y-auto">
+				<DialogHeader>
+					<DialogTitle>{title}</DialogTitle>
+					<DialogDescription>{description}</DialogDescription>
+				</DialogHeader>
+				{children}
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/src/components/extra-info.tsx
+++ b/src/components/extra-info.tsx
@@ -30,7 +30,7 @@ export default function ExtraInfo({
 				</Button>
 			</DialogTrigger>
 
-			<DialogContent className="max-h-[90vh] max-w-[90vw] overflow-y-auto">
+			<DialogContent className="w-app max-h-[90vh] overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle>{title}</DialogTitle>
 					<DialogDescription>{description}</DialogDescription>

--- a/src/components/flash-card-review-session.tsx
+++ b/src/components/flash-card-review-session.tsx
@@ -126,7 +126,12 @@ export function FlashCardReviewSession({
 				{pids.map((pid, i) => {
 					const phrase = phrasesMap[pid]
 					const card = cardsMap[pid]
-
+					if (!card || card === null) {
+						console.log(`Error on this card render:`, pid, phrase, card)
+						throw new Error(
+							'Trying to review a card that does not exist. (Consider refreshing the page.)'
+						)
+					}
 					return (
 						<Card
 							key={i}

--- a/src/components/language-is-empty.tsx
+++ b/src/components/language-is-empty.tsx
@@ -1,0 +1,68 @@
+import { Link } from '@tanstack/react-router'
+import { Garlic } from './garlic'
+import Callout from './ui/callout'
+import { buttonVariants } from './ui/button-variants'
+import { MessageSquarePlus } from 'lucide-react'
+
+export function LanguageIsEmpty({ lang }: { lang: string }) {
+	return (
+		<Callout className="mt-4" Icon={() => <Garlic size={120} />}>
+			<h3 className="h3">Library under construction</h3>
+			<p>
+				This language is fully empty! But Sunlo is a community effort &ndash;{' '}
+				<em>you</em> have the power to do something about it.
+			</p>
+			<p>
+				You must know <em>at least one phrase</em> in this new language, right?
+				Add it to the library!
+			</p>
+			<Link
+				className={buttonVariants({ size: 'lg' })}
+				to="/learn/$lang/add-phrase"
+				params={{ lang }}
+			>
+				<MessageSquarePlus size="48" className="h-12 w-12 grow" />
+				Add phrases to the library
+			</Link>
+		</Callout>
+	)
+}
+
+export function LanguageFilteredIsEmpty({ lang }: { lang: string }) {
+	return (
+		<Callout Icon={() => <Garlic size={120} />}>
+			<h3 className="h3">Library under construction</h3>
+			<p>
+				This language has cards but none of them are translated into languages
+				you know. But Sunlo is a community effort &mdash; you can add phrases
+				and new translations any time you want.
+			</p>
+			<ul className="ms-4 list-disc space-y-4">
+				<li>
+					<Link
+						to="/learn/$lang/add-phrase"
+						params={{ lang }}
+						className="s-link"
+					>
+						Add phrases to the library
+					</Link>
+				</li>
+				<li>
+					<Link
+						to="/learn/$lang/library"
+						params={{ lang }}
+						search={{ filter: 'language_no_translations' }}
+						className="s-link"
+					>
+						View existing phrases to add translations in one of your languages
+					</Link>{' '}
+				</li>
+				<li>
+					<Link to="/profile" className="s-link">
+						Or, update your profile to view additional translations
+					</Link>{' '}
+				</li>
+			</ul>
+		</Callout>
+	)
+}

--- a/src/components/language-phrases-accordion.tsx
+++ b/src/components/language-phrases-accordion.tsx
@@ -62,6 +62,7 @@ function PhraseAccordionItem({
 					lang={phrase.lang!}
 					deckId={deckId}
 					pid={phrase.id!}
+					// @ts-expect-error
 					card={card}
 				/>
 				<AccordionTrigger>{phrase.text}</AccordionTrigger>

--- a/src/components/language-phrases-accordion.tsx
+++ b/src/components/language-phrases-accordion.tsx
@@ -7,11 +7,11 @@ import {
 } from '@/components/ui/accordion'
 import { CardStatusDropdown } from './card-status-dropdown'
 import { AddTranslationsDialog } from './add-translations-dialog'
-import { useLanguage } from '@/lib/use-language'
 import { useDeck } from '@/lib/use-deck'
 import PhraseExtraInfo from './phrase-extra-info'
 import PermalinkButton from './permalink-button'
 import SharePhraseButton from './share-phrase-button'
+import { useDeckPidsAndRecs } from '@/lib/process-pids'
 
 interface PhrasesWithOptionalOrder {
 	lang: string
@@ -22,21 +22,24 @@ export function LanguagePhrasesAccordionComponent({
 	lang,
 	pids = null,
 }: PhrasesWithOptionalOrder) {
-	const { data: language } = useLanguage(lang)
 	const { data: deck } = useDeck(lang)
-	if (!language)
+	// we are using filtered phrases but unfiltered pids
+	// because the user will manage filtering
+	const { phrasesMapFiltered, language: languagePids } =
+		useDeckPidsAndRecs(lang)
+	if (!deck)
 		throw new Error(
 			"We can't find that language. Are you sure you have the correct URL?"
 		)
-	const pidsToUse = pids ?? language.pids
+	const pidsToUse = pids ?? languagePids
 	return (
 		<Accordion type="single" collapsible className="w-full">
 			{pidsToUse.map((pid) => (
 				<PhraseAccordionItem
 					key={pid}
-					phrase={language.phrasesMap[pid]}
+					phrase={phrasesMapFiltered[pid]}
 					card={deck?.cardsMap[pid] ?? null}
-					deckId={deck?.meta.id}
+					deckId={deck?.meta.id!}
 				/>
 			))}
 		</Accordion>
@@ -45,7 +48,7 @@ export function LanguagePhrasesAccordionComponent({
 
 function PhraseAccordionItem({
 	phrase,
-	card = null,
+	card,
 	deckId,
 }: {
 	phrase: PhraseFull

--- a/src/components/phrase-extra-info.tsx
+++ b/src/components/phrase-extra-info.tsx
@@ -1,19 +1,10 @@
 import { CardFull, uuid } from '@/types/main'
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogHeader,
-	DialogTitle,
-	DialogTrigger,
-} from './ui/dialog'
 import { ago } from '@/lib/dayjs'
 import { useLanguagePhrase } from '@/lib/use-language'
-import { Button } from './ui/button'
-import { Ellipsis } from 'lucide-react'
 import { useDeckCard } from '@/lib/use-deck'
 import { dateDiff, intervals, retrievability, round } from '@/lib/utils'
 import Flagged from './flagged'
+import ExtraInfo from './extra-info'
 
 export default function PhraseExtraInfo({
 	pid,
@@ -27,40 +18,27 @@ export default function PhraseExtraInfo({
 	const phrase = useLanguagePhrase(pid, lang)
 	const card = useDeckCard(pid, lang)
 
-	return (
-		<Dialog>
-			<DialogTrigger className={className} asChild>
-				<Button variant="ghost" size="icon-sm">
-					<Ellipsis className="size-4" />
-					<span className="sr-only">Show more</span>
-				</Button>
-			</DialogTrigger>
-			{phrase.isPending ? null : (
-				<DialogContent className="max-h-[90vh] max-w-[90vw] overflow-y-auto">
-					<DialogHeader>
-						<DialogTitle>User card details</DialogTitle>
-						<DialogDescription>
-							&ldquo;{phrase.data.text}&rdquo;
-						</DialogDescription>
-					</DialogHeader>
-
-					<div className="block space-y-4">
-						<div className="flex flex-col">
-							<span className="font-semibold">Phrase ID</span>
-							<span>{phrase.data.id}</span>
-						</div>
-						<div className="flex flex-col">
-							<span className="font-semibold">Phrase created at</span>
-							<span>{ago(phrase.data.created_at)}</span>
-						</div>
+	return !phrase.data ? null : (
+			<ExtraInfo
+				title="User card details"
+				description={`“${phrase.data.text}”`}
+				className={className}
+			>
+				<div className="block space-y-4">
+					<div className="flex flex-col">
+						<span className="font-semibold">Phrase ID</span>
+						<span>{phrase.data.id}</span>
 					</div>
-					{!card.data ?
-						<p>Phrase has no card in your deck</p>
-					:	<CardSection card={card.data} />}
-				</DialogContent>
-			)}
-		</Dialog>
-	)
+					<div className="flex flex-col">
+						<span className="font-semibold">Phrase created at</span>
+						<span>{ago(phrase.data.created_at)}</span>
+					</div>
+				</div>
+				{!card.data ?
+					<p>Phrase has no card in your deck</p>
+				:	<CardSection card={card.data} />}
+			</ExtraInfo>
+		)
 }
 
 function CardSection({ card }: { card: CardFull }) {
@@ -71,7 +49,7 @@ function CardSection({ card }: { card: CardFull }) {
 	)
 	const rev = reviews?.[0] || null
 	const retr =
-		!rev ? null : retrievability(card.last_reviewed_at, card.stability)
+		!rev ? null : retrievability(card.last_reviewed_at, card.stability!)
 	return (
 		<div className="block space-y-4">
 			<div className="flex flex-col">

--- a/src/components/recommended-phrases.tsx
+++ b/src/components/recommended-phrases.tsx
@@ -52,19 +52,19 @@ export function RecommendedPhrasesCard({ lang }: LangOnlyComponentProps) {
 			:	<CardContent className="space-y-4">
 					<PhraseSection
 						description={`Popular among all ${languages[lang]} learners`}
-						pids={pids.recommended.popular.slice(0, 4)}
+						pids={Array.from(pids.top8.popular).slice(0, 4)}
 						lang={lang}
 						Icon={TrendingUp}
 					/>
 					<PhraseSection
 						description="Newly added"
-						pids={pids.recommended.newest.slice(0, 4)}
+						pids={Array.from(pids.top8.newest).slice(0, 4)}
 						lang={lang}
 						Icon={Brain}
 					/>
 					<PhraseSection
 						description="Broaden your vocabulary"
-						pids={pids.recommended.easiest.slice(0, 4)}
+						pids={Array.from(pids.top8.easiest).slice(0, 4)}
 						lang={lang}
 						Icon={Carrot}
 					/>

--- a/src/components/recommended-phrases.tsx
+++ b/src/components/recommended-phrases.tsx
@@ -3,7 +3,6 @@ import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
 import { useDeckPidsAndRecs } from '@/lib/process-pids'
 import { Brain, Carrot, Loader2, LucideIcon, TrendingUp } from 'lucide-react'
 import { LangOnlyComponentProps, pids } from '@/types/main'
-import { useLanguagePhrasesMap } from '@/lib/use-language'
 import { PhraseCard } from './phrase-card'
 
 type PhraseSectionProps = {
@@ -19,8 +18,8 @@ const PhraseSection = ({
 	lang,
 	Icon,
 }: PhraseSectionProps) => {
-	const { data: phrasesMap } = useLanguagePhrasesMap(lang)
-	if (!phrasesMap) return null
+	const { phrasesMapFiltered } = useDeckPidsAndRecs(lang)
+	if (!phrasesMapFiltered) return null
 	return (
 		<div>
 			<p className="my-1 text-lg">
@@ -29,8 +28,8 @@ const PhraseSection = ({
 			{pids?.length > 0 ?
 				<div className="flex flex-row flex-wrap gap-2">
 					{pids.map((pid) => {
-						return !(pid in phrasesMap) ? null : (
-								<PhraseCard key={pid} phrase={phrasesMap[pid]} />
+						return !(pid in phrasesMapFiltered) ? null : (
+								<PhraseCard key={pid} phrase={phrasesMapFiltered[pid]} />
 							)
 					})}
 				</div>

--- a/src/components/recommended-phrases.tsx
+++ b/src/components/recommended-phrases.tsx
@@ -52,19 +52,19 @@ export function RecommendedPhrasesCard({ lang }: LangOnlyComponentProps) {
 			:	<CardContent className="space-y-4">
 					<PhraseSection
 						description={`Popular among all ${languages[lang]} learners`}
-						pids={Array.from(pids.top8.popular).slice(0, 4)}
+						pids={pids.top8.popular.slice(0, 4)}
 						lang={lang}
 						Icon={TrendingUp}
 					/>
 					<PhraseSection
 						description="Newly added"
-						pids={Array.from(pids.top8.newest).slice(0, 4)}
+						pids={pids.top8.newest.slice(0, 4)}
 						lang={lang}
 						Icon={Brain}
 					/>
 					<PhraseSection
 						description="Broaden your vocabulary"
-						pids={Array.from(pids.top8.easiest).slice(0, 4)}
+						pids={pids.top8.easiest.slice(0, 4)}
 						lang={lang}
 						Icon={Carrot}
 					/>

--- a/src/components/recommended-phrases.tsx
+++ b/src/components/recommended-phrases.tsx
@@ -1,7 +1,7 @@
 import languages from '@/lib/languages'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
-import { ProcessedPids } from '@/lib/process-pids'
-import { Brain, Carrot, LucideIcon, TrendingUp } from 'lucide-react'
+import { useDeckPidsAndRecs } from '@/lib/process-pids'
+import { Brain, Carrot, Loader2, LucideIcon, TrendingUp } from 'lucide-react'
 import { LangOnlyComponentProps, pids } from '@/types/main'
 import { useLanguagePhrasesMap } from '@/lib/use-language'
 import { PhraseCard } from './phrase-card'
@@ -39,35 +39,37 @@ const PhraseSection = ({
 	)
 }
 
-export function RecommendedPhrasesCard({
-	lang,
-	pids,
-}: LangOnlyComponentProps & { pids: ProcessedPids }) {
+export function RecommendedPhrasesCard({ lang }: LangOnlyComponentProps) {
+	const pids = useDeckPidsAndRecs(lang)
+
 	return (
 		<Card>
 			<CardHeader>
 				<CardTitle>Recommended For You</CardTitle>
 			</CardHeader>
-			<CardContent className="space-y-4">
-				<PhraseSection
-					description={`Popular among all ${languages[lang]} learners`}
-					pids={pids.recommended.popular.slice(0, 4)}
-					lang={lang}
-					Icon={TrendingUp}
-				/>
-				<PhraseSection
-					description="Newly added"
-					pids={pids.recommended.newest.slice(0, 4)}
-					lang={lang}
-					Icon={Brain}
-				/>
-				<PhraseSection
-					description="Broaden your vocabulary"
-					pids={pids.recommended.easiest.slice(0, 4)}
-					lang={lang}
-					Icon={Carrot}
-				/>
-			</CardContent>
+			{pids === null ?
+				<Loader2 />
+			:	<CardContent className="space-y-4">
+					<PhraseSection
+						description={`Popular among all ${languages[lang]} learners`}
+						pids={pids.recommended.popular.slice(0, 4)}
+						lang={lang}
+						Icon={TrendingUp}
+					/>
+					<PhraseSection
+						description="Newly added"
+						pids={pids.recommended.newest.slice(0, 4)}
+						lang={lang}
+						Icon={Brain}
+					/>
+					<PhraseSection
+						description="Broaden your vocabulary"
+						pids={pids.recommended.easiest.slice(0, 4)}
+						lang={lang}
+						Icon={Carrot}
+					/>
+				</CardContent>
+			}
 		</Card>
 	)
 }

--- a/src/components/review/explain-todays-review.tsx
+++ b/src/components/review/explain-todays-review.tsx
@@ -1,0 +1,104 @@
+import { pids } from '@/types/main'
+import Flagged from '../flagged'
+import { ProcessedDeckAndPids } from '@/lib/process-pids'
+import ExtraInfo from '../extra-info'
+import { AlgoRecsObject } from './select-phrases-to-add-to-review'
+
+type ExplainingTheReviewProps = {
+	today_active: pids
+	countNeeded: number
+	freshCards: pids
+	countSurplusOrDeficit: number
+	cardsToCreate: pids
+	allCardsForToday: pids
+	friendRecsFiltered: pids
+	friendRecsSelected: pids
+	countNeeded2: number
+	algoRecsFiltered: AlgoRecsObject
+	algoRecsSelected: pids
+	countNeeded3: number
+	pids: ProcessedDeckAndPids
+	cardsUnreviewedActiveSelected: pids
+	countNeeded4: number
+	libraryPhrasesSelected: pids
+}
+
+export function ExplainTodaysReview({
+	today_active,
+	countNeeded,
+	freshCards,
+	countSurplusOrDeficit,
+	cardsToCreate,
+	allCardsForToday,
+	friendRecsFiltered,
+	friendRecsSelected,
+	countNeeded2,
+	algoRecsFiltered,
+	algoRecsSelected,
+	countNeeded3,
+	pids,
+	cardsUnreviewedActiveSelected,
+	countNeeded4,
+	libraryPhrasesSelected,
+}: ExplainingTheReviewProps) {
+	return (
+		<ExtraInfo title="Explaining today's review cards">
+			<p>
+				<strong>{today_active.length} cards</strong> previously scheduled.
+				<br />
+				<strong>{countNeeded} new cards</strong> is your daily goal.
+				<br />
+				<strong>{freshCards.length} new cards</strong> selected for you/by you,
+				which is <br />
+				<strong>{Math.abs(countSurplusOrDeficit)} cards</strong>{' '}
+				{countSurplusOrDeficit > 0 ? 'above' : 'less than'} your daily goal.
+				<br />
+				(of which {cardsToCreate.length} were not previously in your deck).
+				<br />
+				<strong>{allCardsForToday.length} total cards</strong> for review today.
+			</p>
+			<Flagged name="friend_recommendations">
+				<p>
+					There are {friendRecsFiltered.length} friend recommendations, of which
+					you've selected {friendRecsSelected.length}. So you still need to get{' '}
+					{countNeeded2} countNeeded2.
+				</p>
+			</Flagged>
+			<p>
+				We offered some recs from the algorithm &mdash;{' '}
+				{algoRecsFiltered.popular.length} popular,{' '}
+				{algoRecsFiltered.easiest.length} easy-ish,{' '}
+				{algoRecsFiltered.newest.length} newest &mdash; and you selected{' '}
+				{algoRecsSelected.length} selectedAlgoRecs, meaning you still need{' '}
+				{countNeeded3}.
+			</p>
+			<p>
+				Next we went looking in your deck for cards you've selected, but haven't
+				reviewed before: there are {pids.unreviewed_active.length} of them (out
+				of {pids.deck.length} total in your deck), and we managed to get{' '}
+				{cardsUnreviewedActiveSelected.length} of them (unsure why there would
+				ever be a discrepancy here), leaving {countNeeded4} to pull from the
+				library.
+			</p>
+			<p>
+				We have {pids.not_in_deck.length} cards in the library that aren't
+				already in your deck or weren't chosen from the recommendations, the{' '}
+				{pids.language.length} total phrases in the library and found{' '}
+				{pids.not_in_deck.length} which are not in your deck, and we grabbed{' '}
+				{libraryPhrasesSelected.length} of them.
+			</p>
+			<p>
+				So the total number of cards is {allCardsForToday.length}, which is{' '}
+				{today_active.length} scheduled + {friendRecsSelected.length} friend
+				recs + {algoRecsSelected.length} algo recs +{' '}
+				{cardsUnreviewedActiveSelected.length} deck +{' '}
+				{libraryPhrasesSelected.length} library ={' '}
+				{today_active.length +
+					friendRecsSelected.length +
+					algoRecsSelected.length +
+					cardsUnreviewedActiveSelected.length +
+					libraryPhrasesSelected.length}
+			</p>
+		</ExtraInfo>
+	)
+}

--- a/src/components/review/flash-card-review-session.tsx
+++ b/src/components/review/flash-card-review-session.tsx
@@ -15,10 +15,10 @@ import {
 	countUnfinishedCards,
 } from '@/lib/use-reviewables'
 import { PostgrestError } from '@supabase/supabase-js'
-import PhraseExtraInfo from './phrase-extra-info'
-import Flagged from './flagged'
-import PermalinkButton from './permalink-button'
-import SharePhraseButton from './share-phrase-button'
+import PhraseExtraInfo from '../phrase-extra-info'
+import Flagged from '../flagged'
+import PermalinkButton from '../permalink-button'
+import SharePhraseButton from '../share-phrase-button'
 import { useLoaderData } from '@tanstack/react-router'
 
 interface ComponentProps {

--- a/src/components/review/not-enough-cards.tsx
+++ b/src/components/review/not-enough-cards.tsx
@@ -1,0 +1,56 @@
+import { MessageCircleWarningIcon } from 'lucide-react'
+import Callout from '../ui/callout'
+import { buttonVariants } from '../ui/button-variants'
+import { Link } from '@tanstack/react-router'
+
+export function NotEnoughCards({
+	lang,
+	countNeeded,
+	newCardsCount,
+	totalCards,
+}: {
+	lang: string
+	countNeeded: number
+	newCardsCount: number
+	totalCards: number
+}) {
+	const noCards = totalCards === 0
+	return (
+		<Callout variant="ghost" Icon={() => <MessageCircleWarningIcon />}>
+			<p>
+				It looks like you don't have {noCards ? 'any' : 'enough new'} cards
+				{noCards ?
+					" to review. You'll have to add at least a few before you can proceed"
+				:	<>
+						in your deck to meet your goal of{' '}
+						<strong className="italic">{countNeeded} new cards a day</strong>
+					</>
+				}
+				.
+			</p>
+			<div className="my-2 flex flex-col gap-2 @lg:flex-row">
+				<Link
+					className={buttonVariants({ variant: 'outline' })}
+					to="/learn/$lang/library"
+					params={{ lang }}
+				>
+					Add cards from the Library
+				</Link>
+
+				<Link
+					className={buttonVariants({ variant: 'outline' })}
+					to="/learn/$lang/add-phrase"
+					params={{ lang }}
+				>
+					Create new cards
+				</Link>
+			</div>
+			{noCards ? null : (
+				<>
+					Or click the big button below and get started with the {newCardsCount}{' '}
+					cards you have.
+				</>
+			)}
+		</Callout>
+	)
+}

--- a/src/components/review/select-phrases-to-add-to-review.tsx
+++ b/src/components/review/select-phrases-to-add-to-review.tsx
@@ -1,0 +1,159 @@
+import languages from '@/lib/languages'
+import { useDeckPidsAndRecs } from '@/lib/process-pids'
+import { useProfile } from '@/lib/use-profile'
+import { pids } from '@/types/main'
+import {
+	Brain,
+	Carrot,
+	CheckCircle,
+	LucideIcon,
+	Sparkles,
+	TrendingUp,
+} from 'lucide-react'
+import {
+	DrawerContent,
+	DrawerDescription,
+	DrawerHeader,
+	DrawerTitle,
+} from '../ui/drawer'
+import {
+	Card,
+	CardDescription,
+	CardFooter,
+	CardHeader,
+	CardTitle,
+} from '../ui/card'
+import { Badge } from '../ui/badge'
+
+export type AlgoRecsFiltersEnum = 'popular' | 'easiest' | 'newest'
+export type AlgoRecsObject = Record<AlgoRecsFiltersEnum, pids>
+
+export function SelectPhrasesToAddToReview({
+	lang,
+	algoRecsSelected,
+	setAlgoRecsSelected,
+	algoRecsFiltered,
+	// countOfCardsDesired,
+}: {
+	lang: string
+	algoRecsSelected: pids
+	setAlgoRecsSelected: (recs: pids) => void
+	algoRecsFiltered: AlgoRecsObject
+	// countOfCardsDesired: number
+}) {
+	const res = useDeckPidsAndRecs(lang)
+	if (!res)
+		throw new Error(
+			'Unable to grab the collated deck pids and filtered phrases'
+		)
+	const phrasesMapFiltered = res.phrasesMapFiltered
+	const { data: profile } = useProfile()
+	if (!profile)
+		throw new Error(
+			'Profile should be here on first render, but it is not showing up'
+		)
+	// Toggle card selection
+	const toggleCardSelection = (pid1: string) => {
+		const updatedRecs =
+			algoRecsSelected.indexOf(pid1) === -1 ?
+				[...algoRecsSelected, pid1]
+			:	algoRecsSelected.filter((pid2) => pid1 !== pid2)
+		setAlgoRecsSelected(updatedRecs)
+	}
+	const sections: {
+		key: AlgoRecsFiltersEnum
+		description: string
+		Icon: LucideIcon
+	}[] = [
+		{
+			key: 'popular',
+			description: `Popular among all ${languages[lang]} learners`,
+			Icon: TrendingUp,
+		},
+		{
+			key: 'easiest',
+			description: `Broaden your vocabulary`,
+			Icon: Carrot,
+		},
+		{
+			key: 'newest',
+			description: `Newly added`,
+			Icon: Brain,
+		},
+	]
+
+	return (
+		<DrawerContent aria-describedby="drawer-description">
+			<div className="@container relative mx-auto w-full max-w-prose overflow-y-auto px-1 pb-10">
+				<DrawerHeader className="bg-background sticky top-0">
+					<DrawerTitle className="sticky top-0 flex items-center gap-2 text-xl">
+						<Sparkles className="h-5 w-5 text-purple-500" />
+						Recommended for you ({algoRecsSelected.length} selected)
+					</DrawerTitle>
+				</DrawerHeader>
+				<DrawerDescription className="">
+					Review and select which recommended cards you want to include in your
+					session
+				</DrawerDescription>
+				<div className="my-6 space-y-6">
+					{sections.map((s) => {
+						return (
+							<div>
+								<p className="my-4 text-lg">
+									<s.Icon className="inline size-6" /> {s.description}
+								</p>
+								<div className="grid gap-3 @lg:grid-cols-2">
+									{algoRecsFiltered[s.key].length > 0 ?
+										algoRecsFiltered[s.key].map((pid) => {
+											const selected = algoRecsSelected.indexOf(pid) > -1
+											const phrase = phrasesMapFiltered[pid]
+											// console.log(`mapping the algo recs`, phrase)
+
+											return (
+												<Card
+													onClick={() => toggleCardSelection(pid)}
+													key={pid}
+													className={`hover:bg-primary/20 cursor-pointer border-1 transition-all ${selected ? 'border-primary bg-primary/10' : ''}`}
+												>
+													<CardHeader className="p-3 pb-0">
+														<CardTitle className="text-base">
+															{phrase.text}
+														</CardTitle>
+														<CardDescription>
+															{phrase.translations[0].text}
+														</CardDescription>
+													</CardHeader>
+													<CardFooter className="flex justify-end p-3 pt-0">
+														<Badge
+															variant={selected ? 'default' : 'outline'}
+															className="grid grid-cols-1 grid-rows-1 place-items-center font-normal [grid-template-areas:'stack']"
+														>
+															<span
+																className={`flex flex-row items-center gap-1 [grid-area:stack] ${selected ? '' : 'invisible'}`}
+															>
+																<CheckCircle className="me-1 h-3 w-3" />
+																Selected
+															</span>
+															<span
+																className={`[grid-area:stack] ${selected ? 'invisible' : ''}`}
+															>
+																Tap to select
+															</span>
+														</Badge>
+													</CardFooter>
+												</Card>
+											)
+										})
+									:	<p className="text-muted-foreground">
+											Sorry, all out of recommendations today
+										</p>
+									}
+								</div>
+							</div>
+						)
+					})}
+				</div>
+			</div>
+		</DrawerContent>
+	)
+}

--- a/src/components/ui/button-variants.tsx
+++ b/src/components/ui/button-variants.tsx
@@ -19,8 +19,8 @@ const buttonVariants = cva(
 			},
 			size: {
 				default: 'h-10 rounded-md px-4 py-2 gap-2',
-				sm: 'h-9 rounded-md px-3 gap-1',
-				lg: 'rounded-md px-8 py-4 text-xl font-medium rounded-lg gap-3',
+				sm: 'h-9 rounded-md px-3 gap-1 [&_svg]:size-3',
+				lg: 'rounded-md px-8 py-4 text-xl font-medium rounded-lg gap-3 [&_svg]:size-6',
 				icon: 'size-10 rounded-full shrink-0',
 				'icon-sm': 'size-6 rounded-full shrink-0',
 				badge: 'h-6 rounded-full font-sm px-2 gap-1 my-0',

--- a/src/components/ui/button-variants.tsx
+++ b/src/components/ui/button-variants.tsx
@@ -12,7 +12,7 @@ const buttonVariants = cva(
 				destructive:
 					'bg-destructive text-destructive-foreground hover:bg-destructive/90',
 				'destructive-outline':
-					'border border-destructive text-destructive bg-destructive/10 hover:bg-destructive hover:text-destructive-foreground',
+					'border border-destructive text-destructive bg-destructive-foreground/80 hover:bg-destructive hover:text-destructive-foreground',
 				ghost: 'hover:bg-primary/30 hover:text-accent-foreground',
 				outline: 'border border-primary bg-card hover:bg-primary/20',
 				link: 'text-primary-foresoft underline-offset-4 hover:underline',

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -10,7 +10,6 @@ type FlagMap = {
 		  }
 }
 export const flags: FlagMap = {
-	smart_recommendations: { enabled: false },
 	friend_recommendations: { enabled: false },
 	friends_activity: { enabled: false },
 	learning_goals: { enabled: false },

--- a/src/lib/process-pids.ts
+++ b/src/lib/process-pids.ts
@@ -13,33 +13,43 @@ function processPids(
 	const not_in_deck = languagePids.filter(
 		(pid) => deckPids.all.indexOf(pid) === -1
 	)
+	const ranked = {
+		easiest: not_in_deck.toSorted(
+			(pid1, pid2) =>
+				// prioritize LOWER values
+				phrasesMap[pid1].avg_difficulty! - phrasesMap[pid2].avg_difficulty!
+		),
+		popular: not_in_deck.toSorted(
+			(pid1, pid2) =>
+				// prioritize HIGHER values
+				phrasesMap[pid2].count_cards! - phrasesMap[pid1].count_cards!
+		),
+		newest: not_in_deck.toSorted((pid1, pid2) =>
+			phrasesMap[pid2].created_at! === phrasesMap[pid1].created_at! ? 0
+			: (
+				// prioritize HIGHER values
+				phrasesMap[pid2].created_at! > phrasesMap[pid1].created_at!
+			) ?
+				1
+			:	-1
+		),
+	}
+
 	return {
-		language: languagePids,
-		deck: deckPids.all,
-		reviewed_last_7d: deckPids.reviewed_last_7d,
-		not_in_deck,
-		recommended: {
-			by_friends: [],
-			easiest: not_in_deck.toSorted(
-				(pid1, pid2) =>
-					// prioritize LOWER values
-					phrasesMap[pid1].avg_difficulty! - phrasesMap[pid2].avg_difficulty!
-			),
-			popular: not_in_deck.toSorted(
-				(pid1, pid2) =>
-					// prioritize HIGHER values
-					phrasesMap[pid2].count_cards! - phrasesMap[pid1].count_cards!
-			),
-			newest: not_in_deck.toSorted((pid1, pid2) =>
-				phrasesMap[pid2].created_at! === phrasesMap[pid1].created_at! ? 0
-				: (
-					// prioritize HIGHER values
-					phrasesMap[pid2].created_at! > phrasesMap[pid1].created_at!
-				) ?
-					1
-				:	-1
-			),
+		language: new Set(languagePids),
+		deck: new Set(deckPids.all),
+		active: new Set(deckPids.active),
+		unreviewed: {
+			ever_active: new Set(deckPids.unreviewed_active),
+			recently: new Set(deckPids.reviewed_last_7d),
 		},
+		notInDeck: new Set(not_in_deck),
+		top8: {
+			easiest: new Set(ranked.easiest.slice(0, 8)),
+			popular: new Set(ranked.popular.slice(0, 8)),
+			newest: new Set(ranked.newest.slice(0, 8)),
+		},
+		// ranked,
 	}
 }
 

--- a/src/lib/process-pids.ts
+++ b/src/lib/process-pids.ts
@@ -5,9 +5,9 @@ import { useLanguagePhrasesMap, useLanguagePids } from './use-language'
 import { arrayDifference, mapArray } from './utils'
 import { useProfile } from './use-profile'
 
-export type ProcessedPids = ReturnType<typeof processPids>
+export type ProcessedDeckAndPids = ReturnType<typeof processDeckPidsAndRecs>
 
-function processPids(
+function processDeckPidsAndRecs(
 	translationLangs: Array<string>,
 	phrasesMap: PhrasesMap,
 	languagePids: pids,
@@ -110,7 +110,7 @@ export function useDeckPidsAndRecs(lang: string) {
 			)
 		}
 		// Now `null` always means pending because we always throw errors.
-		return processPids(
+		return processDeckPidsAndRecs(
 			[profile.language_primary, ...profile.languages_spoken],
 			phrasesMap,
 			languagePids,

--- a/src/lib/process-pids.ts
+++ b/src/lib/process-pids.ts
@@ -62,6 +62,10 @@ function processPids(
 		:	-1
 	)
 
+	const popular8 = popular.slice(0, 8)
+	const easiest8 = arrayDifference(easiest, [popular8]).slice(0, 8)
+	const newest8 = arrayDifference(newest, [popular8, easiest8]).slice(0, 8)
+
 	return {
 		language: languagePids,
 		language_filtered: languagePidsFiltered,
@@ -78,9 +82,9 @@ function processPids(
 		reviewed_last_7d: deckPids.reviewed_last_7d,
 		today_active: deckPids.today_active,
 		top8: {
-			easiest: easiest.slice(0, 8),
-			popular: popular.slice(0, 8),
-			newest: newest.slice(0, 8),
+			easiest: easiest8,
+			popular: popular8,
+			newest: newest8,
 		},
 		phrasesMapFiltered,
 	}

--- a/src/lib/process-pids.ts
+++ b/src/lib/process-pids.ts
@@ -10,49 +10,50 @@ function processPids(
 	languagePids: pids,
 	deckPids: DeckPids
 ) {
-	const not_in_deck = languagePids.filter(
-		(pid) => deckPids.all.indexOf(pid) === -1
-	)
-	const ranked = {
-		easiest: not_in_deck.toSorted(
-			(pid1, pid2) =>
-				// prioritize LOWER values
-				phrasesMap[pid1].avg_difficulty! - phrasesMap[pid2].avg_difficulty!
-		),
-		popular: not_in_deck.toSorted(
-			(pid1, pid2) =>
-				// prioritize HIGHER values
-				phrasesMap[pid2].count_cards! - phrasesMap[pid1].count_cards!
-		),
-		newest: not_in_deck.toSorted((pid1, pid2) =>
-			phrasesMap[pid2].created_at! === phrasesMap[pid1].created_at! ? 0
-			: (
-				// prioritize HIGHER values
-				phrasesMap[pid2].created_at! > phrasesMap[pid1].created_at!
-			) ?
-				1
-			:	-1
-		),
-	}
 	const base = {
 		language: new Set(languagePids),
 		deck: new Set(deckPids.all),
 		active: new Set(deckPids.active),
+		// reviewed: new Set(deckPids.reviewed),
+		reviewed_or_inactive: new Set(deckPids.reviewed_or_inactive),
 		unreviewed_active: new Set(deckPids.unreviewed_active),
 		reviewed_last_7d: new Set(deckPids.reviewed_last_7d),
-		not_in_deck: new Set(not_in_deck),
+		today_active: new Set(deckPids.today_active),
 	}
+	const language_selectables = base.language.difference(
+		base.reviewed_or_inactive
+	)
+	const arr_language_selectables = Array.from(language_selectables)
+	const easiest = arr_language_selectables.toSorted(
+		(pid1, pid2) =>
+			// prioritize LOWER values
+			phrasesMap[pid1].avg_difficulty! - phrasesMap[pid2].avg_difficulty!
+	)
+	const popular = arr_language_selectables.toSorted(
+		(pid1, pid2) =>
+			// prioritize HIGHER values
+			phrasesMap[pid2].count_cards! - phrasesMap[pid1].count_cards!
+	)
+	const newest = arr_language_selectables.toSorted((pid1, pid2) =>
+		phrasesMap[pid2].created_at! === phrasesMap[pid1].created_at! ? 0
+		: (
+			// prioritize HIGHER values
+			phrasesMap[pid2].created_at! > phrasesMap[pid1].created_at!
+		) ?
+			1
+		:	-1
+	)
 
 	return {
 		...base,
 		inactive: base.deck.difference(base.active),
+		language_selectables,
 
 		top8: {
-			easiest: new Set(ranked.easiest.slice(0, 8)),
-			popular: new Set(ranked.popular.slice(0, 8)),
-			newest: new Set(ranked.newest.slice(0, 8)),
+			easiest: new Set(easiest.slice(0, 8)),
+			popular: new Set(popular.slice(0, 8)),
+			newest: new Set(newest.slice(0, 8)),
 		},
-		// ranked,
 	}
 }
 

--- a/src/lib/process-pids.ts
+++ b/src/lib/process-pids.ts
@@ -1,4 +1,4 @@
-import { DeckPids, PhrasesMap, pids } from '@/types/main'
+import { DeckPids, PhraseFiltered, PhrasesMap, pids } from '@/types/main'
 import { useMemo } from 'react'
 import { useDeckPids } from './use-deck'
 import { useLanguagePhrasesMap, useLanguagePids } from './use-language'
@@ -16,7 +16,7 @@ function processPids(
 	// filter to only spoken languages, sort primary first
 	const phrasesArrayFiltered = languagePids
 		.map((pid) => {
-			const phrase = phrasesMap[pid]
+			const phrase = phrasesMap[pid] as PhraseFiltered
 			phrase.translations = phrase.translations
 				.filter((t) => translationLangs.indexOf(t.lang) > -1)
 				.toSorted((a, b) => {
@@ -24,13 +24,18 @@ function processPids(
 							0
 						:	translationLangs.indexOf(a.lang) - translationLangs.indexOf(b.lang)
 				})
+			// keep the translations we won't understand, to display in more info
+			phrase.translations_other = phrase.translations.filter(
+				(t) => !(translationLangs.indexOf(t.lang) > -1)
+			)
+
 			return phrase
 		})
-		.filter((p) => p.id && p.translations.length > 0)
+		.filter((p) => p.id)
 
 	const languagePidsFiltered = phrasesArrayFiltered
-		.map((p) => p.id)
-		.filter((p) => p !== null)
+		.filter((p) => p.translations.length > 0 && p.id !== null)
+		.map((p) => p.id!)
 	const phrasesMapFiltered: PhrasesMap = mapArray(phrasesArrayFiltered, 'id')
 
 	const language_selectables = arrayDifference(languagePidsFiltered, [

--- a/src/lib/process-pids.ts
+++ b/src/lib/process-pids.ts
@@ -34,16 +34,19 @@ function processPids(
 			:	-1
 		),
 	}
-
-	return {
+	const base = {
 		language: new Set(languagePids),
 		deck: new Set(deckPids.all),
 		active: new Set(deckPids.active),
-		unreviewed: {
-			ever_active: new Set(deckPids.unreviewed_active),
-			recently: new Set(deckPids.reviewed_last_7d),
-		},
-		notInDeck: new Set(not_in_deck),
+		unreviewed_active: new Set(deckPids.unreviewed_active),
+		reviewed_last_7d: new Set(deckPids.reviewed_last_7d),
+		not_in_deck: new Set(not_in_deck),
+	}
+
+	return {
+		...base,
+		inactive: base.deck.difference(base.active),
+
 		top8: {
 			easiest: new Set(ranked.easiest.slice(0, 8)),
 			popular: new Set(ranked.popular.slice(0, 8)),

--- a/src/lib/use-deck.ts
+++ b/src/lib/use-deck.ts
@@ -43,6 +43,14 @@ async function fetchDeck(lang: string): Promise<DeckLoaded> {
 		reviewed: cardsArray
 			.filter((c) => c.last_reviewed_at !== null)
 			.map((c) => c.phrase_id!),
+		reviewed_or_inactive: cardsArray
+			.filter(
+				(c) =>
+					c.last_reviewed_at !== null ||
+					c.status === 'skipped' ||
+					c.status === 'learned'
+			)
+			.map((c) => c.phrase_id!),
 		reviewed_last_7d: cardsArray
 			.filter(
 				(c) => c.last_reviewed_at !== null && inLastWeek(c.last_reviewed_at)

--- a/src/lib/use-deck.ts
+++ b/src/lib/use-deck.ts
@@ -36,30 +36,30 @@ async function fetchDeck(lang: string): Promise<DeckLoaded> {
 		)
 	const { cards: cardsArray, ...meta }: DeckFetched = data
 	const pids: DeckPids = {
-		all: cardsArray?.map((c) => c.phrase_id!) ?? [],
-		reviewed:
-			cardsArray
-				?.filter((c) => c.last_reviewed_at !== null)
-				.map((c) => c.phrase_id!) ?? [],
-		reviewed_last_7d:
-			cardsArray
-				?.filter(
-					(c) => c.last_reviewed_at !== null && inLastWeek(c.last_reviewed_at)
-				)
-				?.map((c) => c.phrase_id!) ?? [],
-		unreviewed:
-			cardsArray
-				?.filter((c) => c.last_reviewed_at === null)
-				?.map((c) => c.phrase_id!) ?? [],
-		today:
-			(cardsArray ?? [])
-				.filter(
-					(c) =>
-						c.last_reviewed_at !== null &&
-						typeof c.retrievability_now === 'number' &&
-						c.retrievability_now <= 0.9
-				)
-				?.map((c) => c.phrase_id!) ?? [],
+		all: cardsArray.map((c) => c.phrase_id!),
+		active: cardsArray
+			.filter((c) => c.status === 'active')
+			.map((c) => c.phrase_id!),
+		reviewed: cardsArray
+			.filter((c) => c.last_reviewed_at !== null)
+			.map((c) => c.phrase_id!),
+		reviewed_last_7d: cardsArray
+			.filter(
+				(c) => c.last_reviewed_at !== null && inLastWeek(c.last_reviewed_at)
+			)
+			.map((c) => c.phrase_id!),
+		unreviewed_active: cardsArray
+			.filter((c) => c.last_reviewed_at === null && c.status === 'active')
+			.map((c) => c.phrase_id!),
+		today_active: cardsArray
+			.filter(
+				(c) =>
+					c.last_reviewed_at !== null &&
+					typeof c.retrievability_now === 'number' &&
+					c.retrievability_now <= 0.9 &&
+					c.status === 'active'
+			)
+			.map((c) => c.phrase_id!),
 	}
 	const cardsMap: CardsMap = mapArray(cardsArray, 'phrase_id')
 	return {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,4 @@
+import { uuid } from '@/types/main'
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
@@ -75,4 +76,16 @@ export function todayString() {
 
 export function min0(num: number) {
 	return Math.max(0, num)
+}
+
+export function arrayUnion(arrs: Array<Array<uuid>>): Array<uuid> {
+	return [...new Set([...arrs.flat()])]
+}
+
+export function arrayDifference(
+	arr1: Array<uuid>,
+	arr2: Array<Array<uuid>>
+): Array<uuid> {
+	const set2 = new Set(arr2.flat())
+	return arr1.filter((item) => !set2.has(item))
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -72,3 +72,7 @@ export function todayString() {
 	now.setHours(now.getHours() - 4)
 	return `${now.getFullYear()}-${makeItHave2Digits(now.getMonth() + 1)}-${makeItHave2Digits(now.getDate())}`
 }
+
+export function min0(num: number) {
+	return Math.max(0, num)
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -39,6 +39,7 @@ export function dateDiff(prev_at: string | Date, later_at?: string | Date) {
 		: typeof later_at === 'string' ? new Date(later_at)
 		: later_at
 	const prev: Date = typeof prev_at === 'string' ? new Date(prev_at) : prev_at
+	// @ts-expect-error
 	return (later - prev) / 1000 / 24 / 60 / 60
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,7 @@ import { routeTree } from './routeTree.gen'
 import Routes from './routes'
 
 import 'styles/globals.css'
+import { Button } from './components/ui/button'
 
 const queryClient = new QueryClient()
 
@@ -29,8 +30,13 @@ const router = createRouter({
 			<Loader className="size-12" />
 		</div>
 	),
-	defaultErrorComponent: ({ error }) => (
-		<ShowError show={!!error}>Error: {error?.message}</ShowError>
+	defaultErrorComponent: ({ error, reset }) => (
+		<ShowError show={!!error}>
+			<p>Error: {error?.message}</p>
+			<Button variant="destructive-outline" onClick={() => reset()}>
+				Refresh the page
+			</Button>
+		</ShowError>
 	),
 })
 
@@ -41,7 +47,10 @@ declare module '@tanstack/react-router' {
 	}
 }
 
-createRoot(document.getElementById('root')).render(
+const root = document.getElementById('root')
+if (!root) throw new Error('No root element on the page')
+
+createRoot(root).render(
 	<StrictMode>
 		<ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
 			<QueryClientProvider client={queryClient}>

--- a/src/routes/_user/learn.$lang.index.tsx
+++ b/src/routes/_user/learn.$lang.index.tsx
@@ -149,8 +149,8 @@ function DeckOverview({ lang }: LangOnlyComponentProps) {
 					<p>You've kept up with your routine 4 out of 5 days this week</p>
 				</Flagged>
 				<p>
-					{deckPids?.today.length} active cards are scheduled for today, along
-					with 15 new ones
+					{deckPids?.today_active.length} active cards are scheduled for today,
+					along with 15 new ones
 				</p>
 			</CardContent>
 			<CardFooter>

--- a/src/routes/_user/learn.$lang.index.tsx
+++ b/src/routes/_user/learn.$lang.index.tsx
@@ -27,7 +27,6 @@ import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import Flagged from '@/components/flagged'
 import { RecommendedPhrasesCard } from '@/components/recommended-phrases'
-import { useProcessPids } from '@/lib/process-pids'
 import { useLanguage } from '@/lib/use-language'
 
 export const Route = createFileRoute('/_user/learn/$lang/')({
@@ -41,11 +40,6 @@ function WelcomePage() {
 	if (!language) throw new Error("Could not load this language's data")
 	if (!deck) throw new Error("Could not load this deck's data")
 
-	const processedPids = useProcessPids(
-		language.phrasesMap,
-		language.pids,
-		deck.pids
-	)
 	const deckIsNew = !(deck.pids.all.length > 0)
 	return (
 		<div className="space-y-8 px-2">
@@ -53,7 +47,7 @@ function WelcomePage() {
 				<Empty lang={lang} />
 			:	<DeckOverview lang={lang} />}
 
-			<RecommendedPhrasesCard lang={lang} pids={processedPids} />
+			<RecommendedPhrasesCard lang={lang} />
 			<Flagged name="friends_activity" className="hidden">
 				<FriendsSection lang={lang} />
 			</Flagged>

--- a/src/routes/_user/learn.$lang.library.tsx
+++ b/src/routes/_user/learn.$lang.library.tsx
@@ -7,9 +7,11 @@ import { LanguagePhrasesAccordionComponent } from '@/components/language-phrases
 import Callout from '@/components/ui/callout'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
-import { Plus } from 'lucide-react'
+import { MessageSquarePlus, Plus, SearchX } from 'lucide-react'
 import { buttonVariants } from '@/components/ui/button-variants'
 import { useDeckPidsAndRecs } from '@/lib/process-pids'
+import { Button } from '@/components/ui/button'
+import { Garlic } from '@/components/garlic'
 
 export const Route = createFileRoute('/_user/learn/$lang/library')({
 	component: DeckLibraryPage,
@@ -113,19 +115,45 @@ function DeckContents({ lang }: LangOnlyComponentProps) {
 				</div>
 				{pids.language!.length > 0 ?
 					<div className="flex-basis-[20rem] flex shrink flex-row flex-wrap gap-4">
-						<LanguagePhrasesAccordionComponent
-							pids={filteredPids}
-							lang={lang}
-						/>
+						{filteredPids.length > 0 ?
+							<LanguagePhrasesAccordionComponent
+								pids={filteredPids}
+								lang={lang}
+							/>
+						:	<Empty clear={() => setFilter('language')} />}
 					</div>
-				:	<Callout className="mt-4" variant="ghost">
-						This language is fully empty! We should have a good pitch here for
-						you, user. To say "come check out some starter phrases and
-						contribute to the community" or somesuch.
+				:	<Callout className="mt-4" Icon={() => <Garlic size={120} />}>
+						<p>
+							This language is fully empty! But Sunlo is a community effort
+							&ndash; <em>you</em> have the power to do something about it.
+						</p>
+						<p>
+							You must know <em>at least one phrase</em> in this new language,
+							right? Add it to the library!
+						</p>
+						<Link
+							className={buttonVariants({ size: 'lg' })}
+							to="/learn/$lang/add-phrase"
+							params={{ lang }}
+						>
+							<MessageSquarePlus size="48" className="h-12 w-12 grow" /> Add a
+							phrase to the library
+						</Link>
 					</Callout>
 				}
 			</CardContent>
 		</Card>
+	)
+}
+
+function Empty({ clear }: { clear: () => void }) {
+	return (
+		<Callout variant="ghost" Icon={() => <SearchX />}>
+			<p>There are no phrases in the library that match this search.</p>
+			<Button variant="outline" onClick={clear}>
+				Clear filters
+			</Button>
+		</Callout>
 	)
 }
 

--- a/src/routes/_user/learn.$lang.library.tsx
+++ b/src/routes/_user/learn.$lang.library.tsx
@@ -1,17 +1,15 @@
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import languages from '@/lib/languages'
 import type { LangOnlyComponentProps } from '@/types/main'
-import { useDeck } from '@/lib/use-deck'
-import { useLanguage } from '@/lib/use-language'
 import { LanguagePhrasesAccordionComponent } from '@/components/language-phrases-accordion'
 import Callout from '@/components/ui/callout'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Plus } from 'lucide-react'
 import { buttonVariants } from '@/components/ui/button-variants'
-import { ProcessedPids, useProcessPids } from '@/lib/process-pids'
+import { useDeckPidsAndRecs } from '@/lib/process-pids'
 
 export const Route = createFileRoute('/_user/learn/$lang/library')({
 	component: DeckLibraryPage,
@@ -19,31 +17,27 @@ export const Route = createFileRoute('/_user/learn/$lang/library')({
 
 function DeckLibraryPage() {
 	const { lang } = Route.useParams()
-	const { data: deck } = useDeck(lang)
-	const { data: language } = useLanguage(lang)
-	if (!language) throw new Error("Could not load this language's data")
-	if (!deck) throw new Error("Could not load this deck's data")
 
-	const processedPids = useProcessPids(
-		language.phrasesMap,
-		language.pids,
-		deck.pids
-	)
 	return (
 		<div className="space-y-4 px-2">
-			<DeckContents lang={lang} pids={processedPids} />
+			<DeckContents lang={lang} />
 		</div>
 	)
 }
 
 type FilterEnum = 'language' | 'deck' | 'reviewed_last_7d' | 'not_in_deck'
 // | 'recommended'
+// | 'recommended_by_friends' | 'recommended_easiest' | 'recommended_newest' | 'recommended_popular'
 
-function DeckContents({
-	lang,
-	pids,
-}: LangOnlyComponentProps & { pids: ProcessedPids }) {
+function DeckContents({ lang }: LangOnlyComponentProps) {
+	const pids = useDeckPidsAndRecs(lang)
 	const [filter, setFilter] = useState<FilterEnum>('not_in_deck')
+	if (!pids) {
+		console.log(
+			'Trying to render DeckContents but not getting anything for the recommended pids object'
+		)
+		return null
+	}
 
 	const filteredPids = pids[filter!]
 	return (

--- a/src/routes/_user/learn.$lang.library.tsx
+++ b/src/routes/_user/learn.$lang.library.tsx
@@ -73,21 +73,21 @@ function DeckContents({ lang }: LangOnlyComponentProps) {
 						setFilter={setFilter}
 						filter={filter}
 						text="All phrases"
-						count={pids.language?.size}
+						count={pids.language?.length}
 					/>
 					<BadgeFilter
 						name="active"
 						setFilter={setFilter}
 						filter={filter}
 						text="Active deck"
-						count={pids.active?.size}
+						count={pids.active?.length}
 					/>
 					<BadgeFilter
 						name="inactive"
 						setFilter={setFilter}
 						filter={filter}
 						text="Inactive"
-						count={pids.inactive?.size}
+						count={pids.inactive?.length}
 					/>
 					{/*<BadgeFilter
 						name="recommended"
@@ -101,20 +101,20 @@ function DeckContents({ lang }: LangOnlyComponentProps) {
 						setFilter={setFilter}
 						filter={filter}
 						text="Not in deck"
-						count={pids.not_in_deck?.size}
+						count={pids.not_in_deck?.length}
 					/>
 					<BadgeFilter
 						name="reviewed_last_7d"
 						setFilter={setFilter}
 						filter={filter}
 						text="Reviewed past week"
-						count={pids.reviewed_last_7d?.size}
+						count={pids.reviewed_last_7d?.length}
 					/>
 				</div>
-				{pids.language!.size > 0 ?
+				{pids.language!.length > 0 ?
 					<div className="flex-basis-[20rem] flex shrink flex-row flex-wrap gap-4">
 						<LanguagePhrasesAccordionComponent
-							pids={Array.from(filteredPids)}
+							pids={filteredPids}
 							lang={lang}
 						/>
 					</div>

--- a/src/routes/_user/learn.$lang.library.tsx
+++ b/src/routes/_user/learn.$lang.library.tsx
@@ -25,7 +25,12 @@ function DeckLibraryPage() {
 	)
 }
 
-type FilterEnum = 'language' | 'deck' | 'reviewed_last_7d' | 'not_in_deck'
+type FilterEnum =
+	| 'language'
+	| 'active'
+	| 'inactive'
+	| 'reviewed_last_7d'
+	| 'not_in_deck'
 // | 'recommended'
 // | 'recommended_by_friends' | 'recommended_easiest' | 'recommended_newest' | 'recommended_popular'
 
@@ -68,14 +73,21 @@ function DeckContents({ lang }: LangOnlyComponentProps) {
 						setFilter={setFilter}
 						filter={filter}
 						text="All phrases"
-						count={pids.language?.length}
+						count={pids.language?.size}
 					/>
 					<BadgeFilter
-						name="deck"
+						name="active"
 						setFilter={setFilter}
 						filter={filter}
-						text="In your deck"
-						count={pids.deck?.length}
+						text="Active deck"
+						count={pids.active?.size}
+					/>
+					<BadgeFilter
+						name="inactive"
+						setFilter={setFilter}
+						filter={filter}
+						text="Inactive"
+						count={pids.inactive?.size}
 					/>
 					{/*<BadgeFilter
 						name="recommended"
@@ -89,20 +101,20 @@ function DeckContents({ lang }: LangOnlyComponentProps) {
 						setFilter={setFilter}
 						filter={filter}
 						text="Not in deck"
-						count={pids.not_in_deck?.length}
+						count={pids.not_in_deck?.size}
 					/>
 					<BadgeFilter
 						name="reviewed_last_7d"
 						setFilter={setFilter}
 						filter={filter}
 						text="Reviewed past week"
-						count={pids.reviewed_last_7d?.length}
+						count={pids.reviewed_last_7d?.size}
 					/>
 				</div>
-				{pids.language!.length > 0 ?
+				{pids.language!.size > 0 ?
 					<div className="flex-basis-[20rem] flex shrink flex-row flex-wrap gap-4">
 						<LanguagePhrasesAccordionComponent
-							pids={filteredPids}
+							pids={Array.from(filteredPids)}
 							lang={lang}
 						/>
 					</div>

--- a/src/routes/_user/learn.$lang.library.tsx
+++ b/src/routes/_user/learn.$lang.library.tsx
@@ -28,11 +28,13 @@ function DeckLibraryPage() {
 }
 
 type FilterEnum =
-	| 'language'
+	| 'language_filtered'
 	| 'active'
 	| 'inactive'
 	| 'reviewed_last_7d'
 	| 'not_in_deck'
+	| 'language_no_translations'
+	| 'language'
 // | 'recommended'
 // | 'recommended_by_friends' | 'recommended_easiest' | 'recommended_newest' | 'recommended_popular'
 
@@ -71,46 +73,60 @@ function DeckContents({ lang }: LangOnlyComponentProps) {
 				<div className="text-muted-foreground mb-4 flex flex-row flex-wrap gap-2">
 					<span className="text-sm">Filters:</span>
 					<BadgeFilter
-						name="language"
+						name="language_filtered"
 						setFilter={setFilter}
 						filter={filter}
 						text="All phrases"
-						count={pids.language?.length}
+						count={pids.language_filtered.length}
 					/>
 					<BadgeFilter
 						name="active"
 						setFilter={setFilter}
 						filter={filter}
 						text="Active deck"
-						count={pids.active?.length}
+						count={pids.active.length}
 					/>
 					<BadgeFilter
 						name="inactive"
 						setFilter={setFilter}
 						filter={filter}
 						text="Inactive"
-						count={pids.inactive?.length}
+						count={pids.inactive.length}
 					/>
 					{/*<BadgeFilter
 						name="recommended"
 						setFilter={setFilter}
 						filter={filter}
 						text="Recommended"
-						count={pids.recommended?.length}
+						count={pids.recommended.length}
 					/>*/}
 					<BadgeFilter
 						name="not_in_deck"
 						setFilter={setFilter}
 						filter={filter}
 						text="Not in deck"
-						count={pids.not_in_deck?.length}
+						count={pids.not_in_deck.length}
 					/>
 					<BadgeFilter
 						name="reviewed_last_7d"
 						setFilter={setFilter}
 						filter={filter}
 						text="Reviewed past week"
-						count={pids.reviewed_last_7d?.length}
+						count={pids.reviewed_last_7d.length}
+					/>
+					<BadgeFilter
+						name="language_no_translations"
+						setFilter={setFilter}
+						filter={filter}
+						text="Needs translations"
+						count={pids.language_no_translations.length}
+					/>
+					<BadgeFilter
+						name="language"
+						setFilter={setFilter}
+						filter={filter}
+						text="No filters"
+						count={pids.language.length}
 					/>
 				</div>
 				{pids.language!.length > 0 ?

--- a/src/routes/_user/learn.$lang.library.tsx
+++ b/src/routes/_user/learn.$lang.library.tsx
@@ -7,11 +7,11 @@ import { LanguagePhrasesAccordionComponent } from '@/components/language-phrases
 import Callout from '@/components/ui/callout'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
-import { MessageSquarePlus, Plus, SearchX } from 'lucide-react'
+import { Plus, SearchX } from 'lucide-react'
 import { buttonVariants } from '@/components/ui/button-variants'
 import { useDeckPidsAndRecs } from '@/lib/process-pids'
 import { Button } from '@/components/ui/button'
-import { Garlic } from '@/components/garlic'
+import { LanguageIsEmpty } from '@/components/language-is-empty'
 
 export const Route = createFileRoute('/_user/learn/$lang/library')({
 	component: DeckLibraryPage,
@@ -138,25 +138,7 @@ function DeckContents({ lang }: LangOnlyComponentProps) {
 							/>
 						:	<Empty clear={() => setFilter('language')} />}
 					</div>
-				:	<Callout className="mt-4" Icon={() => <Garlic size={120} />}>
-						<p>
-							This language is fully empty! But Sunlo is a community effort
-							&ndash; <em>you</em> have the power to do something about it.
-						</p>
-						<p>
-							You must know <em>at least one phrase</em> in this new language,
-							right? Add it to the library!
-						</p>
-						<Link
-							className={buttonVariants({ size: 'lg' })}
-							to="/learn/$lang/add-phrase"
-							params={{ lang }}
-						>
-							<MessageSquarePlus size="48" className="h-12 w-12 grow" /> Add a
-							phrase to the library
-						</Link>
-					</Callout>
-				}
+				:	<LanguageIsEmpty lang={lang} />}
 			</CardContent>
 		</Card>
 	)

--- a/src/routes/_user/learn.$lang.review.go.tsx
+++ b/src/routes/_user/learn.$lang.review.go.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Navigate } from '@tanstack/react-router'
 
-import { FlashCardReviewSession } from '@/components/flash-card-review-session'
+import { FlashCardReviewSession } from '@/components/review/flash-card-review-session'
 import { getFromLocalStorage } from '@/lib/use-reviewables'
 import { useMemo } from 'react'
 import { pids } from '@/types/main'

--- a/src/routes/_user/learn.$lang.review.index.tsx
+++ b/src/routes/_user/learn.$lang.review.index.tsx
@@ -46,6 +46,7 @@ import { useDeckPidsAndRecs } from '@/lib/process-pids'
 import { useDeckCardsMap, useDeckMeta, useDeckPids } from '@/lib/use-deck'
 import supabase from '@/lib/supabase-client'
 import { useLanguagePhrasesMap } from '@/lib/use-language'
+import { useProfile } from '@/lib/use-profile'
 
 export const Route = createFileRoute('/_user/learn/$lang/review/')({
 	component: ReviewPage,
@@ -406,6 +407,15 @@ function ReviewCardsToAddToDeck({
 		throw new Error(
 			"Attempting to present this new-cards-algo-review interface but can't load cardsMap or phrasesMap"
 		)
+	const { data: profile } = useProfile()
+	if (!profile)
+		throw new Error(
+			'Profile should be here on first render, but it is not showing up'
+		)
+	const translation_langs = [
+		profile.language_primary,
+		...profile.languages_spoken,
+	]
 	// Toggle card selection
 	const toggleCardSelection = (pid1: string) => {
 		const updatedRecs =
@@ -421,20 +431,20 @@ function ReviewCardsToAddToDeck({
 	const countAllAlgoRecs = allAlgoRecsInOneSet.size
 
 	return (
-		<DrawerContent>
-			<div className="mx-auto w-full max-w-prose">
-				<DrawerHeader>
-					<DrawerTitle className="flex items-center gap-2 text-xl">
-						<Users className="h-5 w-5 text-purple-500" />
+		<DrawerContent aria-describedby="drawer-description">
+			<div className="@container relative mx-auto w-full max-w-prose overflow-y-auto">
+				<DrawerHeader className="bg-background sticky top-0">
+					<DrawerTitle className="sticky top-0 flex items-center gap-2 text-xl">
+						<Sparkles className="h-5 w-5 text-purple-500" />
 						Recommended for you ({approvedAlgoRecs.length} of {countAllAlgoRecs}{' '}
 						selected)
 					</DrawerTitle>
-					<DrawerDescription>
+				</DrawerHeader>
+				<div className="grid gap-3 p-4 @lg:grid-cols-2">
+					<DrawerDescription className="col-span-2">
 						Review and select which recommended cards you want to include in
 						your session
 					</DrawerDescription>
-				</DrawerHeader>
-				<div className="grid gap-3 p-4 @lg:grid-cols-2">
 					{Array.from(allAlgoRecsInOneSet).map((pid) => {
 						const selected = approvedAlgoRecs.indexOf(pid) > -1
 						return (

--- a/src/routes/_user/learn.$lang.review.index.tsx
+++ b/src/routes/_user/learn.$lang.review.index.tsx
@@ -472,6 +472,25 @@ function ReviewCardsToAddToDeck({
 					</DrawerDescription>
 					{Array.from(allAlgoRecsInOneSet).map((pid) => {
 						const selected = approvedAlgoRecs.indexOf(pid) > -1
+						// @@TODO move this logic obv
+						console.log(
+							`being very loud about filtering phrases and translation languages in the wrong place`
+						)
+						let phrase = phrasesMap[pid]
+						// filter to only spoken languages, sort primary first
+						phrase.translations = phrase.translations
+							.filter((t) => translation_langs.indexOf(t.lang) > -1)
+							.toSorted((a, b) => {
+								return a.lang === b.lang ?
+										0
+									:	translation_langs.indexOf(a.lang) -
+											translation_langs.indexOf(b.lang)
+							})
+						if (phrase.translations.length === 0) {
+							console.log('skipping a phrase with no usable translations')
+							return null
+						}
+
 						return (
 							<Card
 								onClick={() => toggleCardSelection(pid)}
@@ -479,11 +498,9 @@ function ReviewCardsToAddToDeck({
 								className={`hover:bg-primary/20 cursor-pointer border-1 transition-all ${selected ? 'border-primary bg-primary/10' : ''}`}
 							>
 								<CardHeader className="p-3 pb-0">
-									<CardTitle className="text-base">
-										{phrasesMap[pid].text}
-									</CardTitle>
+									<CardTitle className="text-base">{phrase.text}</CardTitle>
 									<CardDescription>
-										{phrasesMap[pid].translations[0].text}
+										{phrase.translations[0].text}
 									</CardDescription>
 								</CardHeader>
 								<CardFooter className="flex justify-end p-3 pt-0">

--- a/src/routes/_user/learn.$lang.review.index.tsx
+++ b/src/routes/_user/learn.$lang.review.index.tsx
@@ -1,9 +1,8 @@
-import { pids } from '@/types/main'
+import { pids, uuid } from '@/types/main'
 import {
 	createFileRoute,
 	Link,
 	Navigate,
-	useLoaderData,
 	useNavigate,
 } from '@tanstack/react-router'
 import {
@@ -14,7 +13,6 @@ import {
 	CardHeader,
 	CardTitle,
 } from '@/components/ui/card'
-
 import languages from '@/lib/languages'
 import {
 	BookOpen,

--- a/src/routes/_user/learn.$lang.review.index.tsx
+++ b/src/routes/_user/learn.$lang.review.index.tsx
@@ -1,4 +1,4 @@
-import { pids, uuid } from '@/types/main'
+import { pids } from '@/types/main'
 import {
 	createFileRoute,
 	Link,
@@ -47,6 +47,7 @@ import { useDeckCardsMap, useDeckMeta, useDeckPids } from '@/lib/use-deck'
 import supabase from '@/lib/supabase-client'
 import { useLanguagePhrasesMap } from '@/lib/use-language'
 import { useProfile } from '@/lib/use-profile'
+import ExtraInfo from '@/components/extra-info'
 
 export const Route = createFileRoute('/_user/learn/$lang/review/')({
 	component: ReviewPage,
@@ -254,12 +255,36 @@ function ReviewPage() {
 	return (
 		<Card>
 			<CardHeader>
-				<CardTitle>Get Ready to review your {languages[lang]} cards</CardTitle>
+				<CardTitle className="flex flex-row justify-between">
+					<div>Get Ready to review your {languages[lang]} cards</div>
+					<ExtraInfo>
+						<p>
+							There are {today_active.length} cards waiting for you today based
+							on previous reviews. Then we're going to collate{' '}
+							{countNewCardsDesired} new cards for you (or more, if you
+							choose!).
+						</p>
+						<p>
+							There are {friendRecommendations.length} total friend
+							recommendations, of which you've selected{' '}
+							{selectedFriendRecommendations.length}. So you still need to get{' '}
+							{countNeededFromDeck} more cards; we'll check in your deck,
+							finding {newCardsUnreviewedFromDeck.length} fresh cards.
+						</p>
+						<p>
+							That leaves {countNeededFromAlgo} to fetch from the algo, of which
+							you've selected {approvedAlgoRecs.length}. This means we will pick{' '}
+							{countNeededFromLibraryRandom} phrases just randomly from the
+							library. And in total, we'll make {newCardsToCreate.length} new
+							cards either due to friend/algo recs or randomly from the lib.
+						</p>
+					</ExtraInfo>
+				</CardTitle>
 			</CardHeader>
 			<CardContent className="space-y-4">
 				<p className="text-muted-foreground max-w-2xl text-lg">
 					Your personalized review session is prepared and waiting for you.
-					Here's what to expect:
+					Here's what to expect...
 				</p>
 				<div className="flex flex-row flex-wrap gap-4 text-sm">
 					<Card className="grow basis-40">

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -102,10 +102,11 @@ export type CardsMap = {
 
 export type DeckPids = {
 	all: pids
+	active: pids
 	reviewed: pids
 	reviewed_last_7d: pids
-	unreviewed: pids
-	today: pids
+	unreviewed_active: pids
+	today_active: pids
 }
 export type DeckLoaded = {
 	meta: DeckMeta

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -104,6 +104,7 @@ export type DeckPids = {
 	all: pids
 	active: pids
 	reviewed: pids
+	reviewed_or_inactive: pids
 	reviewed_last_7d: pids
 	unreviewed_active: pids
 	today_active: pids

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -83,6 +83,9 @@ export type PhraseMeta = Tables<'meta_phrase_info'>
 export type PhraseFull = PhraseMeta & {
 	translations: Array<TranslationRow>
 }
+export type PhraseFiltered = PhraseFull & {
+	translations_other?: Array<TranslationRow>
+}
 export type PhraseFullInsert = PhraseInsert & {
 	translations: Array<TranslationInsert>
 	relation_pids?: pids

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -4,9 +4,9 @@
 		"paths": {
 			"@/*": ["./*"]
 		},
-		"target": "ES2023",
+		"target": "ES2022",
 		"useDefineForClassFields": true,
-		"lib": ["ES2023", "DOM", "DOM.Iterable"],
+		"lib": ["ES2024", "DOM", "DOM.Iterable", "ESNext"],
 		"module": "ESNext",
 		"skipLibCheck": true,
 		/* Bundler mode */


### PR DESCRIPTION
This feature really fills out the daily review's "staging" screen at `review/index`, by constructing the day's review step by step and giving the user a way to confirm any new cards that will be created and added to their deck for today. The process goes:

1. Determine the daily goal of new cards
2. Add all the card reviews sent from friends (currently 0 because we haven't built the feature yet)
3. Let the user pick from smart recommendations of cards not in the deck
4. Add the remaining number of cards from the deck (unreviewed)
5. If more cards are needed, pick randomly from the library (cards that weren't already declined)

When the user submits the form to go and get started, the new list of pids for the day will be stored in localStorage (already working before this point) and the mutation will fire off an API call to create new cards for all of steps 3 and 5 above, and include them in the daily review manifest.

*Note: This feature creates some new hooks and adds a bunch of metadata in the form of `Set` objects, and so on. There's a lot in here to review, but also this is just a big hairy feature set with lots of markup and interaction management and different states to track, so some increased complexity must be allowed.*