### PR TITLE
Add Edge Middleware for social previews

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -201,7 +201,7 @@ async function fetchOGData(
 						:	undefined
 
 					return {
-						title: data.title,
+						title: `${data.title} - ${langName} Playlist`,
 						description:
 							data.description || `A ${langName} learning playlist on Sunlo`,
 						image: imageUrl,
@@ -219,7 +219,7 @@ async function fetchOGData(
 
 				if (data) {
 					return {
-						title: `Translation Request: ${data.prompt.slice(0, 60)}${data.prompt.length > 60 ? '...' : ''}`,
+						title: `${langName} Translation Request`,
 						description: data.prompt,
 						url: path,
 					}


### PR DESCRIPTION
Intercepts requests from social media crawlers (Facebook, Instagram, Twitter, LinkedIn, WhatsApp, Signal, Slack, Telegram, Discord, etc.) and returns HTML with Open Graph meta tags for link previews.

Supports:
- Language pages (/learn/:lang, /learn/:lang/feed)
- Phrase pages (/learn/:lang/phrases/:id)
- Playlist pages (/learn/:lang/playlists/:id)
- Request pages (/learn/:lang/requests/:id)

The SPA remains unchanged - middleware only serves crawlers.