### PR TITLE
Try Immer for imperative updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"class-variance-authority": "^0.7.1",
 		"cmdk": "1.1.1",
 		"dayjs": "^1.11.13",
+		"immer": "^10.1.3",
 		"lucide-react": "^0.544.0",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
+      immer:
+        specifier: ^10.1.3
+        version: 10.1.3
       lucide-react:
         specifier: ^0.544.0
         version: 0.544.0(react@19.1.0)
@@ -118,7 +121,7 @@ importers:
         version: 3.25.32
       zustand:
         specifier: ^5.0.5
-        version: 5.0.5(@types/react@19.1.6)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
+        version: 5.0.5(@types/react@19.1.6)(immer@10.1.3)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
     devDependencies:
       '@eslint/js':
         specifier: ^9.27.0
@@ -2141,6 +2144,9 @@ packages:
   ignore@7.0.4:
     resolution: {integrity: sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==}
     engines: {node: '>= 4'}
+
+  immer@10.1.3:
+    resolution: {integrity: sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -4864,6 +4870,8 @@ snapshots:
 
   ignore@7.0.4: {}
 
+  immer@10.1.3: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -5529,8 +5537,9 @@ snapshots:
 
   zod@3.25.32: {}
 
-  zustand@5.0.5(@types/react@19.1.6)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0)):
+  zustand@5.0.5(@types/react@19.1.6)(immer@10.1.3)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0)):
     optionalDependencies:
       '@types/react': 19.1.6
+      immer: 10.1.3
       react: 19.1.0
       use-sync-external-store: 1.5.0(react@19.1.0)

--- a/src/components/add-tags.tsx
+++ b/src/components/add-tags.tsx
@@ -69,14 +69,7 @@ export function AddTags({ phraseId, lang }: { phraseId: uuid; lang: string }) {
 				void queryClient.setQueryData<LanguageLoaded>(
 					['language', lang],
 					(old) => {
-						if (!old) {
-							void queryClient.invalidateQueries({
-								queryKey: ['language', lang],
-							})
-							return
-						}
-
-						return produce(old, (draft) => {
+						return produce(old!, (draft) => {
 							if (Array.isArray(draft.phrasesMap[phraseId].tags))
 								draft.phrasesMap[phraseId].tags.push(newTags)
 							else draft.phrasesMap[phraseId].tags = newTags

--- a/src/components/profile/update-profile-form.tsx
+++ b/src/components/profile/update-profile-form.tsx
@@ -13,6 +13,8 @@ import { Button } from '@/components/ui/button'
 import UsernameField from '../fields/username-field'
 import { LanguagesKnownField } from '../fields/languages-known-field'
 import AvatarEditorField from '../fields/avatar-editor-field'
+import { avatarUrlify } from '@/lib/utils'
+import { produce } from 'immer'
 
 const ProfileEditFormSchema = z.object({
 	username: z
@@ -55,7 +57,19 @@ export default function UpdateProfileForm({
 				avatar_path: data?.avatar_path ?? null,
 				languages_known: (data?.languages_known as LanguageKnown[]) ?? [],
 			})
-			void queryClient.invalidateQueries({ queryKey: ['user'] })
+			if (data)
+				void queryClient.setQueryData<ProfileFull>(
+					['user', data.uid],
+					(old) => {
+						return produce<ProfileFull>(old!, (draft) => {
+							draft.username = data.username ?? ''
+							draft.avatar_path = data.avatar_path ?? ''
+							draft.avatarUrl = avatarUrlify(data.avatar_path)
+							draft.languages_known = data.languages_known
+						})
+					}
+				)
+			else void queryClient.invalidateQueries({ queryKey: ['user'] })
 		},
 	})
 


### PR DESCRIPTION
Some of this is just proving the concept, but it seems promising. We should test and merge it without feeling the need to be toooo complete I think, partly because some of the immer work will be impractical as long as we are still calculating e.g. `DeckPids` at fetch-time, rather than via selects. 

We are _also_ separately moving toward selects for these things, but need to do so carefully because so many decisions have been based on our previous data-fetching strategies and these are potentially expensive operations. But assuming we are able to get rid of things like DeckPids in the cache, (potentially even just caching DeckFetched!! and calculating all the rest in Selects and maybe returning Sets and Maps and such, after some research of course), then performing imperative updates will get much easier, and Immer will keep it all nice and simple for us.