### PR TITLE
Cleanup: empty language state

### DIFF
--- a/src/components/errors.tsx
+++ b/src/components/errors.tsx
@@ -29,6 +29,7 @@ export function ShowError({
 		<Callout
 			className={className}
 			variant="problem"
+			size="sm"
 			alert
 			Icon={DestructiveTriangle}
 		>
@@ -71,6 +72,7 @@ export const ShowErrorDontLog = memo(function ShowAndLogError({
 		<Callout
 			className={className}
 			variant="problem"
+			size="sm"
 			alert
 			Icon={DestructiveTriangle}
 		>

--- a/src/components/navs/deck-switcher.tsx
+++ b/src/components/navs/deck-switcher.tsx
@@ -43,7 +43,7 @@ const useDeckMenuData = () => {
 function NoDecks() {
 	const { setClosedMobile } = useSidebar()
 	return (
-		<Callout>
+		<Callout size="sm">
 			<p>It seems like you're not learning any languages yet! Get started.</p>
 			<Button className="mt-2 w-full" asChild>
 				<Link onClick={setClosedMobile} to="/learn/add-deck">

--- a/src/components/navs/nav-main.tsx
+++ b/src/components/navs/nav-main.tsx
@@ -1,6 +1,5 @@
 import { makeLinks } from '@/hooks/links'
 import OneSidebarMenu from '@/components/navs/one-sidebar-menu'
-import Callout from '@/components/ui/callout'
 import { Button } from '@/components/ui/button'
 import { Link } from '@tanstack/react-router'
 import languages from '@/lib/languages'
@@ -38,11 +37,9 @@ export function NavMain({ lang }: { lang?: string }) {
 
 	return (
 		<>
-			{!deckMenu || !lang ? null : (
+			{!deckMenu || !lang || !(lang in languages) ? null : (
 				<div className="bg-primary/10 mx-2 rounded-2xl pb-2">
-					{!(lang in languages) ?
-						<LanguageNotFound />
-					: !isDeckFound ?
+					{!isDeckFound ?
 						<DeckNotFound lang={lang} />
 					:	<OneSidebarMenu menu={deckMenu} title="" />}
 				</div>
@@ -58,30 +55,20 @@ export function NavMain({ lang }: { lang?: string }) {
 	)
 }
 
-function LanguageNotFound() {
-	return (
-		<Callout className="m-2">
-			<p>
-				This language doesn't seem to exist. Please check your URL and try
-				again.
-			</p>
-		</Callout>
-	)
-}
-
-function DeckNotFound({ lang }: LangOnlyComponentProps) {
+function DeckNotFound(props: LangOnlyComponentProps) {
 	const { setClosedMobile } = useSidebar()
 	return (
-		<Callout className="m-2">
+		<div className="p-4 pb-2">
 			<p>
-				It seems like you're not studying {languages[lang]} (yet). Would you
-				like to start working on a new deck?
+				Start work on a new deck of{' '}
+				<span className="s-language-name">{languages[props.lang]}</span> flash
+				cards?
 			</p>
-			<Button className="mt-2 w-full" asChild>
-				<Link to="/learn/add-deck" onClick={setClosedMobile} search={{ lang }}>
+			<Button className="mt-2 w-full" asChild size="sm">
+				<Link to="/learn/add-deck" onClick={setClosedMobile} search={props}>
 					Start Learning
 				</Link>
 			</Button>
-		</Callout>
+		</div>
 	)
 }

--- a/src/components/ui/callout.tsx
+++ b/src/components/ui/callout.tsx
@@ -3,6 +3,7 @@ import type { ComponentType, HTMLAttributes, PropsWithChildren } from 'react'
 
 type CalloutProps = PropsWithChildren & {
 	variant?: 'default' | 'problem' | 'ghost'
+	size?: 'default' | 'sm'
 	className?: string
 	alert?: boolean
 	Icon?: ComponentType
@@ -14,8 +15,14 @@ const variants = {
 	ghost: 'border text-muted-foreground bg-muted',
 }
 
+const sizes = {
+	default: 'py-[5%]',
+	sm: 'py-[5%] @lg:py-[3%]',
+}
+
 export default function Callout({
 	variant = 'default',
+	size = 'default',
 	alert = false,
 	Icon,
 	className,
@@ -27,13 +34,14 @@ export default function Callout({
 		<div
 			{...props}
 			className={cn(
-				'flex flex-col items-center gap-4 rounded border px-[5%] py-[5%] @lg:flex-row @lg:py-[3%]',
+				'@container flex flex-col items-start gap-4 rounded border px-[5%] @lg:flex-row',
 				variants[variant],
+				sizes[size],
 				className
 			)}
 		>
 			{!Icon ? null : (
-				<div className="min-w-4vh aspect-square">
+				<div className="w-6cqw aspect-square">
 					<Icon />
 				</div>
 			)}

--- a/src/routes/_user/learn.$lang.index.tsx
+++ b/src/routes/_user/learn.$lang.index.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { buttonVariants } from '@/components/ui/button-variants'
-import type { LangOnlyComponentProps } from '@/types/main'
 import {
 	Card,
 	CardContent,
@@ -22,6 +21,7 @@ import {
 import languages from '@/lib/languages'
 import { ago } from '@/lib/dayjs'
 import {
+	deckQueryOptions,
 	useDeckActivityChartData,
 	useDeckMeta,
 	useDeckPids,
@@ -30,7 +30,7 @@ import {
 import { cn } from '@/lib/utils'
 import Flagged from '@/components/flagged'
 import { RecommendedPhrasesCard } from '@/components/recommended-phrases'
-import { useLanguageMeta } from '@/hooks/use-language'
+import { languageQueryOptions, useLanguageMeta } from '@/hooks/use-language'
 import { FriendProfiles } from './friends.index'
 import { ActivityChart } from '@/components/activity-chart'
 import { DeckStatsBadges } from '@/components/stats-badges'
@@ -38,6 +38,18 @@ import Callout from '@/components/ui/callout'
 
 export const Route = createFileRoute('/_user/learn/$lang/')({
 	component: WelcomePage,
+	loader: async ({
+		params: { lang },
+		context: {
+			queryClient,
+			auth: { userId },
+		},
+	}) => {
+		await Promise.all([
+			queryClient.prefetchQuery(languageQueryOptions(lang)),
+			queryClient.prefetchQuery(deckQueryOptions(lang, userId)),
+		])
+	},
 })
 
 function WelcomePage() {
@@ -50,16 +62,17 @@ function WelcomePage() {
 		<div className="space-y-8">
 			{deckIsNew ?
 				<Empty />
-			:	<DeckOverview lang={lang} />}
+			:	<DeckOverview />}
 
 			<RecommendedPhrasesCard lang={lang} />
 			<FriendProfiles />
-			<DeckSettings lang={lang} />
+			<DeckSettings />
 		</div>
 	)
 }
 
-function DeckOverview({ lang }: LangOnlyComponentProps) {
+function DeckOverview() {
+	const { lang } = Route.useParams()
 	const { data: meta } = useDeckMeta(lang)
 	const { data: pids } = useDeckPids(lang)
 	const { data: routineStats } = useDeckRoutineStats(lang)
@@ -179,7 +192,8 @@ function DeckOverview({ lang }: LangOnlyComponentProps) {
 	)
 }
 
-function DeckSettings({ lang }: LangOnlyComponentProps) {
+function DeckSettings() {
+	const { lang } = Route.useParams()
 	const { data } = useDeckMeta(lang)
 
 	return (

--- a/src/routes/_user/learn.$lang.index.tsx
+++ b/src/routes/_user/learn.$lang.index.tsx
@@ -11,11 +11,11 @@ import {
 } from '@/components/ui/card'
 import {
 	BookOpenText,
+	Construction,
 	Contact,
 	Library,
 	MessageSquarePlus,
 	MessageSquareQuote,
-	NotebookPen,
 	Rocket,
 	Search,
 } from 'lucide-react'
@@ -30,10 +30,11 @@ import {
 import { cn } from '@/lib/utils'
 import Flagged from '@/components/flagged'
 import { RecommendedPhrasesCard } from '@/components/recommended-phrases'
-import { useLanguage } from '@/hooks/use-language'
+import { useLanguageMeta } from '@/hooks/use-language'
 import { FriendProfiles } from './friends.index'
 import { ActivityChart } from '@/components/activity-chart'
 import { DeckStatsBadges } from '@/components/stats-badges'
+import Callout from '@/components/ui/callout'
 
 export const Route = createFileRoute('/_user/learn/$lang/')({
 	component: WelcomePage,
@@ -42,15 +43,13 @@ export const Route = createFileRoute('/_user/learn/$lang/')({
 function WelcomePage() {
 	const { lang } = Route.useParams()
 	const { data: pids } = useDeckPids(lang)
-	const { data: language } = useLanguage(lang)
-	if (!language) throw new Error("Could not load this language's data")
 	if (!pids) throw new Error("Could not load this deck's data")
 
 	const deckIsNew = !(pids.all.length > 0)
 	return (
 		<div className="space-y-8">
 			{deckIsNew ?
-				<Empty lang={lang} />
+				<Empty />
 			:	<DeckOverview lang={lang} />}
 
 			<RecommendedPhrasesCard lang={lang} />
@@ -229,21 +228,84 @@ function DeckSettings({ lang }: LangOnlyComponentProps) {
 	)
 }
 
-function Empty({ lang }: LangOnlyComponentProps) {
+const Icon = () => (
+	<Construction className="bg-accent text-accent-foreground h-12 w-12 rounded-full border border-white p-2" />
+)
+
+function NewLang() {
+	const { lang } = Route.useParams()
+
+	return (
+		<Callout Icon={Icon}>
+			<div className="flex flex-col gap-2">
+				<p className="h3 text-primary-foresoft font-bold">
+					It looks like this is a brand new language!
+				</p>
+				<p>
+					You are going to have to do a bit of extra prep. Here are some tips to
+					get you started:
+				</p>
+				<ul className="ml-4 list-disc space-y-2">
+					<li>
+						Recruit a friend! Your best best in the world is a native-speaker
+						whose face lights up with joy when they get to tell you something
+						new about their culture.{' '}
+						<Link from={Route.fullPath} className="s-link">
+							Ask them to sign up and help you build your flashcard deck.
+						</Link>
+					</li>
+					<li>
+						Think of phrases you will find immediately useful, or a situation in
+						the last 48 hours where you wanted to communicate something, but
+						didn't know how. Then text a friend and ask them, and{' '}
+						<Link
+							from={Route.fullPath}
+							to="/learn/$lang/add-phrase"
+							className="s-link"
+						>
+							make a flash card out of their response
+						</Link>
+						.
+					</li>
+					<li>
+						Or, if you have a good example you want to ask about,
+						<Link
+							from={Route.fullPath}
+							to="/learn/$lang/requests/new"
+							className="s-link"
+						>
+							make a Phrase Request share the link with your friends
+						</Link>
+						, so they can answer your request and help build the library for
+						everyone else who comes after you wanting to learn {languages[lang]}
+						.
+					</li>
+					{/*<li>?? join our discord community?? with other learners?? </li>*/}
+				</ul>
+			</div>
+		</Callout>
+	)
+}
+
+function Empty() {
+	const { lang } = Route.useParams()
+
+	const { data: languageMeta } = useLanguageMeta(lang)
 	return (
 		<Card>
 			<CardHeader>
 				<CardTitle>
-					<p className="mb-6 text-3xl font-bold">Welcome to Your New Deck!</p>
+					<p className="text-3xl font-bold">Welcome to Your New Deck!</p>
 				</CardTitle>
 			</CardHeader>
 			<CardContent className="space-y-6">
+				{!((languageMeta?.phrases_to_learn ?? 0) > 15) && <NewLang />}
 				<p className="text-lg">
 					Let's get started by setting up your learning experience. Do you want
 					to start by browsing the public deck of flash cards, or invite a
 					friend to help you out?
 				</p>
-				<div className="flex flex-col gap-2 @lg:flex-row">
+				<div className="flex flex-col gap-4 @lg:flex-row">
 					<Link
 						to="/learn/$lang/library"
 						from={Route.fullPath}
@@ -261,13 +323,22 @@ function Empty({ lang }: LangOnlyComponentProps) {
 				<p className="text-lg">
 					Or, do you already have a phrase in mind you'd like to add?
 				</p>
-				<Link
-					to="/learn/$lang/add-phrase"
-					from={Route.fullPath}
-					className={buttonVariants({ variant: 'secondary' })}
-				>
-					<NotebookPen /> Add a phrase
-				</Link>
+				<div className="flex gap-4">
+					<Link
+						to="/learn/$lang/add-phrase"
+						from={Route.fullPath}
+						className={buttonVariants({ variant: 'secondary' })}
+					>
+						<MessageSquarePlus /> Add a Phrase
+					</Link>
+					<Link
+						to="/learn/$lang/requests/new"
+						from={Route.fullPath}
+						className={buttonVariants({ variant: 'secondary' })}
+					>
+						<MessageSquareQuote /> Request a Phrase
+					</Link>
+				</div>
 			</CardContent>
 		</Card>
 	)

--- a/src/routes/_user/learn.$lang.requests.new.tsx
+++ b/src/routes/_user/learn.$lang.requests.new.tsx
@@ -141,12 +141,15 @@ function Page() {
 							)}
 						/>
 
-						{createRequestMutation.isError && (
-							<Callout variant="problem">
-								<p className="font-bold">Error</p>
-								<p>{createRequestMutation.error.message}</p>
-							</Callout>
-						)}
+						{
+							// @TODO replace this with one of our many Error components
+							createRequestMutation.isError && (
+								<Callout size="sm" variant="problem">
+									<p className="font-bold">Error</p>
+									<p>{createRequestMutation.error.message}</p>
+								</Callout>
+							)
+						}
 
 						<Button type="submit" disabled={createRequestMutation.isPending}>
 							{createRequestMutation.isPending ?

--- a/src/routes/_user/learn.index.tsx
+++ b/src/routes/_user/learn.index.tsx
@@ -26,7 +26,7 @@ export default function Page() {
 						))}
 					</div>
 					<Link
-						className="s-link-muted items-center gap-1"
+						className="s-link-muted flex flex-row items-center gap-1 text-sm"
 						to="/learn/archived"
 					>
 						<Archive size={14} />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -172,7 +172,7 @@
 	@apply decoration-primary-foresoft hover:decoration-primary-foresoft/50 text-primary-foresoft cursor-pointer underline decoration-dashed decoration-1 underline-offset-2 transition-all hover:decoration-solid hover:decoration-2 hover:underline-offset-1;
 }
 @utility s-link-muted {
-	@apply decoration-primary-foresoft/50 text-primary-foresoft flex flex-row gap-0 text-sm underline underline-offset-2 opacity-70 transition-all hover:gap-1 hover:underline-offset-3 hover:opacity-90;
+	@apply decoration-primary-foresoft/50 text-primary-foresoft underline underline-offset-2 opacity-70 transition-all hover:gap-1 hover:underline-offset-3 hover:opacity-90;
 }
 @utility s-link-hidden {
 	@apply decoration-primary/30 flex-shrink-0 underline-offset-4 hover:underline;
@@ -209,6 +209,9 @@
 }
 @utility h5 {
 	@apply my-2 text-lg font-bold;
+}
+@utility s-language-name {
+	@apply text-accent-foreground font-semibold italic;
 }
 
 @layer base {


### PR DESCRIPTION
There's a lot more I'd like to do with entry guides and such, but for now this will be a good start. It does raise a couple of issues though, some arising from the types but having implications for the UX:

1. we really should be ableto return a `null` deck instead of throwing a big red error direct from the queryFn!
2. maybe people get kicked over to a more "public" version of the page, or maybe it's just a little more graceful...
3. right now every page is "kick", but perhaps only some should be kick and others should be like if you try to do a protected operation you get a signin intercept