### PR TITLE
Clean up the design of a bunch of navigational elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"class-variance-authority": "^0.7.1",
 		"cmdk": "1.1.1",
 		"dayjs": "^1.11.13",
-		"lucide-react": "^0.441.0",
+		"lucide-react": "^0.544.0",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
 		"react-hook-form": "^7.56.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^1.11.13
         version: 1.11.13
       lucide-react:
-        specifier: ^0.441.0
-        version: 0.441.0(react@19.1.0)
+        specifier: ^0.544.0
+        version: 0.544.0(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -2283,10 +2283,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.441.0:
-    resolution: {integrity: sha512-0vfExYtvSDhkC2lqg0zYVW1Uu9GsI4knuV9GP9by5z0Xhc4Zi5RejTxfz9LsjRmCyWVzHCJvxGKZWcRyvQCWVg==}
+  lucide-react@0.544.0:
+    resolution: {integrity: sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==}
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -4923,7 +4923,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.441.0(react@19.1.0):
+  lucide-react@0.544.0(react@19.1.0):
     dependencies:
       react: 19.1.0
 

--- a/src/components/card-status-dropdown.tsx
+++ b/src/components/card-status-dropdown.tsx
@@ -271,7 +271,7 @@ export function CardStatusHeart({ pid, lang }: OnePhraseComponentProps) {
 	return (
 		<Button
 			variant="outline"
-			size="icon-sm"
+			size="icon"
 			className={card?.status === 'active' ? 'border-primary-foresoft/30' : ''}
 			onClick={() => mutation.mutate({ status })}
 		>

--- a/src/components/cards/card-result-simple.tsx
+++ b/src/components/cards/card-result-simple.tsx
@@ -18,7 +18,7 @@ export function CardResultSimple({ phrase }: { phrase: PhraseStub }) {
 						to="/learn/$lang/$id"
 						params={{ lang: phrase.lang, id: phrase.id }}
 						variant="ghost"
-						size="icon-sm"
+						size="icon"
 						text=""
 					/>
 					<CardStatusHeart pid={phrase.id} lang={phrase.lang} />

--- a/src/components/chat/card-preview.tsx
+++ b/src/components/chat/card-preview.tsx
@@ -65,7 +65,7 @@ export function CardPreview({
 							<CardStatusDropdown pid={pid} lang={lang} />
 							{!chosenTranslation && (
 								<AddTranslationsDialog
-									size="badge"
+									size="sm"
 									variant="secondary"
 									phrase={phrase}
 								/>
@@ -75,7 +75,7 @@ export function CardPreview({
 								params={{ lang, id: pid }}
 								className={buttonVariants({
 									variant: 'secondary',
-									size: 'badge',
+									size: 'sm',
 								})}
 							>
 								<LinkIcon className="text-muted-foreground" />

--- a/src/components/chat/request-preview.tsx
+++ b/src/components/chat/request-preview.tsx
@@ -53,7 +53,7 @@ export function RequestPreview({
 								params={{ lang, id }}
 								className={buttonVariants({
 									variant: 'secondary',
-									size: 'badge',
+									size: 'sm',
 								})}
 							>
 								<LinkIcon className="text-muted-foreground" />

--- a/src/components/copy-link-button.tsx
+++ b/src/components/copy-link-button.tsx
@@ -23,7 +23,7 @@ export default function CopyLinkButton({
 	url,
 	text = 'Copy link',
 	variant = 'ghost',
-	size = 'badge',
+	size = 'sm',
 	className = '',
 	collapse = true,
 	...props

--- a/src/components/extra-info.tsx
+++ b/src/components/extra-info.tsx
@@ -24,7 +24,7 @@ export default function ExtraInfo({
 	return (
 		<Dialog>
 			<DialogTrigger className={className} asChild>
-				<Button variant="ghost" size="icon-sm">
+				<Button variant="ghost" size="icon">
 					<Ellipsis className="size-4" />
 					<span className="sr-only">Show more</span>
 				</Button>

--- a/src/components/fields/languages-known-field.tsx
+++ b/src/components/fields/languages-known-field.tsx
@@ -55,7 +55,7 @@ export function LanguagesKnownField<T extends FieldValues>({
 								<Button
 									type="button"
 									variant="ghost"
-									size="icon-sm"
+									size="icon"
 									onClick={() => move(index, index - 1)}
 									disabled={index === 0}
 								>
@@ -64,7 +64,7 @@ export function LanguagesKnownField<T extends FieldValues>({
 								<Button
 									type="button"
 									variant="ghost"
-									size="icon-sm"
+									size="icon"
 									onClick={() => move(index, index + 1)}
 									disabled={index === fields.length - 1}
 								>

--- a/src/components/language-phrases-accordion.tsx
+++ b/src/components/language-phrases-accordion.tsx
@@ -39,12 +39,12 @@ function PhraseAccordionItem({ pid, lang }: OnePhraseComponentProps) {
 
 	return (
 		<AccordionItem value={pid} className="mb-2 rounded px-2 shadow-sm">
-			<div className="flex flex-row items-center gap-2">
+			<div className="ms-3 flex flex-row items-center gap-2">
 				<CardStatusDropdown lang={lang} pid={pid!} />
 				<AccordionTrigger>{phrase.text}</AccordionTrigger>
 			</div>
 			<AccordionContent>
-				<div className="space-y-1 pt-2 pl-6">
+				<div className="space-y-1 pt-2 pl-4">
 					<p className="text-muted-foreground text-sm">
 						{phrase.translations?.length ? 'Translations' : 'No Translations'}
 					</p>
@@ -66,11 +66,12 @@ function PhraseAccordionItem({ pid, lang }: OnePhraseComponentProps) {
 							</Badge>
 						))}
 					</div>
-					<div className="my-4 flex flex-row gap-2">
+					<div className="my-4 flex flex-row items-center gap-2">
 						<PermalinkButton
 							to="/learn/$lang/$id"
 							params={{ lang, id: pid }}
 							variant="outline-accent"
+							text="View details"
 						/>
 						<SharePhraseButton pid={pid} lang={lang} variant="outline-accent" />
 						<PhraseExtraInfo lang={lang} pid={pid} />

--- a/src/components/language-phrases-accordion.tsx
+++ b/src/components/language-phrases-accordion.tsx
@@ -70,16 +70,10 @@ function PhraseAccordionItem({ pid, lang }: OnePhraseComponentProps) {
 						<PermalinkButton
 							to="/learn/$lang/$id"
 							params={{ lang, id: pid }}
-							variant="link"
-							className="text-xs"
+							variant="outline-accent"
 						/>
-						<SharePhraseButton
-							pid={pid}
-							lang={lang}
-							variant="link"
-							className="text-xs"
-						/>
-						<PhraseExtraInfo lang={lang} pid={pid} className="ms-auto" />
+						<SharePhraseButton pid={pid} lang={lang} variant="outline-accent" />
+						<PhraseExtraInfo lang={lang} pid={pid} />
 					</div>
 				</div>
 			</AccordionContent>

--- a/src/components/navs/app-nav.tsx
+++ b/src/components/navs/app-nav.tsx
@@ -53,13 +53,13 @@ const Nav = memo(function Nav({ matches }: { matches: AppNavMatch[] }) {
 						<NavigationMenuList className="flex w-full flex-row">
 							{links.map((l: LinkType) => (
 								<NavigationMenuItem
-									className="hover:bg-primary/20 rounded-2xl px-4"
+									className="hover:bg-primary/20 rounded-xl px-3"
 									key={l.link.to}
 								>
 									<NavigationMenuLink asChild>
 										<Link
 											{...l.link}
-											className="flex flex-row items-center justify-center gap-2 border-b-2 py-2"
+											className="flex flex-row items-center justify-center gap-2 border-b-2 py-1.5 text-sm"
 											activeProps={activeProps}
 											activeOptions={l.inexact ? inexactOptions : activeOptions}
 											inactiveProps={inactiveProps}

--- a/src/components/navs/mode-toggle.tsx
+++ b/src/components/navs/mode-toggle.tsx
@@ -25,7 +25,7 @@ export function ModeToggle() {
 					<DropdownMenuTrigger asChild>
 						<SidebarMenuButton
 							size="lg"
-							className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground group-data-[collapsible=icon]:p-2!"
+							className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground rounded-2xl shadow group-data-[collapsible=icon]:p-2!"
 						>
 							<Sun className="h-[1.3rem] w-[1.3rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
 							<Moon className="absolute h-[1.3rem] w-[1.3rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />

--- a/src/components/navs/nav-user.tsx
+++ b/src/components/navs/nav-user.tsx
@@ -41,7 +41,7 @@ export function NavUser() {
 					<DropdownMenuTrigger asChild>
 						<SidebarMenuButton
 							size="lg"
-							className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+							className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground rounded-2xl shadow"
 						>
 							<Avatar className="size-8 rounded-lg">
 								<AvatarImage src={avatarUrl} alt={username} />

--- a/src/components/navs/navbar.tsx
+++ b/src/components/navs/navbar.tsx
@@ -14,7 +14,6 @@ import {
 	useNavigate,
 } from '@tanstack/react-router'
 import { SidebarTrigger } from '@/components/ui/sidebar'
-import { Separator } from '@/components/ui/separator'
 import { useLinks } from '@/hooks/links'
 
 type NavbarLoaderData = {
@@ -22,7 +21,6 @@ type NavbarLoaderData = {
 		title?: string
 		subtitle?: string
 		onBackClick?: string | (() => void)
-		Icon?: ComponentType<{ size?: number | string; className?: string }>
 	}
 	contextMenu?: string[]
 }
@@ -44,7 +42,7 @@ export default function Navbar() {
 
 	return (
 		<nav className="flex items-center justify-between border-b px-[1cqw] py-3">
-			<div className="flex h-12 items-center gap-[1cqw]">
+			<div className="flex h-12 items-center gap-1.5">
 				<SidebarTrigger />
 				<Title matches={matches} />
 			</div>
@@ -75,25 +73,20 @@ function Title({ matches }: { matches: NavbarMatch[] }) {
 			titleBar.onBackClick
 		:	goBackOrToStringUrl
 
-	const Icon = !titleBar ? null : titleBar.Icon
-
 	return (
-		<>
+		<div className="ms-1.5 flex flex-row items-center gap-3">
 			<Button variant="ghost" size="icon" onClick={onBackClickFn}>
 				<ChevronLeft />
 				<span className="sr-only">Back</span>
 			</Button>
-			<Separator orientation="vertical" className="mx-2 h-6" />
+
 			<div className="flex flex-row items-center gap-[1cqw] rounded-2xl">
-				{Icon ?
-					<Icon size={24} />
-				:	null}
 				<div>
 					<h1 className="text-lg font-bold">{titleBar?.title}</h1>
 					<p className="text-sm opacity-80">{titleBar?.subtitle}</p>
 				</div>
 			</div>
-		</>
+		</div>
 	)
 }
 

--- a/src/components/permalink-button.tsx
+++ b/src/components/permalink-button.tsx
@@ -9,7 +9,7 @@ export default function PermalinkButton({
 	params,
 	text = 'Permalink',
 	variant = 'ghost',
-	size = 'badge',
+	size = 'sm',
 	className,
 	...props
 }: { text?: string; className?: string } & LinkProps &

--- a/src/components/requests/request-list-item.tsx
+++ b/src/components/requests/request-list-item.tsx
@@ -33,23 +33,20 @@ export function RequestItem({ request }: { request: PhraseRequestFull }) {
 					</Badge>
 				</div>
 				<div className="text-muted-foreground mt-2 flex min-w-0 items-center gap-2 text-sm">
-					<span className="font-medium">
-						<UserPermalink
-							username={request.requester?.username ?? ''}
-							avatarUrl={avatarUrlify(request.requester?.avatar_path) ?? ''}
-							uid={request.requester_uid}
-							className="text-muted-foreground"
-						/>
-					</span>
-					<span>•</span>
-
 					<Link
 						to="/learn/$lang/requests/$id"
 						params={{ lang: request.lang, id: request.id }}
-						className="s-link-hidden"
+						className="s-link-hidden text-primary-foresoft"
 					>
 						{ago(request.created_at)}
 					</Link>
+					requested by{' '}
+					<UserPermalink
+						username={request.requester?.username ?? ''}
+						avatarUrl={avatarUrlify(request.requester?.avatar_path) ?? ''}
+						uid={request.requester_uid}
+						className="text-muted-foreground"
+					/>
 				</div>
 			</CardHeader>
 			<CardContent>

--- a/src/components/review/review-single-card.tsx
+++ b/src/components/review/review-single-card.tsx
@@ -69,7 +69,7 @@ export function ReviewSingleCard({ pid, lang }: OnePhraseComponentProps) {
 								<div className="me-2 text-xl">{trans.text}</div>
 								<Flagged name="text_to_speech">
 									<Button
-										size="icon-sm"
+										size="icon"
 										variant="secondary"
 										onClick={() => playAudio(trans.text)}
 										aria-label="Play translation"

--- a/src/components/review/when-review-complete-screen.tsx
+++ b/src/components/review/when-review-complete-screen.tsx
@@ -46,7 +46,7 @@ export function WhenComplete() {
 						</Button>
 						<Button
 							size="lg"
-							variant="link"
+							variant="secondary"
 							onClick={actions.skipReviewUnreviewed}
 						>
 							Skip step 2
@@ -90,7 +90,11 @@ export function WhenComplete() {
 							&ndash; and as always, don't forget to say the phrase outloud! Use
 							as many senses as you can.
 						</p>
-						<Button variant="link" size="lg" onClick={actions.skipReviewAgains}>
+						<Button
+							variant="secondary"
+							size="lg"
+							onClick={actions.skipReviewAgains}
+						>
 							Skip step 3
 						</Button>
 					</>

--- a/src/components/share-phrase-button.tsx
+++ b/src/components/share-phrase-button.tsx
@@ -12,7 +12,7 @@ export default function SharePhraseButton({
 	pid,
 	text = 'Share phrase',
 	variant = 'ghost',
-	size = 'badge',
+	size = 'sm',
 	className = '',
 	...props
 }: OnePhraseComponentProps & {

--- a/src/components/share-request-button.tsx
+++ b/src/components/share-request-button.tsx
@@ -13,7 +13,7 @@ export default function ShareRequestButton({
 	id,
 	text = 'Share request',
 	variant = 'ghost',
-	size = 'badge',
+	size = 'sm',
 	className = '',
 	...props
 }: {

--- a/src/components/ui/button-variants.tsx
+++ b/src/components/ui/button-variants.tsx
@@ -25,11 +25,10 @@ const buttonVariants = cva(
 			},
 			size: {
 				default: 'h-10 rounded-2xl px-5 py-2 gap-2',
-				sm: 'h-8 rounded-2xl px-4 gap-1 [&_svg]:size-3',
+				sm: 'h-8 rounded-xl px-4 gap-1 [&_svg]:size-3',
 				lg: 'rounded-2xl px-8 py-4 text-xl font-medium gap-3 [&_svg]:size-6',
-				icon: 'size-8 rounded-2xl shrink-0 aspect-square',
-				'icon-sm': 'size-6 rounded-full shrink-0',
-				badge: 'h-6 rounded-2xl font-sm px-2 gap-1 my-0',
+				icon: 'size-8 rounded-xl shrink-0 aspect-square',
+
 			},
 		},
 		defaultVariants: {

--- a/src/components/user-permalink.tsx
+++ b/src/components/user-permalink.tsx
@@ -7,11 +7,13 @@ export default function ({
 	username,
 	avatarUrl,
 	className,
+	round = false,
 }: {
 	uid: uuid | null
 	username: string | null
 	avatarUrl: string | null
 	className?: string
+	round?: boolean
 }) {
 	if (!uid) return null
 
@@ -20,7 +22,10 @@ export default function ({
 			to="/friends/$uid"
 			params={{ uid }}
 			className={cn(
-				`hover:outline-primary/30 text-primary-foresoft inline-flex flex-row place-items-baseline items-center gap-1 rounded-2xl hover:outline`,
+				round ?
+					`hover:outline-primary/30 rounded-2xl hover:outline`
+				:	`s-link-hidden text-primary-foresoft`,
+				`text-primary-foresoft inline-flex flex-row place-items-baseline items-center gap-1`,
 				className
 			)}
 		>

--- a/src/hooks/links.ts
+++ b/src/hooks/links.ts
@@ -1,10 +1,10 @@
 import {
-	BookHeart,
 	ClipboardPlus,
 	FileText,
 	HandHeart,
 	HeartHandshake,
 	Home,
+	HouseHeart,
 	Lock,
 	LogIn,
 	Mail,
@@ -93,8 +93,8 @@ const links = (lang?: LangKey): Record<string, LinkType> => ({
 	},
 	'/learn/$lang': {
 		name: languages[lang],
-		title: `${languages[lang]} deck`,
-		Icon: BookHeart,
+		title: `${languages[lang]} home`,
+		Icon: HouseHeart,
 		link: {
 			to: '/learn/$lang',
 			params: { lang },

--- a/src/routes/_user.tsx
+++ b/src/routes/_user.tsx
@@ -17,7 +17,6 @@ import {
 	redirect,
 	useMatches,
 } from '@tanstack/react-router'
-import { Home } from 'lucide-react'
 import { Loader } from '@/components/ui/loader'
 import { useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '@/lib/hooks'
@@ -63,7 +62,6 @@ export const Route = createFileRoute('/_user')({
 			titleBar: {
 				title: `Learning Home`,
 				subtitle: `Which deck are we studying today?`,
-				Icon: Home,
 			} as TitleBar,
 		}
 	},

--- a/src/routes/_user/friends.chats.tsx
+++ b/src/routes/_user/friends.chats.tsx
@@ -1,13 +1,11 @@
 import { ChatsSidebar } from '@/components/friends/chats-sidebar'
 import { TitleBar } from '@/types/main'
 import { createFileRoute } from '@tanstack/react-router'
-import { MessagesSquare } from 'lucide-react'
 
 export const Route = createFileRoute('/_user/friends/chats')({
 	loader: () => ({
 		titleBar: {
 			title: `Chats`,
-			Icon: MessagesSquare,
 		} as TitleBar,
 		SecondSidebar: ChatsSidebar,
 	}),

--- a/src/routes/_user/friends.requests.tsx
+++ b/src/routes/_user/friends.requests.tsx
@@ -30,7 +30,7 @@ function RouteComponent() {
 								to="/friends"
 								aria-disabled="true"
 								className={buttonVariants({
-									size: 'badge',
+									size: 'sm',
 									variant: 'outline',
 								})}
 							>

--- a/src/routes/_user/friends.tsx
+++ b/src/routes/_user/friends.tsx
@@ -1,7 +1,6 @@
 import { TitleBar } from '@/types/main'
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 import { relationsQuery } from '@/lib/friends'
-import { HeartHandshake } from 'lucide-react'
 
 export const Route = createFileRoute('/_user/friends')({
 	component: FriendsPage,
@@ -10,8 +9,7 @@ export const Route = createFileRoute('/_user/friends')({
 		await queryClient.ensureQueryData(relationsQuery(userId))
 		return {
 			titleBar: {
-				title: `Manage Friends and Contacts`,
-				Icon: HeartHandshake,
+				title: `Friends and Contacts`,
 			} as TitleBar,
 			appnav: [
 				'/friends',

--- a/src/routes/_user/learn.$lang.bulk-add.tsx
+++ b/src/routes/_user/learn.$lang.bulk-add.tsx
@@ -288,7 +288,7 @@ function PhraseEntry({
 							<Button
 								type="button"
 								variant="ghost"
-								size="icon-sm"
+								size="icon"
 								onClick={() => removeTranslation(translationIndex)}
 								disabled={translationFields.length === 1}
 							>

--- a/src/routes/_user/learn.$lang.bulk-add.tsx
+++ b/src/routes/_user/learn.$lang.bulk-add.tsx
@@ -317,7 +317,6 @@ function PhraseEntry({
 				<Button
 					type="button"
 					variant="outline"
-					size="sm"
 					onClick={() =>
 						appendTranslation({
 							lang: profile?.languages_known[0]?.lang,

--- a/src/routes/_user/learn.$lang.index.tsx
+++ b/src/routes/_user/learn.$lang.index.tsx
@@ -67,10 +67,9 @@ function DeckOverview({ lang }: LangOnlyComponentProps) {
 							to="/learn/$lang/search"
 							from={Route.fullPath}
 							aria-disabled="true"
-							className={buttonVariants({
-								size: 'badge',
+							className={`${buttonVariants({
 								variant: 'outline',
-							})}
+							})} -mt-2`}
 						>
 							<Search className="size-3" />
 							<span className="me-1">quick search</span>

--- a/src/routes/_user/learn.$lang.library.tsx
+++ b/src/routes/_user/learn.$lang.library.tsx
@@ -153,10 +153,9 @@ function DeckLibraryPage() {
 						<Link
 							to="/learn/$lang/add-phrase"
 							from={Route.fullPath}
-							className={buttonVariants({
-								size: 'badge',
+							className={`${buttonVariants({
 								variant: 'outline',
-							})}
+							})} -mt-2`}
 						>
 							<Plus className="size-3" />
 							<span className="me-1">new phrase</span>

--- a/src/routes/_user/learn.$lang.requests.index.lazy.tsx
+++ b/src/routes/_user/learn.$lang.requests.index.lazy.tsx
@@ -30,7 +30,7 @@ function Page() {
 							to="/learn/$lang/requests/new"
 							params={{ lang }}
 							className={
-								` ${buttonVariants({
+								`${buttonVariants({
 									variant: 'outline',
 								})} -mt-2` as const
 							}

--- a/src/routes/_user/learn.$lang.review.go.tsx
+++ b/src/routes/_user/learn.$lang.review.go.tsx
@@ -66,7 +66,7 @@ function FlashCardReviewSession({ manifest }: { manifest: pids }) {
 					{!atTheEnd && reviewStage === 1 ?
 						<>
 							<Button
-								size="icon-sm"
+								size="icon"
 								variant="default"
 								onClick={gotoPrevious}
 								disabled={currentCardIndex === 0}
@@ -78,7 +78,7 @@ function FlashCardReviewSession({ manifest }: { manifest: pids }) {
 								Card {currentCardIndex + 1} of {manifest.length}
 							</div>
 							<Button
-								size="icon-sm"
+								size="icon"
 								variant="default"
 								onClick={gotoNext}
 								disabled={atTheEnd}

--- a/src/routes/_user/learn.$lang.review.tsx
+++ b/src/routes/_user/learn.$lang.review.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 import { TitleBar } from '@/types/main'
 import languages from '@/lib/languages'
-import { BookHeart } from 'lucide-react'
 import { todayString } from '@/lib/utils'
 import { ReviewStoreProvider } from '@/components/review/review-context-provider'
 import { useState } from 'react'
@@ -17,7 +16,6 @@ export const Route = createFileRoute('/_user/learn/$lang/review')({
 			],
 			titleBar: {
 				title: `Review ${languages[lang]} cards`,
-				Icon: BookHeart,
 				onBackClick: '/learn/$lang',
 			} as TitleBar,
 		}

--- a/src/routes/_user/learn.$lang.search.tsx
+++ b/src/routes/_user/learn.$lang.search.tsx
@@ -146,7 +146,7 @@ function SearchTab() {
 					<Button type="submit">
 						<Search /> Search Phrase
 					</Button>
-					<Button variant="link" asChild>
+					<Button variant="secondary" asChild>
 						<Link
 							to="/learn/$lang/add-phrase"
 							from={Route.fullPath}

--- a/src/routes/_user/learn.$lang.tsx
+++ b/src/routes/_user/learn.$lang.tsx
@@ -3,7 +3,6 @@ import { TitleBar } from '@/types/main'
 import languages from '@/lib/languages'
 import { languageQueryOptions } from '@/lib/use-language'
 import { deckQueryOptions } from '@/lib/use-deck'
-import { BookHeart } from 'lucide-react'
 
 export const Route = createFileRoute('/_user/learn/$lang')({
 	component: LanguageLayout,
@@ -43,7 +42,6 @@ export const Route = createFileRoute('/_user/learn/$lang')({
 			],
 			titleBar: {
 				title: `${languages[lang]} Deck`,
-				Icon: BookHeart,
 			} as TitleBar,
 		}
 	},

--- a/src/routes/_user/learn.add-deck.tsx
+++ b/src/routes/_user/learn.add-deck.tsx
@@ -2,7 +2,6 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 import { useController, useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { RouteIcon } from 'lucide-react'
 import type { TitleBar } from '@/types/main'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -25,7 +24,6 @@ export const Route = createFileRoute('/_user/learn/add-deck')({
 	loader: () => ({
 		titleBar: {
 			title: `Start Learning a New Language`,
-			Icon: RouteIcon,
 		} as TitleBar,
 	}),
 	component: NewDeckForm,

--- a/src/routes/_user/learn.tsx
+++ b/src/routes/_user/learn.tsx
@@ -2,8 +2,6 @@ import { PendingRequestsHeader } from '@/components/friends/pending-requests-hea
 import { TitleBar } from '@/types/main'
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 
-import { Home } from 'lucide-react'
-
 export const Route = createFileRoute('/_user/learn')({
 	component: LearnLayout,
 	loader: () => {
@@ -13,7 +11,6 @@ export const Route = createFileRoute('/_user/learn')({
 			titleBar: {
 				title: `Learning Home`,
 				subtitle: `Which deck are we studying today?`,
-				Icon: Home,
 			} as TitleBar,
 		}
 	},

--- a/src/routes/_user/profile.tsx
+++ b/src/routes/_user/profile.tsx
@@ -1,13 +1,11 @@
 import { TitleBar } from '@/types/main'
 import { createFileRoute, Outlet } from '@tanstack/react-router'
-import { UserPen } from 'lucide-react'
 
 export const Route = createFileRoute('/_user/profile')({
 	component: ProfilePage,
 	loader: () => ({
 		titleBar: {
 			title: `Manage your Profile`,
-			Icon: UserPen,
 		} as TitleBar,
 	}),
 })

--- a/src/types/main.d.ts
+++ b/src/types/main.d.ts
@@ -90,7 +90,6 @@ export type MenuType = LinkType & {
 export type TitleBar = {
 	title: string
 	subtitle?: string
-	Icon?: LucideIcon
 	onBackClick?: string | (() => void)
 }
 


### PR DESCRIPTION
This PR:
* removes the last remnants of the button variant=link
* removes button size=icon-sm (just use sm, or icon)
* removes button size=badge (just use sm)
* standardizes some button sizes (e.g. we don't need to modify the font size within the button, just use the button; we don't need to use one sm and one md, just do them the same)
* adds the `shadow rounded-2xl` to the two menus in the sidebar footer (dark mode; user menu)
<img width="259" height="150" alt="image" src="https://github.com/user-attachments/assets/d1a1dc64-51b1-40c5-9082-c9176f2fb7de" />

* shrinks the navbar links to 'sm' sizing