### PR TITLE
Feature: navbar quicksearch

### DIFF
--- a/src/components/navs/navbar.tsx
+++ b/src/components/navs/navbar.tsx
@@ -1,5 +1,5 @@
 import { ComponentType, useCallback, useState } from 'react'
-import { ChevronLeft, MoreVertical } from 'lucide-react'
+import { ChevronLeft, MoreVertical, Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
 	DropdownMenu,
@@ -15,6 +15,14 @@ import {
 } from '@tanstack/react-router'
 import { SidebarTrigger } from '@/components/ui/sidebar'
 import { useLinks } from '@/hooks/links'
+import { LinkType } from '@/types/main'
+import { Dialog, DialogContent, DialogTrigger } from '../ui/dialog'
+
+type SearchResult = {
+	title: string
+	description: string
+	link: LinkType
+}
 
 type NavbarLoaderData = {
 	titleBar?: {
@@ -22,6 +30,7 @@ type NavbarLoaderData = {
 		subtitle?: string
 		onBackClick?: string | (() => void)
 	}
+	searchFn: (query: string) => SearchResult
 	contextMenu?: string[]
 }
 type NavbarMatch = RouteMatch<
@@ -46,8 +55,10 @@ export default function Navbar() {
 				<SidebarTrigger />
 				<Title matches={matches} />
 			</div>
-
-			<ContextMenu matches={matches} />
+			<div className="flex flex-row items-center gap-3">
+				<SearchFlyout matches={matches} />
+				<ContextMenu matches={matches} />
+			</div>
 		</nav>
 	)
 }
@@ -122,5 +133,25 @@ function ContextMenu({ matches }: { matches: NavbarMatch[] }) {
 				)}
 			</DropdownMenuContent>
 		</DropdownMenu>
+	)
+}
+
+function SearchFlyout({ matches }: { matches: NavbarMatch[] }) {
+	const [isOpen, setIsOpen] = useState(false)
+	const setClosed = useCallback(() => setIsOpen(false), [setIsOpen])
+	const match = matches.findLast((m) => !!m?.loaderData?.searchFn)
+	// if (!match) return null
+	// const searchFn = match.loaderData?.searchFn
+	// if (!searchFn) return null
+
+	return (
+		<Dialog>
+			<DialogTrigger asChild>
+				<Button size="icon" variant="ghost">
+					<Search />
+				</Button>
+			</DialogTrigger>
+			<DialogContent>hihi</DialogContent>
+		</Dialog>
 	)
 }

