### PR TITLE
Move search button from app nav to navbar

### DIFF
--- a/e2e/navigations/deck-workflows.spec.ts
+++ b/e2e/navigations/deck-workflows.spec.ts
@@ -90,7 +90,7 @@ test.describe('Deck Workflow Navigation', () => {
 		await expect(page).toHaveURL(new RegExp(`/learn/${TEST_LANG}`))
 
 		// Click search icon button in nav
-		await page.getByTestId('appnav-search-button').click()
+		await page.getByTestId('navbar-search-button').click()
 
 		// Search overlay modal should be visible
 		await expect(page.getByTestId('browse-search-overlay')).toBeVisible()
@@ -206,7 +206,7 @@ test.describe('Deck Workflow Navigation', () => {
 		await expect(page).toHaveURL(new RegExp(`/learn/${TEST_LANG}`))
 
 		// Open search modal using icon button
-		await page.getByTestId('appnav-search-button').click()
+		await page.getByTestId('navbar-search-button').click()
 		await expect(page.getByTestId('browse-search-overlay')).toBeVisible()
 
 		// Close search modal

--- a/e2e/navigations/logged-in.spec.ts
+++ b/e2e/navigations/logged-in.spec.ts
@@ -136,7 +136,7 @@ test.describe('Logged In Navigation', () => {
 			.click()
 
 		// Click search icon button in the app nav
-		await page.getByTestId('appnav-search-button').click()
+		await page.getByTestId('navbar-search-button').click()
 
 		// Search overlay modal should be visible
 		await expect(page.getByTestId('browse-search-overlay')).toBeVisible()
@@ -149,7 +149,7 @@ test.describe('Logged In Navigation', () => {
 			.click()
 
 		// Open search modal
-		await page.getByTestId('appnav-search-button').click()
+		await page.getByTestId('navbar-search-button').click()
 		await expect(page.getByTestId('browse-search-overlay')).toBeVisible()
 
 		// Find search input inside the modal

--- a/scenetest/scenes/friends.spec.md
+++ b/scenetest/scenes/friends.spec.md
@@ -5,7 +5,7 @@ learner:
 - login
 - openTo /friends/chats
 - see chats-page
-- click appnav-search-button
+- click navbar-search-button
 - see friend-search-overlay
 - see friend-search-input
 
@@ -16,7 +16,7 @@ learner:
 - login
 - openTo /friends/chats
 - see chats-page
-- click appnav-search-button
+- click navbar-search-button
 - see friend-search-overlay
 - typeInto friend-search-input Lex
 - see friend-search-results
@@ -28,7 +28,7 @@ learner:
 - login
 - openTo /friends/chats
 - see chats-page
-- click appnav-search-button
+- click navbar-search-button
 - see friend-search-overlay
 - click close-dialog-button
 - notSee friend-search-overlay

--- a/scenetest/scenes/learn.spec.md
+++ b/scenetest/scenes/learn.spec.md
@@ -54,7 +54,7 @@ learner:
 
 - login
 - go-to-deck
-- click appnav-search-button
+- click navbar-search-button
 - up
 - see browse-search-overlay
 - typeInto browse-search-input tea

--- a/src/components/navs/app-nav.tsx
+++ b/src/components/navs/app-nav.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
-import { Link, useMatches, useRouter } from '@tanstack/react-router'
-import { MoreVertical, Search } from 'lucide-react'
+import { Link, useMatches } from '@tanstack/react-router'
+import { MoreVertical } from 'lucide-react'
 import { useIntersectionObserver } from '@/hooks/use-debounce'
 
 import {
@@ -42,11 +42,6 @@ export function AppNav() {
 	)
 	const contextMenu = (contextMenuMatch?.context as MyRouterContext)
 		?.contextMenu
-	const searchActionMatch = matches.findLast(
-		(m) => (m.context as MyRouterContext)?.searchAction
-	)
-	const searchAction = (searchActionMatch?.context as MyRouterContext)
-		?.searchAction
 	const links = useLinks(appnav)
 	const [ref, entry] = useIntersectionObserver({
 		threshold: 0,
@@ -89,30 +84,9 @@ export function AppNav() {
 						</NavigationMenuList>
 					</NavigationMenu>
 				</div>
-				{searchAction && <SearchButton />}
 				<ContextMenu contextMenu={contextMenu} />
 			</div>
 		</>
-	)
-}
-
-function SearchButton() {
-	const router = useRouter()
-	return (
-		<Button
-			variant="ghost"
-			size="icon"
-			className="me-2"
-			data-testid="appnav-search-button"
-			onClick={() => {
-				const url = new URL(window.location.href)
-				url.searchParams.set('search', 'true')
-				void router.navigate({ to: url.pathname + url.search, replace: true })
-			}}
-		>
-			<Search />
-			<span className="sr-only">Search</span>
-		</Button>
 	)
 }
 

--- a/src/components/navs/navbar.tsx
+++ b/src/components/navs/navbar.tsx
@@ -1,5 +1,5 @@
 import { useEffectEvent } from 'react'
-import { ChevronLeft } from 'lucide-react'
+import { ChevronLeft, Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
 import { useNavigate, useRouter, useMatches } from '@tanstack/react-router'
@@ -13,6 +13,9 @@ export default function Navbar() {
 	const focusMode = matches.some(
 		(m) => (m.context as MyRouterContext)?.focusMode
 	)
+	const hasSearchAction = matches.some(
+		(m) => (m.context as MyRouterContext)?.searchAction
+	)
 
 	return (
 		<nav
@@ -23,6 +26,7 @@ export default function Navbar() {
 				<Title />
 			</div>
 			<div className="flex items-center gap-2">
+				{!focusMode && hasSearchAction && <NavSearchButton />}
 				{!focusMode && <NotificationBell />}
 				<SidebarTrigger />
 			</div>
@@ -76,5 +80,24 @@ function Title() {
 				</div>
 			</div>
 		</div>
+	)
+}
+
+function NavSearchButton() {
+	const router = useRouter()
+	return (
+		<Button
+			variant="ghost"
+			size="icon"
+			data-testid="navbar-search-button"
+			onClick={() => {
+				const url = new URL(window.location.href)
+				url.searchParams.set('search', 'true')
+				void router.navigate({ to: url.pathname + url.search, replace: true })
+			}}
+		>
+			<Search className="h-5 w-5" />
+			<span className="sr-only">Search</span>
+		</Button>
 	)
 }

--- a/src/routes/_user/friends/-chats-sidebar.tsx
+++ b/src/routes/_user/friends/-chats-sidebar.tsx
@@ -85,7 +85,7 @@ function ChatEntryItem({ entry }: { entry: ChatEntry }) {
 						<div className="bg-primary h-2.5 w-2.5 rounded-full" />
 					:	null}
 				</div>
-				{hasPendingRequest && !previewMessage ?
+				{hasPendingRequest ?
 					<p className="text-muted-foreground line-clamp-1 text-xs">
 						<UserPlus className="me-1 inline size-3" />
 						Wants to connect • {ago(mostRecentActivity)}


### PR DESCRIPTION
## Summary
Relocates the search button from the app navigation component to the navbar component for better UX and layout organization.

## Key Changes
- **Removed search functionality from AppNav**: Deleted the `SearchButton` component and related search action detection logic from `app-nav.tsx`
- **Added search button to Navbar**: Implemented `NavSearchButton` component in `navbar.tsx` with the same search functionality, now conditionally displayed when `hasSearchAction` is available and not in focus mode
- **Updated imports**: Removed unused `useRouter` and `Search` icon from app-nav; added `Search` icon to navbar
- **Updated test identifiers**: Changed test ID from `appnav-search-button` to `navbar-search-button` across all test files and scene tests
- **Minor bug fix**: Fixed conditional logic in `chats-sidebar.tsx` to remove unnecessary `!previewMessage` check alongside `hasPendingRequest`

## Implementation Details
- The search button now respects the `focusMode` state and only displays when not in focus mode
- Search action detection uses the same router context matching pattern, now checking `hasSearchAction` instead of storing the full `searchAction` object
- The button maintains the same functionality: setting a `search=true` query parameter and navigating to the current path with the updated search params

https://claude.ai/code/session_016ubaT4LckUfoKi49y7gVJx