### PR TITLE
Extract pure review utilities to separate module

### DIFF
--- a/src/features/review/hooks.ts
+++ b/src/features/review/hooks.ts
@@ -3,12 +3,11 @@ import supabase from '@/lib/supabase-client'
 import type { UseLiveQueryResult, uuid } from '@/types/main'
 import { toastError } from '@/components/ui/sonner'
 import {
-	getIndexOfNextAgainCard,
-	getIndexOfNextUnreviewedCard,
 	useCardIndex,
-	useNextValid,
 	useReviewActions,
+	useReviewDayString,
 	useReviewLang,
+	useReviewStage,
 } from './store'
 import { PostgrestError } from '@supabase/supabase-js'
 import { cardReviewsCollection, reviewDaysCollection } from './collections'
@@ -22,20 +21,17 @@ import {
 } from './schemas'
 import { calculateFSRS, type Score } from './fsrs'
 import type { CardDirectionType } from '@/features/deck/schemas'
-import { toManifestEntry, type ManifestEntry } from './manifest'
+import type { ManifestEntry } from './manifest'
+import {
+	buildReviewsMap,
+	getIndexOfNextAgainCard,
+	getIndexOfNextUnreviewedCard,
+	type ReviewsMap,
+	type ReviewStages,
+} from './review-utils'
 
-/*
-	null: not yet initialised (zustand store only)
-	1. doing the first review
-	2. going back for unreviewed
-	3. skip unreviewed and see screen asking to re-review
-	4. doing re-reviews
-	5. skip re-reviews and end
-*/
-export type ReviewStages = null | 1 | 2 | 3 | 4 | 5
-export type ReviewsMap = {
-	[key: string]: CardReviewType
-}
+export type { ReviewStages, ReviewsMap }
+export { buildReviewsMap }
 
 interface PostReviewInput {
 	phrase_id: uuid
@@ -160,14 +156,16 @@ function mapToStats(
 	}
 }
 
