### PR TITLE
Add QR code to friend invite page and convert to lazy route

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"cmdk": "1.1.1",
 		"dayjs": "^1.11.19",
 		"lucide-react": "^0.544.0",
+		"qrcode.react": "^4.2.0",
 		"react": "^19.2.3",
 		"react-dom": "^19.2.3",
 		"react-hook-form": "^7.68.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       lucide-react:
         specifier: ^0.544.0
         version: 0.544.0(react@19.2.3)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.3)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -2747,6 +2750,11 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   railroad-diagrams@1.0.0:
     resolution: {integrity: sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==}
@@ -5890,6 +5898,10 @@ snapshots:
   property-information@7.1.0: {}
 
   punycode@2.3.1: {}
+
+  qrcode.react@4.2.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   railroad-diagrams@1.0.0: {}
 

--- a/scenetest/TEST_IDS.md
+++ b/scenetest/TEST_IDS.md
@@ -198,6 +198,14 @@ natural wrapper element to label.
 | `chat-messages-container` | data-testid | Chat page          | Messages container        |
 | `chat-message-bubble`     | data-testid | Chat page          | Individual message bubble |
 
+## Friends / Invite
+
+| Selector             | Attribute   | Component/Location | Description                                  |
+| -------------------- | ----------- | ------------------ | -------------------------------------------- |
+| `invite-friend-page` | data-testid | Invite route       | Invite page container                        |
+| `invite-qr-card`     | data-testid | Invite page        | Card wrapping the QR code section            |
+| `invite-qr-code`     | data-testid | Invite page        | QR code element encoding the signup referral |
+
 ## Review
 
 | Selector               | Attribute   | Component/Location | Description             |

--- a/scenetest/scenes/invite.spec.md
+++ b/scenetest/scenes/invite.spec.md
@@ -1,0 +1,9 @@
+# learner sees QR code on invite page
+
+learner:
+
+- login
+- openTo /friends/invite
+- see invite-friend-page
+- see invite-qr-card
+- see invite-qr-code

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -37,7 +37,6 @@ import { Route as UserLearnBrowseRouteImport } from './routes/_user/learn/browse
 import { Route as UserLearnArchivedRouteImport } from './routes/_user/learn/archived'
 import { Route as UserLearnAddDeckRouteImport } from './routes/_user/learn/add-deck'
 import { Route as UserLearnLangRouteImport } from './routes/_user/learn/$lang'
-import { Route as UserFriendsInviteRouteImport } from './routes/_user/friends/invite'
 import { Route as UserFriendsChatsRouteImport } from './routes/_user/friends/chats'
 import { Route as UserFriendsUidRouteImport } from './routes/_user/friends/$uid'
 import { Route as UserLearnBrowseIndexRouteImport } from './routes/_user/learn/browse.index'
@@ -71,6 +70,9 @@ const RequestRemovalLazyRouteImport = createFileRoute('/request-removal')()
 const PrivacyPolicyLazyRouteImport = createFileRoute('/privacy-policy')()
 const MicrocopyLazyRouteImport = createFileRoute('/microcopy')()
 const ComponentsLazyRouteImport = createFileRoute('/components')()
+const UserFriendsInviteLazyRouteImport = createFileRoute(
+  '/_user/friends/invite',
+)()
 
 const ThemesLazyRoute = ThemesLazyRouteImport.update({
   id: '/themes',
@@ -189,6 +191,13 @@ const UserFriendsIndexRoute = UserFriendsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => UserFriendsRoute,
 } as any)
