### PR TITLE
Remove unused functions from storage schema

### DIFF
--- a/supabase/migrations/20250407095350_remote_schema.sql
+++ b/supabase/migrations/20250407095350_remote_schema.sql
@@ -1,60 +1,20 @@
-set check_function_bodies = off;
-
-CREATE OR REPLACE FUNCTION storage.extension(name text)
- RETURNS text
- LANGUAGE plpgsql
-AS $function$
-DECLARE
-_parts text[];
-_filename text;
-BEGIN
-    select string_to_array(name, '/') into _parts;
-    select _parts[array_length(_parts,1)] into _filename;
-    -- @todo return the last part instead of 2
-    return split_part(_filename, '.', 2);
-END
-$function$
-;
-
-CREATE OR REPLACE FUNCTION storage.filename(name text)
- RETURNS text
- LANGUAGE plpgsql
-AS $function$
-DECLARE
-_parts text[];
-BEGIN
-    select string_to_array(name, '/') into _parts;
-    return _parts[array_length(_parts,1)];
-END
-$function$
-;
-
-CREATE OR REPLACE FUNCTION storage.foldername(name text)
- RETURNS text[]
- LANGUAGE plpgsql
-AS $function$
-DECLARE
-_parts text[];
-BEGIN
-    select string_to_array(name, '/') into _parts;
-    return _parts[1:array_length(_parts,1)-1];
-END
-$function$
-;
-
 grant delete on table "storage"."s3_multipart_uploads" to "postgres";
 
 grant insert on table "storage"."s3_multipart_uploads" to "postgres";
 
 grant references on table "storage"."s3_multipart_uploads" to "postgres";
 
-grant select on table "storage"."s3_multipart_uploads" to "postgres";
+grant
+select
+	on table "storage"."s3_multipart_uploads" to "postgres";
 
 grant trigger on table "storage"."s3_multipart_uploads" to "postgres";
 
-grant truncate on table "storage"."s3_multipart_uploads" to "postgres";
+grant
+truncate on table "storage"."s3_multipart_uploads" to "postgres";
 
-grant update on table "storage"."s3_multipart_uploads" to "postgres";
+grant
+update on table "storage"."s3_multipart_uploads" to "postgres";
 
 grant delete on table "storage"."s3_multipart_uploads_parts" to "postgres";
 
@@ -62,36 +22,25 @@ grant insert on table "storage"."s3_multipart_uploads_parts" to "postgres";
 
 grant references on table "storage"."s3_multipart_uploads_parts" to "postgres";
 
-grant select on table "storage"."s3_multipart_uploads_parts" to "postgres";
+grant
+select
+	on table "storage"."s3_multipart_uploads_parts" to "postgres";
 
 grant trigger on table "storage"."s3_multipart_uploads_parts" to "postgres";
 
-grant truncate on table "storage"."s3_multipart_uploads_parts" to "postgres";
+grant
+truncate on table "storage"."s3_multipart_uploads_parts" to "postgres";
 
-grant update on table "storage"."s3_multipart_uploads_parts" to "postgres";
+grant
+update on table "storage"."s3_multipart_uploads_parts" to "postgres";
 
-create policy "Allow users to select, insert, update 1oj01fe_0"
-on "storage"."objects"
-as permissive
-for insert
-to authenticated
-with check ((bucket_id = 'avatars'::text));
+create policy "Allow users to select, insert, update 1oj01fe_0" on "storage"."objects" as permissive for insert to authenticated
+with
+	check ((bucket_id = 'avatars'::text));
 
+create policy "Allow users to select, insert, update 1oj01fe_1" on "storage"."objects" as permissive for
+update to authenticated using ((bucket_id = 'avatars'::text));
 
-create policy "Allow users to select, insert, update 1oj01fe_1"
-on "storage"."objects"
-as permissive
-for update
-to authenticated
-using ((bucket_id = 'avatars'::text));
-
-
-create policy "Allow users to select, insert, update 1oj01fe_2"
-on "storage"."objects"
-as permissive
-for select
-to authenticated
-using ((bucket_id = 'avatars'::text));
-
-
-
+create policy "Allow users to select, insert, update 1oj01fe_2" on "storage"."objects" as permissive for
+select
+	to authenticated using ((bucket_id = 'avatars'::text));


### PR DESCRIPTION
This was causing migrations to fail on load, per [this issue](https://github.com/orgs/supabase/discussions/34270), and it seems these three functions are unused anyway.

Because we're not really able to test storage-related features we may have to do some other DX work to merge this with confidence.
- [ ] The URL-maker for storage objects hardcodes the production supabase URL so doesn't work with preview variables
- [ ] The seeds don't include images; when viewing a preview or dev version of the app we are actually looking at images from the production server (thanks to the hardcoding mentioned above)