-/** Build a ReviewsMap keyed by manifest entry (phrase_id:direction) */
-export function buildReviewsMap(reviews: Array<CardReviewType>): ReviewsMap {
-	const map: ReviewsMap = {}
-	// Iterate in chronological order so the last (newest) review wins per key
-	for (const r of reviews) {
-		map[toManifestEntry(r.phrase_id, r.direction)] = r
-	}
-	return map
+export function useNextValid(): number {
+	const currentCardIndex = useCardIndex()
+	const lang = useReviewLang()
+	const day_session = useReviewDayString()
+	const stage = useReviewStage()
+	const { data: reviewsData } = useReviewsToday(lang, day_session)
+	const { manifest, reviewsMap } = reviewsData
+	return (stage ?? 0) < 3 ?
+			getIndexOfNextUnreviewedCard(manifest!, reviewsMap, currentCardIndex)
+		:	getIndexOfNextAgainCard(manifest!, reviewsMap, currentCardIndex)
 }
 
 export function useReviewsToday(lang: string, day_session: string) {

--- a/src/features/review/index.ts
+++ b/src/features/review/index.ts
@@ -12,9 +12,18 @@ export {
 // Collections
 export { cardReviewsCollection, reviewDaysCollection } from './collections'
 
-// Hooks
+// Pure utilities (no supabase dependency)
 export {
 	buildReviewsMap,
+	getIndexOfNextUnreviewedCard,
+	getIndexOfNextAgainCard,
+	type ReviewStages,
+	type ReviewsMap,
+} from './review-utils'
+
+// Hooks
+export {
+	useNextValid,
 	useReviewsToday,
 	useReviewsTodayStats,
 	useReviewDay,
@@ -24,8 +33,6 @@ export {
 	useOneCardReviews,
 	useUpdateReviewStage,
 	useActiveReviewRemaining,
-	type ReviewStages,
-	type ReviewsMap,
 	type ReviewStats,
 } from './hooks'
 
@@ -34,9 +41,6 @@ export {
 	useReviewActions,
 	useReviewLang,
 	useCardIndex,
-	useNextValid,
-	getIndexOfNextUnreviewedCard,
-	getIndexOfNextAgainCard,
 	useReviewStore,
 } from './store'
 

--- a/src/features/review/review-map.test.ts
+++ b/src/features/review/review-map.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildReviewsMap } from '@/features/review/hooks'
+import { buildReviewsMap } from '@/features/review/review-utils'
 import { toManifestEntry } from '@/features/review/manifest'
 import type { CardReviewType } from '@/features/review/schemas'
 

--- a/src/features/review/review-utils.ts
+++ b/src/features/review/review-utils.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure functions and types for the review system.
+ * This module has NO runtime dependencies on supabase or React hooks,
+ * so it can be safely imported in unit tests.
+ */
+
+import type { CardReviewType } from './schemas'
+import { toManifestEntry } from './manifest'
+
+/*
+	null: not yet initialised (zustand store only)
+	1. doing the first review
+	2. going back for unreviewed
+	3. skip unreviewed and see screen asking to re-review
+	4. doing re-reviews
+	5. skip re-reviews and end
+*/
+export type ReviewStages = null | 1 | 2 | 3 | 4 | 5
+export type ReviewsMap = {
+	[key: string]: CardReviewType
+}
+
+/** Build a ReviewsMap keyed by manifest entry (phrase_id:direction) */
+export function buildReviewsMap(reviews: Array<CardReviewType>): ReviewsMap {
+	const map: ReviewsMap = {}
+	// Iterate in chronological order so the last (newest) review wins per key
+	for (const r of reviews) {
+		map[toManifestEntry(r.phrase_id, r.direction)] = r
+	}
+	return map
+}
+
+export function getIndexOfNextUnreviewedCard(
+	manifest: Array<string>,
+	reviewsMap: ReviewsMap,
+	currentCardIndex: number
+) {
+	const index = manifest.findIndex((pid, i) => {
+		// if we're currently at card 3 of 40, don't even check cards 0-3
+		// but if we're at 40/40 we should check from the start
+		if (currentCardIndex !== manifest.length && i <= currentCardIndex)
+			return false
+		// if the entry is undefined, it means we haven't reviewed this card yet
+		return !reviewsMap[pid]
+	})
+
+	return index !== -1 ? index : manifest.length
+}
+
+export function getIndexOfNextAgainCard(
+	manifest: Array<string>,
+	reviewsMap: ReviewsMap,
+	currentCardIndex: number
+) {
+	const index = manifest.findIndex((_, i) => {
+		// we want first to check state.currentCardIndex + 1
+		const indexChecking = (i + currentCardIndex + 1) % manifest.length
+		return reviewsMap[manifest[indexChecking]]?.score === 1
+	})
+	return index !== -1 ?
+			(index + currentCardIndex + 1) % manifest.length
+		:	manifest.length
+}

--- a/src/features/review/store.test.ts
+++ b/src/features/review/store.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest'
 import {
 	getIndexOfNextUnreviewedCard,
 	getIndexOfNextAgainCard,
-} from '@/features/review/store'
-import type { ReviewsMap } from '@/features/review/hooks'
+	type ReviewsMap,
+} from '@/features/review/review-utils'
 import type { CardReviewType } from '@/features/review/schemas'
 import type { ManifestEntry } from '@/features/review/manifest'
 

--- a/src/features/review/store.ts
+++ b/src/features/review/store.ts
@@ -3,7 +3,7 @@ import { createStore } from 'zustand'
 import { useStore } from 'zustand'
 import { devtools, persist } from 'zustand/middleware'
 
-import { type ReviewsMap, type ReviewStages, useReviewsToday } from './hooks'
+import type { ReviewStages } from './review-utils'
 import type { ManifestEntry } from './manifest'
 
 const DEFAULT_PROPS = {
@@ -125,50 +125,6 @@ export function useReviewStore<T>(selector: (state: ReviewState) => T): T {
 	const store = useContext(ReviewStoreContext)
 	if (!store) throw new Error('Missing ReviewStoreContext in the tree')
 	return useStore(store, selector)
-}
-
-export function useNextValid(): number {
-	const currentCardIndex = useCardIndex()
-	const lang = useReviewLang()
-	const day_session = useReviewDayString()
-	const stage = useReviewStage()
-	const { data: reviewsData } = useReviewsToday(lang, day_session)
-	const { manifest, reviewsMap } = reviewsData
-	return (stage ?? 0) < 3 ?
-			getIndexOfNextUnreviewedCard(manifest!, reviewsMap, currentCardIndex)
-		:	getIndexOfNextAgainCard(manifest!, reviewsMap, currentCardIndex)
-}
-
-export function getIndexOfNextUnreviewedCard(
-	manifest: Array<string>,
-	reviewsMap: ReviewsMap,
-	currentCardIndex: number
-) {
-	const index = manifest.findIndex((pid, i) => {
-		// if we're currently at card 3 of 40, don't even check cards 0-3
-		// but if we're at 40/40 we should check from the start
-		if (currentCardIndex !== manifest.length && i <= currentCardIndex)
-			return false
-		// if the entry is undefined, it means we haven't reviewed this card yet
-		return !reviewsMap[pid]
-	})
-
-	return index !== -1 ? index : manifest.length
-}
-
-export function getIndexOfNextAgainCard(
-	manifest: Array<string>,
-	reviewsMap: ReviewsMap,
-	currentCardIndex: number
-) {
-	const index = manifest.findIndex((_, i) => {
-		// we want first to check state.currentCardIndex + 1
-		const indexChecking = (i + currentCardIndex + 1) % manifest.length
-		return reviewsMap[manifest[indexChecking]]?.score === 1
-	})
-	return index !== -1 ?
-			(index + currentCardIndex + 1) % manifest.length
-		:	manifest.length
 }
 
 export const useReviewLang = (): string => {

--- a/src/routes/_user/learn/$lang.review.go.tsx
+++ b/src/routes/_user/learn/$lang.review.go.tsx
@@ -4,13 +4,12 @@ import { createFileRoute, Navigate } from '@tanstack/react-router'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import {
 	useCardIndex,
-	useNextValid,
 	useReviewActions,
 	useReviewDayString,
 	useReviewLang,
 	useReviewStage,
 } from '@/features/review/store'
-import { useReviewDay } from '@/features/review/hooks'
+import { useNextValid, useReviewDay } from '@/features/review/hooks'
 import { Loader } from '@/components/ui/loader'
 import { WhenComplete } from '@/components/review/when-review-complete-screen'
 import { ReviewSingleCard } from '@/components/review/review-single-card'


### PR DESCRIPTION
## Summary
Refactored the review system to separate pure utility functions from React hooks and Supabase dependencies. This improves testability and code organization by creating a dependency-free module for core review logic.

## Key Changes
- **New module**: Created `src/features/review/review-utils.ts` containing pure functions and types with no runtime dependencies on Supabase or React hooks
  - Moved `ReviewStages` and `ReviewsMap` types
  - Moved `buildReviewsMap()` function
  - Moved `getIndexOfNextUnreviewedCard()` function
  - Moved `getIndexOfNextAgainCard()` function

- **Updated `hooks.ts`**: 
  - Removed pure utility functions and types (now imported from `review-utils`)
  - Moved `useNextValid()` hook from `store.ts` to `hooks.ts` (where it belongs with other hooks)
  - Re-exported utilities for backward compatibility

- **Updated `store.ts`**: 
  - Removed pure utility functions and `useNextValid()` hook
  - Simplified imports to only use `ReviewStages` type from `review-utils`

- **Updated exports in `index.ts`**: 
  - Organized exports into two sections: pure utilities and hooks
  - Pure utilities now exported from `review-utils`
  - Hooks exported from `hooks.ts`

- **Updated test imports**: 
  - `store.test.ts` now imports utilities from `review-utils`
  - `review-map.test.ts` now imports from `review-utils`
  - Route component imports `useNextValid` from `hooks` instead of `store`

## Implementation Details
- The new `review-utils.ts` module is explicitly documented as having no Supabase or React hook dependencies, making it safe to import in unit tests
- All pure functions maintain their original logic and behavior
- Backward compatibility maintained through re-exports in `hooks.ts`
- Improved code organization with clearer separation of concerns

https://claude.ai/code/session_01SSyvQaw9CD5fU6vUu18bji