+const UserFriendsInviteLazyRoute = UserFriendsInviteLazyRouteImport.update({
+  id: '/invite',
+  path: '/invite',
+  getParentRoute: () => UserFriendsRoute,
+} as any).lazy(() =>
+  import('./routes/_user/friends/invite.lazy').then((d) => d.Route),
+)
 const UserProfileChangePasswordRoute =
   UserProfileChangePasswordRouteImport.update({
     id: '/change-password',
@@ -230,11 +239,6 @@ const UserLearnLangRoute = UserLearnLangRouteImport.update({
   id: '/$lang',
   path: '/$lang',
   getParentRoute: () => UserLearnRoute,
-} as any)
-const UserFriendsInviteRoute = UserFriendsInviteRouteImport.update({
-  id: '/invite',
-  path: '/invite',
-  getParentRoute: () => UserFriendsRoute,
 } as any)
 const UserFriendsChatsRoute = UserFriendsChatsRouteImport.update({
   id: '/chats',
@@ -404,7 +408,6 @@ export interface FileRoutesByFullPath {
   '/welcome': typeof UserWelcomeRoute
   '/friends/$uid': typeof UserFriendsUidRoute
   '/friends/chats': typeof UserFriendsChatsRouteWithChildren
-  '/friends/invite': typeof UserFriendsInviteRoute
   '/learn/$lang': typeof UserLearnLangRouteWithChildren
   '/learn/add-deck': typeof UserLearnAddDeckRoute
   '/learn/archived': typeof UserLearnArchivedRoute
@@ -413,6 +416,7 @@ export interface FileRoutesByFullPath {
   '/profile/change-email': typeof UserProfileChangeEmailRoute
   '/profile/change-email-confirm': typeof UserProfileChangeEmailConfirmRoute
   '/profile/change-password': typeof UserProfileChangePasswordRoute
+  '/friends/invite': typeof UserFriendsInviteLazyRoute
   '/friends/': typeof UserFriendsIndexRoute
   '/learn/': typeof UserLearnIndexRoute
   '/profile/': typeof UserProfileIndexRoute
@@ -459,13 +463,13 @@ export interface FileRoutesByTo {
   '/search': typeof UserSearchRoute
   '/welcome': typeof UserWelcomeRoute
   '/friends/$uid': typeof UserFriendsUidRoute
-  '/friends/invite': typeof UserFriendsInviteRoute
   '/learn/add-deck': typeof UserLearnAddDeckRoute
   '/learn/archived': typeof UserLearnArchivedRoute
   '/learn/contributions': typeof UserLearnContributionsRoute
   '/profile/change-email': typeof UserProfileChangeEmailRoute
   '/profile/change-email-confirm': typeof UserProfileChangeEmailConfirmRoute
   '/profile/change-password': typeof UserProfileChangePasswordRoute
+  '/friends/invite': typeof UserFriendsInviteLazyRoute
   '/friends': typeof UserFriendsIndexRoute
   '/learn': typeof UserLearnIndexRoute
   '/profile': typeof UserProfileIndexRoute
@@ -517,7 +521,6 @@ export interface FileRoutesById {
   '/_user/welcome': typeof UserWelcomeRoute
   '/_user/friends/$uid': typeof UserFriendsUidRoute
   '/_user/friends/chats': typeof UserFriendsChatsRouteWithChildren
-  '/_user/friends/invite': typeof UserFriendsInviteRoute
   '/_user/learn/$lang': typeof UserLearnLangRouteWithChildren
   '/_user/learn/add-deck': typeof UserLearnAddDeckRoute
   '/_user/learn/archived': typeof UserLearnArchivedRoute
@@ -526,6 +529,7 @@ export interface FileRoutesById {
   '/_user/profile/change-email': typeof UserProfileChangeEmailRoute
   '/_user/profile/change-email-confirm': typeof UserProfileChangeEmailConfirmRoute
   '/_user/profile/change-password': typeof UserProfileChangePasswordRoute
+  '/_user/friends/invite': typeof UserFriendsInviteLazyRoute
   '/_user/friends/': typeof UserFriendsIndexRoute
   '/_user/learn/': typeof UserLearnIndexRoute
   '/_user/profile/': typeof UserProfileIndexRoute
@@ -578,7 +582,6 @@ export interface FileRouteTypes {
     | '/welcome'
     | '/friends/$uid'
     | '/friends/chats'
-    | '/friends/invite'
     | '/learn/$lang'
     | '/learn/add-deck'
     | '/learn/archived'
@@ -587,6 +590,7 @@ export interface FileRouteTypes {
     | '/profile/change-email'
     | '/profile/change-email-confirm'
     | '/profile/change-password'
+    | '/friends/invite'
     | '/friends/'
     | '/learn/'
     | '/profile/'
@@ -633,13 +637,13 @@ export interface FileRouteTypes {
     | '/search'
     | '/welcome'
     | '/friends/$uid'
-    | '/friends/invite'
     | '/learn/add-deck'
     | '/learn/archived'
     | '/learn/contributions'
     | '/profile/change-email'
     | '/profile/change-email-confirm'
     | '/profile/change-password'
+    | '/friends/invite'
     | '/friends'
     | '/learn'
     | '/profile'
@@ -690,7 +694,6 @@ export interface FileRouteTypes {
     | '/_user/welcome'
     | '/_user/friends/$uid'
     | '/_user/friends/chats'
-    | '/_user/friends/invite'
     | '/_user/learn/$lang'
     | '/_user/learn/add-deck'
     | '/_user/learn/archived'
@@ -699,6 +702,7 @@ export interface FileRouteTypes {
     | '/_user/profile/change-email'
     | '/_user/profile/change-email-confirm'
     | '/_user/profile/change-password'
+    | '/_user/friends/invite'
     | '/_user/friends/'
     | '/_user/learn/'
     | '/_user/profile/'
@@ -903,6 +907,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UserFriendsIndexRouteImport
       parentRoute: typeof UserFriendsRoute
     }
+    '/_user/friends/invite': {
+      id: '/_user/friends/invite'
+      path: '/invite'
+      fullPath: '/friends/invite'
+      preLoaderRoute: typeof UserFriendsInviteLazyRouteImport
+      parentRoute: typeof UserFriendsRoute
+    }
     '/_user/profile/change-password': {
       id: '/_user/profile/change-password'
       path: '/change-password'
@@ -958,13 +969,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/learn/$lang'
       preLoaderRoute: typeof UserLearnLangRouteImport
       parentRoute: typeof UserLearnRoute
-    }
-    '/_user/friends/invite': {
-      id: '/_user/friends/invite'
-      path: '/invite'
-      fullPath: '/friends/invite'
-      preLoaderRoute: typeof UserFriendsInviteRouteImport
-      parentRoute: typeof UserFriendsRoute
     }
     '/_user/friends/chats': {
       id: '/_user/friends/chats'
@@ -1205,14 +1209,14 @@ const UserFriendsChatsRouteWithChildren =
 interface UserFriendsRouteChildren {
   UserFriendsUidRoute: typeof UserFriendsUidRoute
   UserFriendsChatsRoute: typeof UserFriendsChatsRouteWithChildren
-  UserFriendsInviteRoute: typeof UserFriendsInviteRoute
+  UserFriendsInviteLazyRoute: typeof UserFriendsInviteLazyRoute
   UserFriendsIndexRoute: typeof UserFriendsIndexRoute
 }
 
 const UserFriendsRouteChildren: UserFriendsRouteChildren = {
   UserFriendsUidRoute: UserFriendsUidRoute,
   UserFriendsChatsRoute: UserFriendsChatsRouteWithChildren,
-  UserFriendsInviteRoute: UserFriendsInviteRoute,
+  UserFriendsInviteLazyRoute: UserFriendsInviteLazyRoute,
   UserFriendsIndexRoute: UserFriendsIndexRoute,
 }
 

--- a/src/routes/_user/friends/invite.lazy.tsx
+++ b/src/routes/_user/friends/invite.lazy.tsx
@@ -34,7 +34,10 @@ function InviteFriendPage() {
 	}
 
 	return (
-		<main className="mx-auto max-w-4xl space-y-12 px-4 py-8 @lg:px-6 @xl:px-8">
+		<main
+			className="mx-auto max-w-4xl space-y-12 px-4 py-8 @lg:px-6 @xl:px-8"
+			data-testid="invite-friend-page"
+		>
 			<div className="text-center">
 				<div className="bg-1-mlo-primary text-primary mb-6 inline-flex items-center space-x-2 rounded-full px-4 py-2 text-sm font-medium">
 					<Sparkles className="h-4 w-4" />

--- a/src/routes/_user/friends/invite.lazy.tsx
+++ b/src/routes/_user/friends/invite.lazy.tsx
@@ -105,37 +105,6 @@ function InviteFriendPage() {
 				:	null
 			}
 
-			{/* QR Code */}
-			<Card className="border-border/50 shadow-sm" data-testid="invite-qr-card">
-				<CardContent className="flex flex-col items-center gap-6 p-8 @lg:flex-row @lg:items-center @lg:gap-8">
-					<div
-						className="flex aspect-square items-center justify-center rounded-2xl bg-white p-4 shadow"
-						data-testid="invite-qr-code"
-					>
-						<QRCodeSVG
-							value={signupUrl}
-							size={192}
-							level="M"
-							marginSize={0}
-							aria-label="QR code with invite link"
-						/>
-					</div>
-					<div className="flex-1 space-y-3 text-center @lg:text-start">
-						<div className="bg-1-mlo-accent text-accent-foresoft inline-flex items-center space-x-2 rounded-full px-3 py-1 text-sm font-medium">
-							<QrCode className="h-4 w-4" />
-							<span>Scan to invite</span>
-						</div>
-						<h2 className="text-foreground text-2xl font-bold">
-							Show them in person
-						</h2>
-						<p className="text-muted-foreground text-pretty">
-							Meeting up? Have them point their camera at this QR code to open
-							your invite link and join Sunlo.
-						</p>
-					</div>
-				</CardContent>
-			</Card>
-
 			{/* Sharing Methods */}
 			<Card className="border-border/50 shadow-sm">
 				<CardHeader className="my-0 pt-8 pb-0">
@@ -200,6 +169,37 @@ function InviteFriendPage() {
 								</div>
 							</button>
 						)}
+					</div>
+				</CardContent>
+			</Card>
+
+			{/* QR Code */}
+			<Card className="border-border/50 shadow-sm" data-testid="invite-qr-card">
+				<CardContent className="flex flex-col items-center gap-6 p-8 @lg:flex-row @lg:items-center @lg:gap-8">
+					<div
+						className="flex aspect-square items-center justify-center rounded-2xl bg-white p-4 shadow"
+						data-testid="invite-qr-code"
+					>
+						<QRCodeSVG
+							value={signupUrl}
+							size={192}
+							level="M"
+							marginSize={0}
+							aria-label="QR code with invite link"
+						/>
+					</div>
+					<div className="flex-1 space-y-3 text-center @lg:text-start">
+						<div className="bg-1-mlo-accent text-accent-foresoft inline-flex items-center space-x-2 rounded-full px-3 py-1 text-sm font-medium">
+							<QrCode className="h-4 w-4" />
+							<span>Scan to invite</span>
+						</div>
+						<h2 className="text-foreground text-2xl font-bold">
+							Show them in person
+						</h2>
+						<p className="text-muted-foreground text-pretty">
+							Meeting up? Have them point their camera at this QR code to open
+							your invite link and join Sunlo.
+						</p>
 					</div>
 				</CardContent>
 			</Card>

--- a/src/routes/_user/friends/invite.lazy.tsx
+++ b/src/routes/_user/friends/invite.lazy.tsx
@@ -1,5 +1,13 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { Share, Copy, Mail, MessageSquare, Sparkles } from 'lucide-react'
+import { createLazyFileRoute } from '@tanstack/react-router'
+import {
+	Share,
+	Copy,
+	Mail,
+	MessageSquare,
+	Sparkles,
+	QrCode,
+} from 'lucide-react'
+import { QRCodeSVG } from 'qrcode.react'
 
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { useProfile } from '@/features/profile/hooks'
@@ -7,7 +15,7 @@ import { NativeShareButton } from '@/components/native-share-button'
 import CopyLinkButton from '@/components/copy-link-button'
 import { copyLink } from '@/lib/utils'
 
-export const Route = createFileRoute('/_user/friends/invite')({
+export const Route = createLazyFileRoute('/_user/friends/invite')({
 	component: InviteFriendPage,
 })
 
@@ -93,6 +101,37 @@ function InviteFriendPage() {
 					</div>
 				:	null
 			}
+
+			{/* QR Code */}
+			<Card className="border-border/50 shadow-sm" data-testid="invite-qr-card">
+				<CardContent className="flex flex-col items-center gap-6 p-8 @lg:flex-row @lg:items-center @lg:gap-8">
+					<div
+						className="flex aspect-square items-center justify-center rounded-2xl bg-white p-4 shadow"
+						data-testid="invite-qr-code"
+					>
+						<QRCodeSVG
+							value={signupUrl}
+							size={192}
+							level="M"
+							marginSize={0}
+							aria-label="QR code with invite link"
+						/>
+					</div>
+					<div className="flex-1 space-y-3 text-center @lg:text-start">
+						<div className="bg-1-mlo-accent text-accent-foresoft inline-flex items-center space-x-2 rounded-full px-3 py-1 text-sm font-medium">
+							<QrCode className="h-4 w-4" />
+							<span>Scan to invite</span>
+						</div>
+						<h2 className="text-foreground text-2xl font-bold">
+							Show them in person
+						</h2>
+						<p className="text-muted-foreground text-pretty">
+							Meeting up? Have them point their camera at this QR code to open
+							your invite link and join Sunlo.
+						</p>
+					</div>
+				</CardContent>
+			</Card>
 
 			{/* Sharing Methods */}
 			<Card className="border-border/50 shadow-sm">


### PR DESCRIPTION
## Summary
This PR adds a QR code feature to the friend invite page and converts the route to use lazy loading for better code splitting and performance.

## Key Changes
- **Convert invite route to lazy loading**: Changed from `createFileRoute` to `createLazyFileRoute` in the invite page component and updated route tree configuration to use lazy route loading
- **Add QR code section**: Implemented a new card section on the invite page that displays a QR code encoding the signup referral URL, allowing users to share invites in-person by having others scan the code
- **Add QR code dependency**: Added `qrcode.react` package for QR code generation
- **Add test IDs**: Added `data-testid` attributes to the main container and QR code card for testing purposes
- **Add scene test**: Created a new scene test to verify the QR code section is visible on the invite page

## Implementation Details
- The QR code is generated using `QRCodeSVG` component with a size of 192px and medium error correction level
- The QR code section is displayed in a responsive card layout with the code on the left and descriptive text on the right (on larger screens)
- Updated the route tree generation to properly handle the lazy-loaded invite route
- Added documentation for the new test IDs in `TEST_IDS.md`

https://claude.ai/code/session_01Bvz52MukeQDPTqsKc95xxU