### PR TITLE
Add error handling for card collection updates

### DIFF
--- a/src/components/card-pieces/card-status-dropdown.tsx
+++ b/src/components/card-pieces/card-status-dropdown.tsx
@@ -185,23 +185,29 @@ function useCardStatusMutation(phrase: AnyPhrase) {
 			return data
 		},
 		onSuccess: (data, variables) => {
-			if (data[0]) updatePhraseCounts(phrase.card, data[0])
+			try {
+				if (data[0]) updatePhraseCounts(phrase.card, data[0])
 
-			if (phrase.card) {
-				for (const card of data) {
-					cardsCollection.utils.writeUpdate({
-						phrase_id: card.phrase_id,
-						direction: card.direction,
-						status: variables.status,
-					})
+				if (phrase.card) {
+					for (const card of data) {
+						cardsCollection.utils.writeUpdate({
+							phrase_id: card.phrase_id,
+							direction: card.direction,
+							status: variables.status,
+						})
+					}
+				} else {
+					for (const card of data) {
+						cardsCollection.utils.writeInsert(CardMetaSchema.parse(card))
+					}
 				}
-				toastSuccess(`Updated card status to "${data[0].status}"`)
-			} else {
-				for (const card of data) {
-					cardsCollection.utils.writeInsert(CardMetaSchema.parse(card))
-				}
-				toastSuccess('Added this phrase to your deck')
+			} catch (e) {
+				console.error('Card saved but failed to update local collection', e)
 			}
+
+			if (phrase.card)
+				toastSuccess(`Updated card status to "${data[0].status}"`)
+			else toastSuccess('Added this phrase to your deck')
 		},
 		onError: (error) => {
 			if (phrase.card) toastError('There was an error updating this card')

--- a/src/components/card-pieces/card-status-dropdown.tsx
+++ b/src/components/card-pieces/card-status-dropdown.tsx
@@ -203,6 +203,10 @@ function useCardStatusMutation(phrase: AnyPhrase) {
 				}
 			} catch (e) {
 				console.error('Card saved but failed to update local collection', e)
+				toastError(
+					'Card saved, but your app may be out of date — try refreshing'
+				)
+				return
 			}
 
 			if (phrase.card)


### PR DESCRIPTION
## Summary
Added error handling and improved user feedback for card collection updates in the card status mutation hook. The changes wrap the local collection update logic in a try-catch block to gracefully handle failures while still preserving the server-side changes.

## Key Changes
- Wrapped card collection update logic in a try-catch block to handle potential errors during `writeUpdate` and `writeInsert` operations
- Added user-facing error toast when local collection updates fail, informing users to refresh if needed
- Added console error logging for debugging failed collection updates
- Moved success toast messages outside the try-catch block to only show after all operations complete successfully
- Improved code organization by separating error handling from success messaging

## Implementation Details
- When a card status update succeeds on the server but fails locally, users now receive a helpful message suggesting they refresh their app rather than experiencing a silent failure
- The error handling prevents the success toast from displaying if the local collection update fails, avoiding misleading feedback
- Server-side changes are preserved even if local cache updates fail, maintaining data consistency

https://claude.ai/code/session_01CV4wNLAyw9Pb3vHxeMxCBU