### PR TITLE
Use the database for ReviewRow persistence

### DIFF
--- a/src/components/review/review-single-card.tsx
+++ b/src/components/review/review-single-card.tsx
@@ -1,8 +1,4 @@
-import {
-	useReviewState,
-	useOneReview,
-	useReviewMutation,
-} from '@/lib/use-reviewables'
+import { useReviewState } from '@/lib/use-reviewables'
 import { DailyCacheKey, TranslationRow, uuid } from '@/types/main'
 import { useState } from 'react'
 import toast from 'react-hot-toast'
@@ -15,6 +11,7 @@ import Flagged from '@/components/flagged'
 import { Button } from '@/components/ui/button'
 import { Play } from 'lucide-react'
 import { useLanguagePhrase } from '@/lib/use-language'
+import { useOneReviewToday, useReviewMutation } from '@/lib/use-reviews'
 
 interface ReviewSingleCardProps {
 	dailyCacheKey: DailyCacheKey
@@ -34,7 +31,8 @@ export function ReviewSingleCard({
 }: ReviewSingleCardProps) {
 	const lang = dailyCacheKey[1]
 	const [revealCard, setRevealCard] = useState(false)
-	const { data: prevData } = useOneReview(dailyCacheKey, pid)
+	const { data: prevData } = useOneReviewToday(dailyCacheKey, pid)
+
 	const { data: state } = useReviewState(dailyCacheKey)
 	const { mutate, isPending } = useReviewMutation(
 		pid,

--- a/src/components/review/review-single-card.tsx
+++ b/src/components/review/review-single-card.tsx
@@ -1,4 +1,4 @@
-import { useReviewState } from '@/lib/use-reviewables'
+import { useReviewStage } from '@/lib/use-reviewables'
 import { DailyCacheKey, TranslationRow, uuid } from '@/types/main'
 import { useState } from 'react'
 import toast from 'react-hot-toast'
@@ -32,8 +32,7 @@ export function ReviewSingleCard({
 	const lang = dailyCacheKey[1]
 	const [revealCard, setRevealCard] = useState(false)
 	const { data: prevData } = useOneReviewToday(dailyCacheKey, pid)
-
-	const { data: state } = useReviewState(dailyCacheKey)
+	const { data: stage } = useReviewStage(dailyCacheKey)
 	const { mutate, isPending } = useReviewMutation(
 		pid,
 		dailyCacheKey,
@@ -45,7 +44,7 @@ export function ReviewSingleCard({
 
 	if (!phrase) return null
 
-	const showAnswers = prevData && state.reviewStage === 1 ? true : revealCard
+	const showAnswers = prevData && stage === 1 ? true : revealCard
 	return (
 		<Card className="mx-auto flex min-h-[80vh] w-full flex-col">
 			<CardHeader className="flex flex-row items-center justify-end gap-2">
@@ -106,7 +105,7 @@ export function ReviewSingleCard({
 							onClick={() => mutate({ score: 1 })}
 							disabled={isPending}
 							className={
-								prevData?.score === 1 && state.reviewStage < 4 ?
+								prevData?.score === 1 && stage < 4 ?
 									'ring-primary ring-2 ring-offset-3'
 								:	''
 							}

--- a/src/components/review/when-review-complete-screen.tsx
+++ b/src/components/review/when-review-complete-screen.tsx
@@ -2,8 +2,13 @@ import { DailyCacheKey } from '@/types/main'
 import { Card, CardContent, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import SuccessCheckmark from '@/components/success-checkmark'
-import { setReviewStage, useReviewState } from '@/lib/use-reviewables'
+import {
+	setReviewStage,
+	useManifest,
+	useReviewStage,
+} from '@/lib/use-reviewables'
 import { useQueryClient } from '@tanstack/react-query'
+import { useReviewsToday } from '@/lib/use-reviews'
 
 type ComponentProps = {
 	dailyCacheKey: DailyCacheKey
@@ -16,15 +21,18 @@ export function WhenComplete({
 	goToFirstSkipped,
 	goToFirstAgain,
 }: ComponentProps) {
-	const {
-		data: { reviewStage, unreviewedCount, againCount },
-	} = useReviewState(dailyCacheKey)
-
+	const { data: reviewsToday } = useReviewsToday(dailyCacheKey)
+	const { data: manifest } = useManifest(dailyCacheKey)
+	const { data: stage } = useReviewStage(dailyCacheKey)
 	const queryClient = useQueryClient()
 
+	if (!reviewsToday || !manifest || !stage) return null
+
+	const unreviewedCount = manifest.length - reviewsToday.totalReviewed
+	const againCount = reviewsToday.totalAgain
 	const showWhich =
-		unreviewedCount && reviewStage < 2 ? 'a'
-		: againCount && reviewStage < 4 ? 'b'
+		unreviewedCount && stage < 2 ? 'a'
+		: againCount && stage < 4 ? 'b'
 		: 'c'
 
 	return (

--- a/src/lib/use-reviewables.ts
+++ b/src/lib/use-reviewables.ts
@@ -1,11 +1,10 @@
 import type { DailyCacheKey, ReviewStages } from '@/types/main'
-import { pids, ReviewRow, uuid } from '@/types/main'
+import { pids, ReviewsLoaded } from '@/types/main'
 import {
 	QueryClient,
 	queryOptions,
 	useSuspenseQuery,
 } from '@tanstack/react-query'
-import { useReviewsToday } from '@/lib/use-reviews'
 
 function getFromLocalStorage<T>(queryKey: DailyCacheKey): null | T {
 	const data = localStorage.getItem(JSON.stringify(queryKey))
@@ -36,84 +35,72 @@ export const setManifest = (
 	queryClient.setQueryData([...dailyCacheKey, 'manifest'], data)
 }
 
-const getReviewFromLocalStorage = (
-	dailyCacheKey: DailyCacheKey,
-	pid: uuid
-): ReviewRow | null => getFromLocalStorage<ReviewRow>([...dailyCacheKey, pid])
-
 export function getIndexOfNextUnreviewedCard(
+	queryClient: QueryClient,
 	dailyCacheKey: DailyCacheKey,
+	manifest: pids,
 	currentCardIndex: number
 ) {
-	const pids = getFromLocalStorage<pids>([...dailyCacheKey, 'manifest'])
-	if (pids === null)
+	if (manifest === null)
 		throw new Error(
 			'trying to fetch index of next card, but there is no review set up for today'
 		)
-	const index = pids.findIndex((pid, i) => {
+	const reviews = queryClient.getQueryData<ReviewsLoaded>(dailyCacheKey)
+	const index = manifest.findIndex((pid, i) => {
 		// if we're currently at card 3 of 40, don't even check cards 0-3
 		if (i <= currentCardIndex) return false
-		const entry = getReviewFromLocalStorage(dailyCacheKey, pid)
-		return entry === null
+		const entry = reviews?.map[pid]
+		// if the entry is undefined, it means we haven't reviewed this card yet
+		return !entry
 	})
 
-	return index !== -1 ? index : pids.length
+	return index !== -1 ? index : manifest.length
 }
 
 function getIndexOfNextAgainCard(
+	queryClient: QueryClient,
 	dailyCacheKey: DailyCacheKey,
+	manifest: pids,
 	currentCardIndex: number
 ) {
-	const pids = getFromLocalStorage<pids>([...dailyCacheKey, 'manifest'])
-	if (pids === null)
+	if (manifest === null)
 		throw new Error(
 			'trying to fetch index of next card, but there is no review set up for today'
 		)
-	const index = pids.findIndex((pid, i) => {
+	const reviews = queryClient.getQueryData<ReviewsLoaded>(dailyCacheKey)
+	const index = manifest.findIndex((pid, i) => {
 		// if we're currently at card 3 of 40, don't even check cards 0-3
 		if (i <= currentCardIndex) return false
-		const entry = getReviewFromLocalStorage(dailyCacheKey, pid)
-		return entry?.score === 1
+		return reviews?.map[pid]?.score === 1
 	})
 
-	return index !== -1 ? index : pids.length
+	return index !== -1 ? index : manifest.length
 }
 
 export function getIndexOfLoopedAgainCard(
+	queryClient: QueryClient,
 	dailyCacheKey: DailyCacheKey,
+	manifest: pids,
 	i: number
 ) {
-	const countManifestCards =
-		getFromLocalStorage<pids>([...dailyCacheKey, 'manifest'])?.length ?? 0
-	const foundCardIndex = getIndexOfNextAgainCard(dailyCacheKey, i)
+	const foundCardIndex = getIndexOfNextAgainCard(
+		queryClient,
+		dailyCacheKey,
+		manifest,
+		i
+	)
 	const finalFoundIndex =
-		!(foundCardIndex === countManifestCards) ? foundCardIndex : (
-			getIndexOfNextAgainCard(dailyCacheKey, -1)
-		)
+		!(foundCardIndex === manifest.length) ?
+			foundCardIndex
+		:	getIndexOfNextAgainCard(queryClient, dailyCacheKey, manifest, -1)
 	return finalFoundIndex
 }
 
-export const useReviewState = (dailyCacheKey: DailyCacheKey) => {
-	const { data: reviews } = useReviewsToday(dailyCacheKey)
-	const { data: manifest } = useManifest(dailyCacheKey)
-
+export const useReviewStage = (dailyCacheKey: DailyCacheKey) => {
 	return useSuspenseQuery({
-		queryKey: [...dailyCacheKey, 'review-state'],
-		queryFn: () => {
-			const res = {
-				reviewStage:
-					getFromLocalStorage<ReviewStages>([...dailyCacheKey, 'stage']) ?? 0,
-				totalCount: manifest?.length ?? 0,
-				unreviewedCount: manifest?.filter(
-					(pid) => !reviews?.find((r) => r.phrase_id === pid)
-				).length,
-				againCount: manifest?.filter((pid) =>
-					reviews?.find((r) => r.phrase_id === pid && r.score === 1)
-				).length,
-			}
-			console.log('useReviewState', res)
-			return res
-		},
+		queryKey: [...dailyCacheKey, 'stage'],
+		queryFn: () =>
+			getFromLocalStorage<ReviewStages>([...dailyCacheKey, 'stage']) ?? 0,
 		refetchOnMount: true,
 		refetchOnWindowFocus: true,
 	})
@@ -126,19 +113,4 @@ export const setReviewStage = (
 ) => {
 	setFromLocalStorage([...dailyCacheKey, 'stage'], data)
 	queryClient.setQueryData([...dailyCacheKey, 'stage'], data)
-	queryClient.invalidateQueries({
-		queryKey: [...dailyCacheKey, 'review-state'],
-	})
-}
-
-// for when you DON'T want to send a mutation to the DB
-// (second review in a day doesn't count for the algo)
-export const setOneReview = (
-	dailyCacheKey: DailyCacheKey,
-	pid: uuid,
-	data: ReviewRow,
-	queryClient: QueryClient
-) => {
-	queryClient.setQueryData([...dailyCacheKey, pid], data)
-	setFromLocalStorage([...dailyCacheKey, pid], data)
 }

--- a/src/lib/use-reviewables.ts
+++ b/src/lib/use-reviewables.ts
@@ -1,33 +1,10 @@
 import type { DailyCacheKey, ReviewStages } from '@/types/main'
-import supabase from './supabase-client'
-import { pids, ReviewInsert, ReviewRow, ReviewUpdate, uuid } from '@/types/main'
+import { pids, ReviewRow, uuid } from '@/types/main'
 import {
 	QueryClient,
 	queryOptions,
-	useMutation,
-	useQueryClient,
 	useSuspenseQuery,
 } from '@tanstack/react-query'
-import toast from 'react-hot-toast'
-import { PostgrestError } from '@supabase/supabase-js'
-
-const postReview = async (submitData: ReviewInsert) => {
-	const { data } = await supabase
-		.rpc('insert_user_card_review', submitData)
-		.throwOnError()
-
-	return data
-}
-
-const updateReview = async (submitData: ReviewUpdate) => {
-	if (!submitData?.review_id || !submitData?.score)
-		throw new Error('Invalid inputs; cannot update')
-	const { data } = await supabase
-		.rpc('update_user_card_review', submitData)
-		.throwOnError()
-
-	return data
-}
 
 function getFromLocalStorage<T>(queryKey: DailyCacheKey): null | T {
 	const data = localStorage.getItem(JSON.stringify(queryKey))
@@ -153,14 +130,6 @@ export const setReviewStage = (
 	})
 }
 
-export const useOneReview = (dailyCacheKey: DailyCacheKey, pid: uuid) =>
-	useSuspenseQuery({
-		queryKey: [...dailyCacheKey, pid],
-		queryFn: () => getReviewFromLocalStorage(dailyCacheKey, pid),
-		refetchOnMount: true,
-		refetchOnWindowFocus: true,
-	})
-
 // for when you DON'T want to send a mutation to the DB
 // (second review in a day doesn't count for the algo)
 export const setOneReview = (
@@ -171,69 +140,4 @@ export const setOneReview = (
 ) => {
 	queryClient.setQueryData([...dailyCacheKey, pid], data)
 	setFromLocalStorage([...dailyCacheKey, pid], data)
-}
-
-// for when you want to send a mutation to the DB
-// and update the local cache and this custom query cache
-export function useReviewMutation(
-	pid: uuid,
-	dailyCacheKey: DailyCacheKey,
-	proceed: () => void,
-	resetRevealCard: () => void
-) {
-	const queryClient = useQueryClient()
-	const { data: prevData } = useOneReview(dailyCacheKey, pid)
-	const { data: state } = useReviewState(dailyCacheKey)
-
-	return useMutation<ReviewRow, PostgrestError, { score: number }>({
-		mutationKey: [...dailyCacheKey, pid],
-		// @ts-expect-error ts-2322 -- because Supabase view fields are always | null
-		mutationFn: async ({ score }: { score: number }) => {
-			// We want 1 mutation per day per card. We can send a second mutation
-			// only during stage 1 or 2, to _correct_ an improper input.
-
-			// no mutations when re-reviewing incorrect
-			if (state.reviewStage > 3)
-				return {
-					...prevData,
-					score,
-				}
-
-			// during stages 1 and 2 send an update only if the score has changed
-			if (prevData?.score === score) return prevData
-			if (prevData?.id)
-				return await updateReview({
-					score,
-					review_id: prevData.id,
-				})
-
-			// standard case: card has not been reviewed today
-			return await postReview({
-				score,
-				phrase_id: pid,
-				lang: dailyCacheKey[1],
-				day_session: dailyCacheKey[3],
-			})
-		},
-		onSuccess: (data) => {
-			if (data.score === 1)
-				toast('okay', { icon: '🤔', position: 'bottom-center' })
-			if (data.score === 2)
-				toast('okay', { icon: '🤷', position: 'bottom-center' })
-			if (data.score === 3)
-				toast('got it', { icon: '👍️', position: 'bottom-center' })
-			if (data.score === 4) toast.success('nice', { position: 'bottom-center' })
-
-			const mergedData = { ...prevData, ...data }
-			setOneReview(dailyCacheKey, pid, mergedData, queryClient)
-			setTimeout(() => {
-				resetRevealCard()
-				proceed()
-			}, 1000)
-		},
-		onError: (error) => {
-			toast.error(`There was an error posting your review: ${error.message}`)
-			console.log(`Error posting review:`, error)
-		},
-	})
 }

--- a/src/lib/use-reviews.ts
+++ b/src/lib/use-reviews.ts
@@ -1,0 +1,137 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import supabase from './supabase-client'
+import { useAuth } from './hooks'
+import {
+	DailyCacheKey,
+	ReviewInsert,
+	ReviewRow,
+	ReviewUpdate,
+	uuid,
+} from '@/types/main'
+import toast from 'react-hot-toast'
+import { useReviewState } from './use-reviewables'
+import { PostgrestError } from '@supabase/supabase-js'
+
+const postReview = async (submitData: ReviewInsert) => {
+	const { data } = await supabase
+		.rpc('insert_user_card_review', submitData)
+		.throwOnError()
+
+	return data
+}
+
+const updateReview = async (submitData: ReviewUpdate) => {
+	if (!submitData?.review_id || !submitData?.score)
+		throw new Error('Invalid inputs; cannot update')
+	const { data } = await supabase
+		.rpc('update_user_card_review', submitData)
+		.throwOnError()
+
+	return data
+}
+
+function reviewsQuery(
+	//lang: string,
+	userId: uuid,
+	dailyCacheKey: DailyCacheKey
+) {
+	return {
+		queryKey: dailyCacheKey,
+		queryFn: async () => {
+			const { data } = await supabase
+				.from('user_card_review')
+				.select()
+				.eq('day_session', dailyCacheKey[3])
+				.eq('lang', dailyCacheKey[1])
+				.eq('uid', userId)
+				//.eq('lang', lang)
+				.throwOnError()
+			return data || []
+		},
+	}
+}
+
+export function useReviewsToday(dailyCacheKey: DailyCacheKey) {
+	const { userId } = useAuth()
+	return useQuery({
+		...reviewsQuery(userId!, dailyCacheKey),
+		enabled: !!userId,
+	})
+}
+
+export function useOneReviewToday(dailyCacheKey: DailyCacheKey, pid: uuid) {
+	const { userId } = useAuth()
+	return useQuery({
+		...reviewsQuery(userId!, dailyCacheKey),
+		enabled: !!userId,
+		select: (data) => data.find((review) => review.phrase_id === pid) || null,
+	})
+}
+
+export function useReviewMutation(
+	pid: uuid,
+	dailyCacheKey: DailyCacheKey,
+	proceed: () => void,
+	resetRevealCard: () => void
+) {
+	const queryClient = useQueryClient()
+	const { data: prevData } = useOneReviewToday(dailyCacheKey, pid)
+	const { data: state } = useReviewState(dailyCacheKey)
+
+	return useMutation<ReviewRow, PostgrestError, { score: number }>({
+		mutationKey: [...dailyCacheKey, pid],
+		// @ts-expect-error ts-2322 -- because Supabase view fields are always | null
+		mutationFn: async ({ score }: { score: number }) => {
+			// We want 1 mutation per day per card. We can send a second mutation
+			// only during stage 1 or 2, to _correct_ an improper input.
+
+			// no mutations when re-reviewing incorrect
+			if (state.reviewStage > 3)
+				return {
+					...prevData,
+					score,
+				}
+
+			// during stages 1 and 2 send an update only if the score has changed
+			if (prevData?.score === score) return prevData
+			if (prevData?.id)
+				return await updateReview({
+					score,
+					review_id: prevData.id,
+				})
+
+			// standard case: card has not been reviewed today
+			return await postReview({
+				score,
+				phrase_id: pid,
+				lang: dailyCacheKey[1],
+				day_session: dailyCacheKey[3],
+			})
+		},
+		onSuccess: (data) => {
+			if (data.score === 1)
+				toast('okay', { icon: '🤔', position: 'bottom-center' })
+			if (data.score === 2)
+				toast('okay', { icon: '🤷', position: 'bottom-center' })
+			if (data.score === 3)
+				toast('got it', { icon: '👍️', position: 'bottom-center' })
+			if (data.score === 4) toast.success('nice', { position: 'bottom-center' })
+
+			const mergedData = { ...prevData, ...data }
+			// this is done instead of using invalidateQueries... why? IDK.
+			// it does ensure that the local cache is updated even when the db
+			// data is not changed (e.g. re-reviewing a card)
+			queryClient.setQueryData<Array<ReviewRow>>([dailyCacheKey], (oldData) => {
+				return [...(oldData ?? []), mergedData]
+			})
+			setTimeout(() => {
+				resetRevealCard()
+				proceed()
+			}, 1000)
+		},
+		onError: (error) => {
+			toast.error(`There was an error posting your review: ${error.message}`)
+			console.log(`Error posting review:`, error)
+		},
+	})
+}

--- a/src/lib/use-reviews.ts
+++ b/src/lib/use-reviews.ts
@@ -121,9 +121,12 @@ export function useReviewMutation(
 			// this is done instead of using invalidateQueries... why? IDK.
 			// it does ensure that the local cache is updated even when the db
 			// data is not changed (e.g. re-reviewing a card)
-			queryClient.setQueryData<Array<ReviewRow>>([dailyCacheKey], (oldData) => {
+			queryClient.setQueryData<Array<ReviewRow>>(dailyCacheKey, (oldData) => {
 				return [...(oldData ?? []), mergedData]
 			})
+			/*queryClient.invalidateQueries({
+				queryKey: dailyCacheKey,
+			})*/
 			setTimeout(() => {
 				resetRevealCard()
 				proceed()

--- a/src/routes/_user/learn.$lang.review.go.tsx
+++ b/src/routes/_user/learn.$lang.review.go.tsx
@@ -1,41 +1,57 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { FlashCardReviewSession } from '@/components/review/flash-card-review-session'
-import { manifestQuery, useReviewState } from '@/lib/use-reviewables'
+import { manifestQuery, useReviewStage } from '@/lib/use-reviewables'
 import { useState } from 'react'
 import { todayString } from '@/lib/utils'
 import { DailyCacheKey } from '@/types/main'
+import { reviewsQuery } from '@/lib/use-reviews'
+import { Loader } from '@/components/ui/loader'
 
 export const Route = createFileRoute('/_user/learn/$lang/review/go')({
 	component: ReviewPage,
-	loader: async ({ params: { lang }, context: { queryClient } }) => {
+	loader: async ({
+		params: { lang },
+		context: {
+			queryClient,
+			auth: { userId },
+		},
+	}) => {
 		const dailyCacheKey: DailyCacheKey = ['user', lang, 'review', todayString()]
-
-		const pidsManifest = await queryClient.fetchQuery(
+		const reviewsFetch = queryClient.ensureQueryData(
+			reviewsQuery(userId!, dailyCacheKey)
+		)
+		const manifestFetch = queryClient.ensureQueryData(
 			manifestQuery(dailyCacheKey)
 		)
-		if (!pidsManifest || !pidsManifest.length) throw redirect({ to: '..' })
+		const [_reviews, manifest] = await Promise.all([
+			reviewsFetch,
+			manifestFetch,
+		])
+
+		if (!manifest || !manifest.length) throw redirect({ to: '..' })
 
 		return {
 			appnav: [],
 			dailyCacheKey,
-			pidsManifest,
+			manifest,
 		}
 	},
 })
 
 function ReviewPage() {
 	const data = Route.useLoaderData()
-	// referential stability for the cache key
+	// referential stability for the cache key, even if the loader data changes
 	const [dailyCacheKey] = useState<DailyCacheKey>(data.dailyCacheKey)
-	const {
-		data: { reviewStage },
-	} = useReviewState(dailyCacheKey)
-
+	const { data: reviewStage } = useReviewStage(dailyCacheKey)
+	const { queryClient } = Route.useRouteContext()
+	if (typeof reviewStage !== 'number' || typeof data.manifest !== 'object')
+		return <Loader />
 	return (
 		<FlashCardReviewSession
 			dailyCacheKey={dailyCacheKey}
-			pidsManifest={data.pidsManifest}
+			manifest={data.manifest}
 			reviewStage={reviewStage}
+			queryClient={queryClient}
 		/>
 	)
 }

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -29,6 +29,14 @@ export type LangOnlyComponentProps = {
 */
 export type ReviewStages = 0 | 1 | 2 | 3 | 4 | 5
 export type DailyCacheKey = ['user', string, 'review', ...Array<string>]
+export type ReviewsMap = {
+	[key: uuid]: ReviewRow
+}
+export type ReviewsLoaded = {
+	map: ReviewsMap
+	totalReviewed: number
+	totalAgain: number
+}
 
 export type SelectOption = { value: string; label: string }
 // Don't keep using these. use the framework's types for links and routes

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -358,17 +358,17 @@ export type Database = {
           },
           {
             foreignKeyName: "user_card_lang_uid_fkey"
-            columns: ["lang", "uid"]
+            columns: ["uid", "lang"]
             isOneToOne: false
             referencedRelation: "user_deck"
-            referencedColumns: ["lang", "uid"]
+            referencedColumns: ["uid", "lang"]
           },
           {
             foreignKeyName: "user_card_lang_uid_fkey"
-            columns: ["lang", "uid"]
+            columns: ["uid", "lang"]
             isOneToOne: false
             referencedRelation: "user_deck_plus"
-            referencedColumns: ["lang", "uid"]
+            referencedColumns: ["uid", "lang"]
           },
           {
             foreignKeyName: "user_card_phrase_id_fkey"
@@ -403,6 +403,7 @@ export type Database = {
       user_card_review: {
         Row: {
           created_at: string
+          day_first_review: boolean
           day_session: string
           difficulty: number | null
           id: string
@@ -416,6 +417,7 @@ export type Database = {
         }
         Insert: {
           created_at?: string
+          day_first_review?: boolean
           day_session: string
           difficulty?: number | null
           id?: string
@@ -429,6 +431,7 @@ export type Database = {
         }
         Update: {
           created_at?: string
+          day_first_review?: boolean
           day_session?: string
           difficulty?: number | null
           id?: string
@@ -443,17 +446,17 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "user_card_review_lang_uid_fkey"
-            columns: ["lang", "uid"]
+            columns: ["uid", "lang"]
             isOneToOne: false
             referencedRelation: "user_deck"
-            referencedColumns: ["lang", "uid"]
+            referencedColumns: ["uid", "lang"]
           },
           {
             foreignKeyName: "user_card_review_lang_uid_fkey"
-            columns: ["lang", "uid"]
+            columns: ["uid", "lang"]
             isOneToOne: false
             referencedRelation: "user_deck_plus"
-            referencedColumns: ["lang", "uid"]
+            referencedColumns: ["uid", "lang"]
           },
           {
             foreignKeyName: "user_card_review_phrase_id_fkey"
@@ -471,17 +474,17 @@ export type Database = {
           },
           {
             foreignKeyName: "user_card_review_phrase_id_uid_fkey"
-            columns: ["phrase_id", "uid"]
+            columns: ["uid", "phrase_id"]
             isOneToOne: false
             referencedRelation: "user_card"
-            referencedColumns: ["phrase_id", "uid"]
+            referencedColumns: ["uid", "phrase_id"]
           },
           {
             foreignKeyName: "user_card_review_phrase_id_uid_fkey"
-            columns: ["phrase_id", "uid"]
+            columns: ["uid", "phrase_id"]
             isOneToOne: false
             referencedRelation: "user_card_plus"
-            referencedColumns: ["phrase_id", "uid"]
+            referencedColumns: ["uid", "phrase_id"]
           },
           {
             foreignKeyName: "user_card_review_uid_fkey"
@@ -758,17 +761,17 @@ export type Database = {
           },
           {
             foreignKeyName: "user_card_lang_uid_fkey"
-            columns: ["lang", "uid"]
+            columns: ["uid", "lang"]
             isOneToOne: false
             referencedRelation: "user_deck"
-            referencedColumns: ["lang", "uid"]
+            referencedColumns: ["uid", "lang"]
           },
           {
             foreignKeyName: "user_card_lang_uid_fkey"
-            columns: ["lang", "uid"]
+            columns: ["uid", "lang"]
             isOneToOne: false
             referencedRelation: "user_deck_plus"
-            referencedColumns: ["lang", "uid"]
+            referencedColumns: ["uid", "lang"]
           },
           {
             foreignKeyName: "user_card_phrase_id_fkey"
@@ -932,6 +935,7 @@ export type Database = {
         }
         Returns: {
           created_at: string
+          day_first_review: boolean
           day_session: string
           difficulty: number | null
           id: string
@@ -948,6 +952,7 @@ export type Database = {
         Args: { review_id: string; score: number }
         Returns: {
           created_at: string
+          day_first_review: boolean
           day_session: string
           difficulty: number | null
           id: string

--- a/supabase/migrations/20250605224250_add_subsequent_reviews_to_db.sql
+++ b/supabase/migrations/20250605224250_add_subsequent_reviews_to_db.sql
@@ -1,0 +1,188 @@
+alter table "public"."user_card"
+alter column "lang"
+set not null;
+
+alter table "public"."user_card_review"
+add column "day_first_review" boolean not null default true;
+
+revoke delete on table "public"."user_card_review"
+from
+	"anon";
+
+revoke insert on table "public"."user_card_review"
+from
+	"anon";
+
+revoke references on table "public"."user_card_review"
+from
+	"anon";
+
+revoke
+select
+	on table "public"."user_card_review"
+from
+	"anon";
+
+revoke trigger on table "public"."user_card_review"
+from
+	"anon";
+
+revoke
+truncate on table "public"."user_card_review"
+from
+	"anon";
+
+revoke
+update on table "public"."user_card_review"
+from
+	"anon";
+
+set
+	check_function_bodies = off;
+
+create
+or replace function public.insert_user_card_review (
+	phrase_id uuid,
+	lang character varying,
+	score integer,
+	day_session text,
+	desired_retention numeric default 0.9
+) returns user_card_review language plv8 as $function$
+
+//-- auth check may be redundant for permissions but it will help the planner
+//-- we're fetching the most recent review, whether it was today or another day
+const prevReviewQuery = plv8.execute("SELECT id, created_at, difficulty, stability, review_time_retrievability, day_first_review, to_char(day_session, 'YYYY-DD-MM') as day_session FROM public.user_card_review WHERE phrase_id = $1 AND uid = auth.uid() ORDER BY created_at DESC LIMIT 1", [phrase_id])
+//-- throw new Error('prevReviewQuery: ' + JSON.stringify(prevReviewQuery))
+
+const prev = prevReviewQuery[0] ?? null
+
+const current_timestamp = new Date()
+
+var calc = {
+	created_at: current_timestamp,
+	difficulty: null,
+	stability: null,
+	review_time_retrievability: null,
+	day_first_review: true,
+}
+
+if (!prev) {
+	//-- first review _ever_ gets slightly different calculation
+	calc.stability = plv8.find_function("fsrs_s_0")(score)
+	calc.difficulty = plv8.find_function("fsrs_d_0")(score)
+	calc.review_time_retrievability = null
+}
+else if (prev.day_session === day_session) {
+	// previous review was from today so we do not calculate new values
+	calc.difficulty = prev.difficulty
+	calc.stability = prev.stability
+	calc.review_time_retrievability = prev.review_time_retrievability
+	calc.day_first_review = false
+} else {
+	//-- this is the main calculation block
+	const time_between_reviews = plv8.find_function("fsrs_days_between")(prev.created_at, calc.created_at)
+	if (typeof time_between_reviews !== 'number' || time_between_reviews < -1)
+		throw new Error(`Time between reviews is not a number or is less than -1 (can''t have a most recent review in the future). value calculated as: ${time_between_reviews}, for ${prev.created_at} and ${calc.created_at}`)
+	try {
+		calc.review_time_retrievability = plv8.find_function("fsrs_retrievability")(time_between_reviews, prev.stability)
+			if (typeof calc.review_time_retrievability !== 'number' || calc.review_time_retrievability > 1 || calc.review_time_retrievability < 0)
+				throw new Error(`retrievability is not a number or has wrong value: ${calc.review_time_retrievability}`)
+		calc.stability = plv8.find_function("fsrs_stability")(prev.difficulty, prev.stability, calc.review_time_retrievability, score)
+		calc.difficulty = plv8.find_function("fsrs_difficulty")(prev.difficulty, score)
+	} catch(e) {
+		throw new Error(`Something went wrong in the main calc part.` + JSON.stringify([prev, calc]))
+	}
+}
+
+//-- this should all be covered by DB constraints...
+if (typeof calc.stability !== 'number' || typeof calc.difficulty !== 'number' || calc.stability < 0 || calc.difficulty > 10 || calc.difficulty < 1) {
+	throw new Error(`Difficulty or stability is out of range: ${calc.difficulty}, ${calc.stability}`)
+	return null
+}
+
+const insertedResult = plv8.execute(
+	`INSERT INTO public.user_card_review (score, phrase_id, lang, day_session, review_time_retrievability, difficulty, stability, day_first_review) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *`,
+	[
+		score,
+		phrase_id,
+		lang,
+		day_session,
+		calc.review_time_retrievability,
+		calc.difficulty,
+		calc.stability,
+		calc.day_first_review
+	]
+);
+
+const response = insertedResult[0] ?? null;
+if (!response) throw new Error(`Got all the way to the end and then no row was inserted for ${phrase_id}, ${score}, prev: ${JSON.stringify(prev)}, calc: ${JSON.stringify(calc)}`)
+return response
+
+$function$;
+
+create
+or replace function public.update_user_card_review (review_id uuid, score integer) returns user_card_review language plv8 as $function$
+
+const reviewQuery = plv8.execute("SELECT * FROM public.user_card_review WHERE id = $1", [review_id])
+const review = reviewQuery[0] ?? null
+if (!review) throw new Error(`Could not update because we couldn't find a review with ID ${review_id}`)
+
+if (review.day_first_review === false) {
+	//-- if this is not the first review of the day, we will not be updating the stability and difficulty
+	const updatedSecondReview = plv8.execute(
+		`UPDATE public.user_card_review SET score = $1 WHERE id = $2 RETURNING *`,
+		[
+			score,
+			review_id
+		]
+	)
+	return updatedSecondReview[0] ?? null
+}
+//-- otherwise, it is the first of the day and we have to recalculate
+//-- any previous reviews will be from an earlier day, we do not select
+//-- on whether the previous review was the first of the day or not
+const prevReviewQuery = plv8.execute("SELECT * FROM public.user_card_review WHERE phrase_id = $1 AND uid = auth.uid() AND created_at < $2 ORDER BY created_at DESC LIMIT 1", [review.phrase_id, review.created_at])
+const prev = prevReviewQuery[0] ?? null
+
+var calc = {
+	current: review.created_at,
+	review_time_retrievability: review.review_time_retrievability,
+	difficulty: null,
+	stability: null
+}
+
+if (!prev) {
+	calc.stability = plv8.find_function("fsrs_s_0")(score)
+	calc.difficulty = plv8.find_function("fsrs_d_0")(score)
+} else {
+	const time_between_reviews = plv8.find_function("fsrs_days_between")(prev.created_at, calc.current)
+	if (typeof time_between_reviews !== 'number' || time_between_reviews < -1)
+		throw new Error(`Time between reviews is not a number or is less than -1 (can''t have a most recent review in the future). value calculated as: ${time_between_reviews}, for ${prev.created_at} and ${calc.current}`)
+	try {
+		calc.stability = plv8.find_function("fsrs_stability")(prev.difficulty, prev.stability, calc.review_time_retrievability, score)
+		calc.difficulty = plv8.find_function("fsrs_difficulty")(prev.difficulty, score)
+	} catch(e) {
+		throw new Error(`Something went wrong in the main calc part.` + JSON.stringify([prev, calc]))
+	}
+}
+
+if (typeof calc.stability !== 'number' || typeof calc.difficulty !== 'number' || calc.stability < 0 || calc.difficulty > 10 || calc.difficulty < 1) {
+	throw new Error(`Difficulty or stability is out of range: ${calc.difficulty}, ${calc.stability}`)
+	return null
+}
+
+const updatedResult = plv8.execute(
+	`UPDATE public.user_card_review SET score = $1, difficulty = $2, stability = $3 WHERE id = $4 RETURNING *`,
+	[
+		score,
+		calc.difficulty,
+		calc.stability,
+		review_id
+	]
+);
+
+const response = updatedResult[0] ?? null;
+if (!response) throw new Error(`Got all the way to the end and did not manage to update anything. for review ${review_id}, card ${review.phrase_id}, ${score}, prev: ${JSON.stringify(prev)}, calc: ${JSON.stringify(calc)}`)
+return response
+
+$function$;

--- a/supabase/schemas/base.sql
+++ b/supabase/schemas/base.sql
@@ -293,6 +293,7 @@ create table if not exists
 		"day_session" "date" not null,
 		"lang" character varying not null,
 		"phrase_id" "uuid" not null,
+		"day_first_review" boolean default true not null,
 		constraint "user_card_review_difficulty_check" check (
 			(
 				("difficulty" >= 0.0)
@@ -305,6 +306,8 @@ create table if not exists
 
 alter table "public"."user_card_review" owner to "postgres";
 
+comment on column "public"."user_card_review"."day_first_review" is 'Is it the first review of this card today or not';
+
 create
 or replace function "public"."insert_user_card_review" (
 	"phrase_id" "uuid",
@@ -314,34 +317,43 @@ or replace function "public"."insert_user_card_review" (
 	"desired_retention" numeric default 0.9
 ) returns "public"."user_card_review" language "plv8" as $_$
 
-// auth check should be unnecessary because of RLS but it
-// should also be redundant for the planner
-const prevReviewQuery = plv8.execute("SELECT * FROM public.user_card_review WHERE phrase_id = $1 AND uid = auth.uid() ORDER BY created_at DESC LIMIT 1", [phrase_id])
-// throw new Error('prevReviewQuery: ' + JSON.stringify(prevReviewQuery))
+//-- auth check may be redundant for permissions but it will help the planner
+//-- we're fetching the most recent review, whether it was today or another day
+const prevReviewQuery = plv8.execute("SELECT id, created_at, difficulty, stability, review_time_retrievability, day_first_review, to_char(day_session, 'YYYY-DD-MM') as day_session FROM public.user_card_review WHERE phrase_id = $1 AND uid = auth.uid() ORDER BY created_at DESC LIMIT 1", [phrase_id])
+//-- throw new Error('prevReviewQuery: ' + JSON.stringify(prevReviewQuery))
 
 const prev = prevReviewQuery[0] ?? null
 
+const current_timestamp = new Date()
+
 var calc = {
-	current: new Date(),
-	review_time_retrievability: null,
+	created_at: current_timestamp,
 	difficulty: null,
 	stability: null,
-	new_interval: null,
-	scheduled_for: null
+	review_time_retrievability: null,
+	day_first_review: true,
 }
-// throw new Error(`prev.id ${prev.id}`)
 
-if (!prev) {
+if (prev.day_session === day_session) {
+	// previous review was from today so we do not calculate new values
+	calc.difficulty = prev.difficulty
+	calc.stability = prev.stability
+	calc.review_time_retrievability = prev.review_time_retrievability
+	calc.day_first_review = false
+} else if (!prev) {
+	//-- first review _ever_ gets slightly different calculation
 	calc.stability = plv8.find_function("fsrs_s_0")(score)
 	calc.difficulty = plv8.find_function("fsrs_d_0")(score)
 	calc.review_time_retrievability = null
 } else {
-	const time_between_reviews = plv8.find_function("fsrs_days_between")(prev.created_at, calc.current)
+	//-- this is the main calculation block
+	const time_between_reviews = plv8.find_function("fsrs_days_between")(prev.created_at, calc.created_at)
 	if (typeof time_between_reviews !== 'number' || time_between_reviews < -1)
-		throw new Error(`Time between reviews is not a number or is less than -1 (can''t have a most recent review in the future). value calculated as: ${time_between_reviews}, for ${prev.created_at} and ${calc.current}`)
+		throw new Error(`Time between reviews is not a number or is less than -1 (can''t have a most recent review in the future). value calculated as: ${time_between_reviews}, for ${prev.created_at} and ${calc.created_at}`)
 	try {
 		calc.review_time_retrievability = plv8.find_function("fsrs_retrievability")(time_between_reviews, prev.stability)
-		if (typeof calc.review_time_retrievability !== 'number' || calc.review_time_retrievability > 1 || calc.review_time_retrievability < 0) throw new Error(`retrievability is not a number or has wrong value: ${calc.review_time_retrievability}`)
+			if (typeof calc.review_time_retrievability !== 'number' || calc.review_time_retrievability > 1 || calc.review_time_retrievability < 0)
+				throw new Error(`retrievability is not a number or has wrong value: ${calc.review_time_retrievability}`)
 		calc.stability = plv8.find_function("fsrs_stability")(prev.difficulty, prev.stability, calc.review_time_retrievability, score)
 		calc.difficulty = plv8.find_function("fsrs_difficulty")(prev.difficulty, score)
 	} catch(e) {
@@ -349,35 +361,14 @@ if (!prev) {
 	}
 }
 
+//-- this should all be covered by DB constraints...
 if (typeof calc.stability !== 'number' || typeof calc.difficulty !== 'number' || calc.stability < 0 || calc.difficulty > 10 || calc.difficulty < 1) {
 	throw new Error(`Difficulty or stability is out of range: ${calc.difficulty}, ${calc.stability}`)
 	return null
 }
 
-// assign interval (a float, rounded to an integer) and schedule date
-try {
-	calc.new_interval = score === 1 ? 1 : Math.max(
-		Math.round(
-			plv8.find_function("fsrs_interval")(desired_retention, calc.stability)
-		),
-		1.0
-	)
-	calc.scheduled_for = new Date(
-		calc.current.setDate(
-			calc.current.getDate() + calc.new_interval
-		)
-	)
-} catch(e) {
-	throw new Error('Something went wrong in the scheduling part' + JSON.stringify(calc))
-}
-
-if (!calc.scheduled_for) {
-	throw new Error(`New scheduled_for value is not working...`)
-	return null
-}
-
 const insertedResult = plv8.execute(
-	`INSERT INTO public.user_card_review (score, phrase_id, lang, day_session, review_time_retrievability, difficulty, stability) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *`,
+	`INSERT INTO public.user_card_review (score, phrase_id, lang, day_session, review_time_retrievability, difficulty, stability, day_first_review) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *`,
 	[
 		score,
 		phrase_id,
@@ -385,7 +376,8 @@ const insertedResult = plv8.execute(
 		day_session,
 		calc.review_time_retrievability,
 		calc.difficulty,
-		calc.stability
+		calc.stability,
+		calc.day_first_review
 	]
 );
 
@@ -410,6 +402,20 @@ const reviewQuery = plv8.execute("SELECT * FROM public.user_card_review WHERE id
 const review = reviewQuery[0] ?? null
 if (!review) throw new Error(`Could not update because we couldn't find a review with ID ${review_id}`)
 
+if (review.day_first_review === false) {
+	//-- if this is not the first review of the day, we will not be updating the stability and difficulty
+	const updatedSecondReview = plv8.execute(
+		`UPDATE public.user_card_review SET score = $1 WHERE id = $2 RETURNING *`,
+		[
+			score,
+			review_id
+		]
+	)
+	return updatedSecondReview[0] ?? null
+}
+//-- otherwise, it is the first of the day and we have to recalculate
+//-- any previous reviews will be from an earlier day, we do not select
+//-- on whether the previous review was the first of the day or not
 const prevReviewQuery = plv8.execute("SELECT * FROM public.user_card_review WHERE phrase_id = $1 AND uid = auth.uid() AND created_at < $2 ORDER BY created_at DESC LIMIT 1", [review.phrase_id, review.created_at])
 const prev = prevReviewQuery[0] ?? null
 
@@ -419,7 +425,6 @@ var calc = {
 	difficulty: null,
 	stability: null
 }
-// throw new Error(`prev.id ${prev.id}`)
 
 if (!prev) {
 	calc.stability = plv8.find_function("fsrs_s_0")(score)
@@ -1510,8 +1515,6 @@ grant all on function "public"."fsrs_stability" (
 	"review_time_retrievability" numeric,
 	"score" integer
 ) to "service_role";
-
-grant all on table "public"."user_card_review" to "anon";
 
 grant all on table "public"."user_card_review" to "authenticated";
 


### PR DESCRIPTION
We have achieved one-browser-device persistence by replicating all the ReviewRow's to localstorage and creating a parallel set of `useQuery`s and `setQueryData`s that break the recommended patterns in order to achieve all 3 of, 

1. parallel persistence 
2. optimistic updates, 
3. device-only updates for second and third reviews (because the Algorithm, as currently written, doesn't want to account for anything but the first review in a day/session, so we don't even put them in the database)

In this PR we will attempt to undo the spaghettiness of this situation, stop using localStorage for storing today's review results and instead use standard react-query patterns for both queries and mutations, invalidate cache after a mutation, or carefully update the cache with the results of the call to the supabase API, and find a reasonable solution for 2nd-reviews.

This PR is meant as a _feature-neutral refactor_, and not a piece of feature work; it will have implications on the way reviews behave across devices, but since the current state is that if you try to start a review on one device and finish it on another device, it will not work and you will get bad results... the bar for this is pretty low. The primary bottleneck for this kind of feature enhancement is that this PR does not attempt to address persistence for the review _state_, e.g. storing today's review manifest (cards planned/selected) or the current review stage (are we on the first pass, second pass for skipped cards, or third pass for incorrect answers). This PR will substantially reduce the use of localStorage, but will not eliminate it for these crucial pieces of review state.