### PR TITLE
Transform: search filter interface

### DIFF
--- a/src/routes/_user/learn.$lang.library.tsx
+++ b/src/routes/_user/learn.$lang.library.tsx
@@ -64,18 +64,24 @@ function DeckLibraryPage() {
 		[tagsFilter]
 	)
 
-	const setSelectedTags = (value: SetStateAction<string[]>) => {
-		const newSelectedTags =
-			typeof value === 'function' ? value(selectedTags) : value
-		void navigate({
-			search: (prev) => ({
-				...prev,
-				tags: newSelectedTags.length ? newSelectedTags.join(',') : undefined,
-			}),
-			replace: true,
-			params: true,
-		})
-	}
+	const setSelectedTags = useCallback(
+		(value: SetStateAction<string[]>) => {
+			void navigate({
+				search: (prev) => {
+					const currentTags = prev.tags?.split(',').filter(Boolean) ?? []
+					const newTags =
+						typeof value === 'function' ? value(currentTags) : value
+					return {
+						...prev,
+						tags: newTags.length ? newTags.join(',') : undefined,
+					}
+				},
+				replace: true,
+				params: true,
+			})
+		},
+		[navigate]
+	)
 
 	const filteredPidsByStatus = useMemo(
 		() =>

--- a/src/routes/_user/learn.$lang.search.tsx
+++ b/src/routes/_user/learn.$lang.search.tsx
@@ -28,7 +28,7 @@ interface SearchParams {
 export const Route = createFileRoute('/_user/learn/$lang/search')({
 	validateSearch: (search: Record<string, unknown>): SearchParams => {
 		return {
-			text: (search.text as string) || '',
+			text: (search.text as string) || undefined,
 			tags: (search.tags as string) || undefined,
 		}
 	},


### PR DESCRIPTION
We are basically doing the same stuff in the library and search pages; it's not necessary. we should either be re-using these components or doing away with one of the routes entirely and focusing on the one that remains. It might bebetter to have 1 page to explore and search the library, and another page to admin your deck. Or maybe replace "search" with a "quick search" modal, but it doesn't need to be an entire page that duplicates the library.