### PR TITLE
Update phrase provenance link navigation to use search params

### DIFF
--- a/src/components/cards/big-phrase-card.tsx
+++ b/src/components/cards/big-phrase-card.tsx
@@ -403,7 +403,7 @@ function PhraseProvenanceItem({ item, lang }: PhraseProvenanceItemProps) {
 					<Link
 						to="/learn/$lang/requests/$id"
 						params={{ lang, id: item.requestId }}
-						search={{ show: 'thread' as const, focus: item.commentId }}
+						search={{ focus: item.commentId }}
 						className="s-link font-medium"
 					>
 						{item.prompt}

--- a/src/components/cards/big-phrase-card.tsx
+++ b/src/components/cards/big-phrase-card.tsx
@@ -403,7 +403,7 @@ function PhraseProvenanceItem({ item, lang }: PhraseProvenanceItemProps) {
 					<Link
 						to="/learn/$lang/requests/$id"
 						params={{ lang, id: item.requestId }}
-						hash={`#comment-${item.commentId}`}
+						hash={`comment-${item.commentId}`}
 						className="s-link font-medium"
 					>
 						{item.prompt}

--- a/src/components/cards/big-phrase-card.tsx
+++ b/src/components/cards/big-phrase-card.tsx
@@ -403,7 +403,7 @@ function PhraseProvenanceItem({ item, lang }: PhraseProvenanceItemProps) {
 					<Link
 						to="/learn/$lang/requests/$id"
 						params={{ lang, id: item.requestId }}
-						hash={`comment-${item.commentId}`}
+						search={{ show: 'thread' as const, focus: item.commentId }}
 						className="s-link font-medium"
 					>
 						{item.prompt}


### PR DESCRIPTION
## Summary
Updated the navigation link in the phrase provenance component to use search parameters instead of hash-based navigation for thread display and comment focus.

## Key Changes
- Changed from hash-based navigation (`hash={`#comment-${item.commentId}`}`) to search parameter-based navigation (`search={{ show: 'thread' as const, focus: item.commentId }}`)
- This allows the routing system to properly handle thread display state and comment focus through query parameters rather than URL fragments

## Implementation Details
- The `show` parameter is set to `'thread'` as a const to indicate the thread view should be displayed
- The `focus` parameter now carries the `commentId` value to indicate which comment should be focused
- This approach provides better state management and URL handling compared to hash-based navigation

https://claude.ai/code/session_015ZtA4Q2fzhYkBG1vTe5sSQ