### PR TITLE
Reorganize sidebar navigation and move contributions link

### DIFF
--- a/src/components/navs/app-sidebar.tsx
+++ b/src/components/navs/app-sidebar.tsx
@@ -30,9 +30,9 @@ export function AppSidebar({
 			<SidebarContent>
 				<ActiveReviewCallout currentLang={lang} />
 				<NavMain lang={lang} />
+				<ModeToggle />
 			</SidebarContent>
 			<SidebarFooter>
-				<ModeToggle />
 				<NavUser />
 			</SidebarFooter>
 			<SidebarRail />

--- a/src/components/navs/app-sidebar.tsx
+++ b/src/components/navs/app-sidebar.tsx
@@ -30,7 +30,9 @@ export function AppSidebar({
 			<SidebarContent>
 				<ActiveReviewCallout currentLang={lang} />
 				<NavMain lang={lang} />
-				<ModeToggle />
+				<div className="mt-auto p-2">
+					<ModeToggle />
+				</div>
 			</SidebarContent>
 			<SidebarFooter>
 				<NavUser />

--- a/src/components/navs/nav-main.tsx
+++ b/src/components/navs/nav-main.tsx
@@ -31,7 +31,6 @@ const learnMenu = makeLinks([
 	'/learn',
 	'/learn/browse',
 	'/learn/browse/charts',
-	'/learn/contributions',
 	'/learn/add-deck',
 ])
 const learnMenuPublic = makeLinks([

--- a/src/components/navs/nav-user.tsx
+++ b/src/components/navs/nav-user.tsx
@@ -26,6 +26,7 @@ import { clearUser } from '@/lib/collections/clear-user'
 
 const data = makeLinks([
 	'/profile',
+	'/learn/contributions',
 	'/profile/change-email',
 	'/profile/change-password',
 ])

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -391,7 +391,7 @@ const SidebarContent = ({
 			data-slot="sidebar-content"
 			data-sidebar="content"
 			className={cn(
-				'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+				'flex min-h-0 flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto [scrollbar-width:thin] group-data-[collapsible=icon]:overflow-hidden',
 				className
 			)}
 			{...props}


### PR DESCRIPTION
## Summary
This PR reorganizes the sidebar layout and navigation structure to improve information hierarchy and user experience.

## Key Changes
- **Sidebar Layout**: Moved `ModeToggle` component from `SidebarFooter` to `SidebarContent`, positioning it above the footer section for better visibility
- **Navigation Structure**: Relocated the `/learn/contributions` link from the main learn menu to the user profile menu, making it more contextually relevant to authenticated users
- **Menu Updates**:
  - Removed `/learn/contributions` from the public-facing learn menu in `nav-main.tsx`
  - Added `/learn/contributions` to the user profile menu in `nav-user.tsx`

## Implementation Details
The theme toggle is now more prominently placed in the main content area of the sidebar rather than hidden in the footer, improving discoverability. The contributions link is now grouped with other user-specific actions in the profile menu, creating a clearer separation between public learning resources and user-specific features.

https://claude.ai/code/session_01Uya2pCz7eCxrB6CdUA9aDf