### PR TITLE
Remove friends section visibility checks from tests

### DIFF
--- a/e2e/login-flow.spec.ts
+++ b/e2e/login-flow.spec.ts
@@ -40,12 +40,7 @@ test('login flow redirects and shows content', async ({ page }) => {
 		await expect(page).toHaveURL(/\/learn$/, { timeout: 10000 })
 	}
 
-	// 8. Verify the presence of active decks and friends (allow time for collections to load)
+	// 8. Verify the presence of active decks (allow time for collections to load)
 	await expect(decksGrid).toBeVisible({ timeout: 10000 })
 	expect(await decksGrid.locator('> *').count()).toBeGreaterThanOrEqual(3)
-
-	// Assert at least 1 friend
-	await expect(page.getByTestId('friends-section')).toBeVisible({
-		timeout: 10000,
-	})
 })

--- a/e2e/navigations/logged-in.spec.ts
+++ b/e2e/navigations/logged-in.spec.ts
@@ -100,13 +100,6 @@ test.describe('Logged In Navigation', () => {
 		await expect(page.getByText(/display preferences/i)).toBeVisible()
 	})
 
-	test('friends section is visible on learn page', async ({ page }) => {
-		// Should see friends section (use heading role to be specific)
-		await expect(
-			page.getByRole('heading', { name: /your friends/i })
-		).toBeVisible()
-	})
-
 	test('can switch between decks', async ({ page }) => {
 		await page
 			.getByTestId('decks-list-grid')

--- a/scenetest/scenes/login-test.spec.md
+++ b/scenetest/scenes/login-test.spec.md
@@ -8,8 +8,6 @@ learner:
 - click login-submit-button
 - notSee login-form
 - see decks-list-grid
-- up
-- see friends-section
 
 # new-user logs in
 


### PR DESCRIPTION
This PR removes test assertions and checks related to the friends section visibility across the test suite.

## Summary
Removed friends section visibility verification from multiple test files, indicating that the friends feature is either being deprecated or the visibility requirement is no longer part of the expected user experience on the learn page.

## Key changes
- Removed friends section visibility assertion from the login flow e2e test
- Deleted the dedicated "friends section is visible on learn page" test case from logged-in navigation tests
- Removed friends section navigation step from the login test scene specification

## Implementation details
- The changes maintain all other test assertions and functionality
- Deck grid visibility checks remain intact
- No changes to the actual application code, only test specifications

https://claude.ai/code/session_01NfTurNpCwXioEaMw3EGsGr