### PR TITLE
Fix up the card previews, request previews, add playlist previews

### DIFF
--- a/src/components/cards/card-result-simple.tsx
+++ b/src/components/cards/card-result-simple.tsx
@@ -28,7 +28,7 @@ export function CardResultSimple({
 					{phrase.translations?.map((t) => (
 						<li key={t.id} className="flex items-center gap-2 text-sm">
 							<LangBadge lang={t.lang} />
-							<span>&ldquo;{t.text}&rdquo;</span>
+							<span>{t.text}</span>
 						</li>
 					))}
 				</ul>

--- a/src/routes/_user/friends/-card-preview.tsx
+++ b/src/routes/_user/friends/-card-preview.tsx
@@ -1,12 +1,10 @@
 import { CSSProperties } from 'react'
 import type { uuid } from '@/types/main'
 import { Link } from '@tanstack/react-router'
-import { EllipsisVertical } from 'lucide-react'
 
 import { CardContent, CardTitle } from '@/components/ui/card'
 import Callout from '@/components/ui/callout'
 import { CardStatusHeart } from '@/components/card-pieces/card-status-dropdown'
-import { buttonVariants } from '@/components/ui/button'
 import { Loader } from '@/components/ui/loader'
 import { usePhrase } from '@/hooks/composite-phrase'
 import { CardlikeFlashcard } from '@/components/ui/card-like'
@@ -15,18 +13,21 @@ export function CardPreview({ pid, isMine }: { pid: uuid; isMine: boolean }) {
 	const { data: phrase, status } = usePhrase(pid)
 	const chosenTranslation = phrase?.translations[0]
 
-	if (status === 'not-found')
+	if (status === 'pending') return <Loader className="my-6" />
+	if (status === 'not-found' || !phrase)
 		return (
 			<Callout variant="problem">Can't seem to find that phrase...</Callout>
 		)
 	return (
-		<CardlikeFlashcard
-			className={`relative z-10 mb-0 ${isMine ? 'rounded-br-none' : 'rounded-bl-none'}`}
-			style={{ viewTransitionName: `phrase-${pid}` } as CSSProperties}
+		<Link
+			to={'/learn/$lang/phrases/$id'}
+			params={{ lang: phrase.lang, id: pid }}
 		>
-			{status === 'pending' || !phrase ?
-				<Loader className="my-6" />
-			:	<CardContent className="flex flex-row space-y-2 p-4">
+			<CardlikeFlashcard
+				className={`relative z-10 mb-0 ${isMine ? 'rounded-br-none' : 'rounded-bl-none'}`}
+				style={{ viewTransitionName: `phrase-${pid}` } as CSSProperties}
+			>
+				<CardContent className="flex flex-row space-y-2 p-4">
 					<div className="flex-1">
 						<CardTitle className="text-lg">
 							{phrase.text}{' '}
@@ -47,19 +48,9 @@ export function CardPreview({ pid, isMine }: { pid: uuid; isMine: boolean }) {
 					</div>
 					<div className="flex grow-0 flex-col flex-wrap justify-start gap-2">
 						<CardStatusHeart phrase={phrase} />
-						<Link
-							to={'/learn/$lang/phrases/$id'}
-							params={{ lang: phrase.lang, id: pid }}
-							className={buttonVariants({
-								variant: 'ghost',
-								size: 'icon',
-							})}
-						>
-							<EllipsisVertical className="text-muted-foreground" />
-						</Link>
 					</div>
 				</CardContent>
-			}
-		</CardlikeFlashcard>
+			</CardlikeFlashcard>
+		</Link>
 	)
 }


### PR DESCRIPTION
- clicking preview item should navigate me to the item
- remove the interactions from the preview area (can use them on the item detail page)
- ISBT share playlist items too
- include some select metadata on the preview items
- perhaps re-organize the files, if it seems good to put them maybe in `@/components/chats`