### PR TITLE
Hide notification bell in focus mode

### DIFF
--- a/src/components/navs/navbar.tsx
+++ b/src/components/navs/navbar.tsx
@@ -9,6 +9,11 @@ import type { MyRouterContext } from '@/routes/__root'
 import { NotificationBell } from '@/components/notifications/notification-bell'
 
 export default function Navbar() {
+	const matches = useMatches()
+	const focusMode = matches.some(
+		(m) => (m.context as MyRouterContext)?.focusMode
+	)
+
 	return (
 		<nav
 			className="flex items-center justify-between gap-4 border-b px-2 py-3"
@@ -18,7 +23,7 @@ export default function Navbar() {
 				<Title />
 			</div>
 			<div className="flex items-center gap-2">
-				<NotificationBell />
+				{!focusMode && <NotificationBell />}
 				<SidebarTrigger />
 			</div>
 		</nav>


### PR DESCRIPTION
## Summary
Added focus mode detection to the navbar component to conditionally hide the notification bell when focus mode is active.

## Key Changes
- Added `useMatches()` hook to detect the current route context
- Implemented focus mode detection by checking if any matched route has `focusMode` enabled in its context
- Conditionally render the `NotificationBell` component only when focus mode is disabled

## Implementation Details
The navbar now checks the router context from all matched routes to determine if focus mode is active. When focus mode is enabled, the notification bell is hidden to reduce distractions, while the sidebar trigger remains visible for navigation purposes.

https://claude.ai/code/session_01D3J9NQeVMRsV9Z93BXaQjz