### PR TITLE
Hotfix: Change which themes come first in the rotation

### DIFF
--- a/src/lib/deck-themes.ts
+++ b/src/lib/deck-themes.ts
@@ -10,21 +10,21 @@ const noDeckTheme = {
 export type ThemeType = typeof noDeckTheme
 
 export const themes: ThemeType[] = [
-	// 355 is our true red, 015 is adjacent
-	{ name: 'brick', hue: 30, hueOff: 50, hueAccent: 30 },
-	{ name: 'sand', hue: 55, hueOff: 35, hueAccent: 55 },
-	// 75 looks sick, 95 and 115 look like owl
-	// 135 is adjacent to true green
-	// 155 is our true green,
-	// 175 would seem too close, but human eyes are good at green
-	{ name: 'teal', hue: 180, hueOff: 200, hueAccent: 180 },
 	{ name: 'cyan', hue: 205, hueOff: 225, hueAccent: 205 },
 	{ name: 'ocean', hue: 230, hueOff: 210, hueAccent: 230 },
 	// 255 is adjacent to true purple
 	// 275 is our true purple
 	{ name: 'hotpink', hue: 300, hueOff: 320, hueAccent: 300 },
 	{ name: 'blush', hue: 325, hueOff: 305, hueAccent: 325 },
-	// 335 is adjacent to our true red
+	// 335 is adjacent to our true red, 355 is true red, 015 is adjacent
+	// this one just looks bad in dark mode bc the bg colour is bluish
+	// { name: 'brick', hue: 30, hueOff: 50, hueAccent: 30 },
+	{ name: 'sand', hue: 55, hueOff: 35, hueAccent: 55 },
+	// 75 looks sick, 95 and 115 look like owl
+	// 135 is adjacent to true green
+	// 155 is our true green,
+	// 175 would seem too close, but human eyes are good at green
+	{ name: 'teal', hue: 180, hueOff: 200, hueAccent: 180 },
 ]
 
 export const getThemeCss = (index?: number) => {


### PR DESCRIPTION
The sand and brick themes were looking really bad against the bluish background in dark mode, so I disabled brick and changed the order around so we start in the `cyan` portion and go around from there. People won't see sand will their 5th deck, and by that point I think they can handle it.

```typescript
export const themes: ThemeType[] = [
	{ name: 'cyan', hue: 205, hueOff: 225, hueAccent: 205 },
	{ name: 'ocean', hue: 230, hueOff: 210, hueAccent: 230 },
	// 255 is adjacent to true purple
	// 275 is our true purple
	{ name: 'hotpink', hue: 300, hueOff: 320, hueAccent: 300 },
	{ name: 'blush', hue: 325, hueOff: 305, hueAccent: 325 },
	// 335 is adjacent to our true red, 355 is true red, 015 is adjacent
	// this one just looks bad in dark mode bc the bg colour is bluish
	// { name: 'brick', hue: 30, hueOff: 50, hueAccent: 30 },
	{ name: 'sand', hue: 55, hueOff: 35, hueAccent: 55 },
	// 75 looks sick, 95 and 115 look like owl
	// 135 is adjacent to true green
	// 155 is our true green,
	// 175 would seem too close, but human eyes are good at green
	{ name: 'teal', hue: 180, hueOff: 200, hueAccent: 180 },
]
```