--- a/src/components/navs/navbar.tsx
+++ b/src/components/navs/navbar.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, useCallback, useState } from 'react'
+import { type FormEvent, useCallback, useState } from 'react'
 import { ChevronLeft, MoreVertical, Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -15,14 +15,18 @@ import {
 } from '@tanstack/react-router'
 import { SidebarTrigger } from '@/components/ui/sidebar'
 import { useLinks } from '@/hooks/links'
-import { LinkType } from '@/types/main'
-import { Dialog, DialogContent, DialogTrigger } from '../ui/dialog'
-
-type SearchResult = {
-	title: string
-	description: string
-	link: LinkType
-}
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTrigger,
+	DialogTitle,
+	DialogDescription,
+} from '../ui/dialog'
+import { SearchResult } from '@/types/main'
+import { Input } from '../ui/input'
+import { useMutation } from '@tanstack/react-query'
+import { PostgrestError } from '@supabase/supabase-js'
 
 type NavbarLoaderData = {
 	titleBar?: {
@@ -30,7 +34,10 @@ type NavbarLoaderData = {
 		subtitle?: string
 		onBackClick?: string | (() => void)
 	}
-	searchFn: (query: string) => SearchResult
+	quickSearch: {
+		labelText: string
+		searchFn: ({ query }: { query: string }) => Promise<SearchResult[]>
+	}
 	contextMenu?: string[]
 }
 type NavbarMatch = RouteMatch<
@@ -137,13 +144,9 @@ function ContextMenu({ matches }: { matches: NavbarMatch[] }) {
 }
 
 function SearchFlyout({ matches }: { matches: NavbarMatch[] }) {
-	const [isOpen, setIsOpen] = useState(false)
-	const setClosed = useCallback(() => setIsOpen(false), [setIsOpen])
-	const match = matches.findLast((m) => !!m?.loaderData?.searchFn)
-	// if (!match) return null
-	// const searchFn = match.loaderData?.searchFn
-	// if (!searchFn) return null
-
+	const quickSearch = matches.findLast((m) => !!m?.loaderData?.quickSearch)
+		?.loaderData?.quickSearch
+	if (!quickSearch) return null
 	return (
 		<Dialog>
 			<DialogTrigger asChild>
@@ -151,7 +154,82 @@ function SearchFlyout({ matches }: { matches: NavbarMatch[] }) {
 					<Search />
 				</Button>
 			</DialogTrigger>
-			<DialogContent>hihi</DialogContent>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>{quickSearch.labelText}</DialogTitle>
+					<DialogDescription className="sr-only">
+						Use the input below to search
+					</DialogDescription>
+				</DialogHeader>
+				<SearchForm quickSearch={quickSearch} />
+			</DialogContent>
 		</Dialog>
+	)
+}
+
+function SearchForm({
+	quickSearch,
+}: {
+	quickSearch: NavbarLoaderData['quickSearch']
+}) {
+	const searchMutation = useMutation<
+		SearchResult[],
+		PostgrestError,
+		{ query: string }
+	>({
+		// We use a more specific mutation key to avoid conflicts
+		mutationKey: ['quick-search', quickSearch.labelText, 'form-submit'],
+		mutationFn: quickSearch.searchFn,
+		onSuccess: (data) => console.log(data),
+		onError: (error) => console.log(`Error searching`, error),
+	})
+
+	const handleSubmit = useCallback(
+		(e: FormEvent<HTMLFormElement>) => {
+			e.preventDefault()
+			e.stopPropagation()
+			const formData = new FormData(e.currentTarget)
+			const query = formData.get('quick_search_query') as string
+			searchMutation.mutate({ query: query ?? '' })
+		},
+		[searchMutation]
+	)
+
+	return (
+		<>
+			<form className="flex flex-row items-end gap-2" onSubmit={handleSubmit}>
+				<div className="w-full">
+					<Input placeholder="Quick search" name="quick_search_query" />
+				</div>
+				<Button disabled={searchMutation.isPending}>
+					<Search />
+					<span className="hidden @md:block">Search</span>
+				</Button>
+			</form>
+			<p className="text-muted-foreground text-sm italic">
+				{searchMutation.data?.length ?? 0} results
+			</p>
+			<div className="flex flex-col gap-2">
+				{searchMutation.data?.map((result) => (
+					<SearchResultListItem
+						key={JSON.stringify(result.link.params)}
+						result={result}
+					/>
+				))}
+			</div>
+		</>
+	)
+}
+
+function SearchResultListItem({ result }: { result: SearchResult }) {
+	return (
+		<Link
+			to={result.link.to}
+			params={result.link.params}
+			className="bg-card rounded-xl px-3 py-2 shadow"
+		>
+			<h3>{result.title}</h3>
+			<p>{result.description}</p>
+		</Link>
 	)
 }

--- a/src/routes/_user/learn.$lang.tsx
+++ b/src/routes/_user/learn.$lang.tsx
@@ -3,6 +3,7 @@ import { TitleBar } from '@/types/main'
 import languages from '@/lib/languages'
 import { languageQueryOptions } from '@/hooks/use-language'
 import { deckQueryOptions } from '@/hooks/use-deck'
+import supabase from '@/lib/supabase-client'
 
 export const Route = createFileRoute('/_user/learn/$lang')({
 	component: LanguageLayout,
@@ -40,6 +41,27 @@ export const Route = createFileRoute('/_user/learn/$lang')({
 				'/learn/$lang/add-phrase',
 				'/learn/$lang/deck-settings',
 			],
+			quickSearch: {
+				labelText: 'Search for a phrase',
+				searchFn: async ({ query }: { query: string }) => {
+					console.log(`query`, typeof query, query)
+					const { data } = await supabase
+						.from('meta_phrase_info')
+						.select()
+						.ilikeAnyOf('text', String(query).split(' '))
+						.throwOnError()
+					return data.map((phrase) => {
+						return {
+							title: phrase.text,
+							description: '',
+							link: {
+								to: '/learn/$lang/$id',
+								params: { id: phrase.id, lang: phrase.lang },
+							},
+						}
+					})
+				},
+			},
 			titleBar: {
 				title: `${languages[lang]} Deck`,
 			} as TitleBar,

--- a/src/types/main.d.ts
+++ b/src/types/main.d.ts
@@ -39,6 +39,12 @@ export type AuthState = {
 	userRole: RolesEnum
 }
 
+export type SearchResult = {
+	title: string
+	description: string
+	link: LinkType['link']
+}
+
 export type ChatMessageRow = Tables<'chat_message'>
 export type ChatMessageRelative = ChatMessageRow & {
 	isMine: boolean


### PR DESCRIPTION
This PR adds a "navbar quicksearch" support to the Navbar component, pulling a title and queryFn from a route's loader data to display it as an icon-button in the top right of the screen.

<img width="646" height="661" alt="image" src="https://github.com/user-attachments/assets/8385d155-c6fa-4750-a4ca-2f5282f62883" />
