### PR TITLE
Deploy v0.22.0 - 2-Button Review Default & FSRS Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## v0.22 - 2-Button Review Default
+
+_18 April, 2026_
+
+### Changes
+
+- **Default review mode is now 2-buttons** — new profiles get "Try Again / Correct" instead of the 4-button FSRS scale. Existing profiles keep their current setting.
+
+### Database
+
+- `user_profile.review_answer_mode` default changed to `'2-buttons'`.
+
 ## v0.21 - Bidirectional Cards
 
 _9 April, 2026_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Change Log
 
-## v0.22 - 2-Button Review Default
+## v0.22 - 2-Button Review Default & FSRS Fix
 
 _18 April, 2026_
 
 ### Changes
 
 - **Default review mode is now 2-buttons** — new profiles get "Try Again / Correct" instead of the 4-button FSRS scale. Existing profiles keep their current setting.
+
+### Fixes
+
+- **Phase-3 FSRS values corrected** (#544) — re-reviews of "Again" cards were being stamped with fresh initial FSRS values instead of mirroring the same-session phase-1 snapshot. Since phase-3 rows are tracking-only and never feed scheduling, they now copy difficulty/stability/retrievability directly from the phase-1 review. Two data-repair scripts (`pnpm recompute-reviews`, `pnpm reclassify-phase1-duplicates`) are included to correct historical rows.
 
 ### Database
 

--- a/e2e/mutations/reviews.spec.ts
+++ b/e2e/mutations/reviews.spec.ts
@@ -20,6 +20,11 @@ test.describe.serial('Review Mutations', () => {
 	// oxlint-disable-next-line no-empty-pattern
 	test.beforeAll(async ({}, workerInfo) => {
 		const { uid } = getTestUserForProject(workerInfo as unknown as TestInfo)
+		// This suite exercises the hard/easy buttons, so force 4-button mode.
+		await supabase
+			.from('user_profile')
+			.update({ review_answer_mode: '4-buttons' })
+			.eq('uid', uid)
 		const { data: existingSession } = await getReviewSessionState(
 			uid,
 			TEST_LANG,
@@ -33,6 +38,10 @@ test.describe.serial('Review Mutations', () => {
 	test.afterAll(async ({}, workerInfo) => {
 		const { uid } = getTestUserForProject(workerInfo as unknown as TestInfo)
 		await cleanupReviewSession(uid, TEST_LANG, sessionDate)
+		await supabase
+			.from('user_profile')
+			.update({ review_answer_mode: '2-buttons' })
+			.eq('uid', uid)
 	})
 
 	test('0. create daily review session', async ({ page }) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "sunlo-tanstack",
 	"private": false,
-	"version": "0.21.0",
+	"version": "0.22.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite --host",

--- a/scenetest/TEST_IDS.md
+++ b/scenetest/TEST_IDS.md
@@ -251,7 +251,7 @@ natural wrapper element to label.
 | `review-answer-mode-4-buttons`     | data-testid | Radio group        | Option for 4-button mode              |
 | `update-review-answer-mode-button` | data-testid | Deck settings      | Save button for answer mode           |
 | `clear-review-answer-mode-button`  | data-testid | Deck settings      | Clear deck override button            |
-| `rating-again-button`              | data-testid | Review card        | "Again" / "Forgot" button             |
+| `rating-again-button`              | data-testid | Review card        | "Again" / "Try Again" button          |
 | `rating-hard-button`               | data-testid | Review card        | "Hard" button (4-button mode only)    |
 | `rating-good-button`               | data-testid | Review card        | "Good" / "Correct!" button            |
 | `rating-easy-button`               | data-testid | Review card        | "Easy" button (4-button mode only)    |

--- a/scenetest/scenes/display-preferences.spec.md
+++ b/scenetest/scenes/display-preferences.spec.md
@@ -22,7 +22,21 @@ learner:
 - up
 - seeToast toast-success
 
-# learner sets global review answer mode to 2 buttons
+# learner switches review answer mode to 4 buttons
+
+cleanup: supabase.from('user_profile').update({ review_answer_mode: '2-buttons' }).eq('uid', '[learner.key]')
+
+learner:
+
+- login
+- openTo /profile
+- up
+- see display-preferences-page
+- click answer-mode-4-buttons
+- up
+- seeToast toast-success
+
+# learner switches review answer mode to 2 buttons
 
 cleanup: supabase.from('user_profile').update({ review_answer_mode: '4-buttons' }).eq('uid', '[learner.key]')
 

--- a/scenetest/scenes/review-answer-mode.spec.md
+++ b/scenetest/scenes/review-answer-mode.spec.md
@@ -15,8 +15,10 @@ learner:
 - up
 - seeToast toast-success
 
-# learner sees 4-button mode by default during review
+# learner sees 4-button mode when profile opts into 4-buttons
 
+setup: supabase.from('user_profile').update({ review_answer_mode: '4-buttons' }).eq('uid', '[learner.key]')
+cleanup: supabase.from('user_profile').update({ review_answer_mode: '2-buttons' }).eq('uid', '[learner.key]')
 cleanup: supabase.from('user_deck').update({ review_answer_mode: null }).eq('uid', '[learner.key]').eq('lang', '[team.lang]')
 cleanup: supabase.from('user_card_review').delete().eq('uid', '[learner.key]').eq('lang', '[team.lang]')
 cleanup: supabase.from('user_deck_review_state').delete().eq('uid', '[learner.key]').eq('lang', '[team.lang]')
@@ -44,7 +46,7 @@ learner:
 - prev
 - see rating-easy-button
 
-# learner sees 2-button mode with Forgot/Correct labels
+# learner sees 2-button mode with Try Again/Correct labels
 
 setup: supabase.from('user_deck').update({ review_answer_mode: '2-buttons' }).eq('uid', '[learner.key]').eq('lang', '[team.lang]')
 cleanup: supabase.from('user_deck').update({ review_answer_mode: null }).eq('uid', '[learner.key]').eq('lang', '[team.lang]')

--- a/src/components/review/review-single-card.tsx
+++ b/src/components/review/review-single-card.tsx
@@ -256,7 +256,7 @@ export function ReviewSingleCard({
 									:	''
 								)}
 							>
-								Forgot
+								Try Again
 							</Button>
 						</div>
 						<div className="relative">

--- a/src/features/deck/hooks.ts
+++ b/src/features/deck/hooks.ts
@@ -197,7 +197,7 @@ export const usePreferredTranslationLang = (lang: string): string => {
  * Priority:
  * 1. Deck-specific review_answer_mode (if set)
  * 2. Profile's review_answer_mode
- * 3. Fallback to '4-buttons'
+ * 3. Fallback to '2-buttons'
  */
 export const useReviewAnswerMode = (
 	lang: string
@@ -207,5 +207,5 @@ export const useReviewAnswerMode = (
 	if (deck?.review_answer_mode) {
 		return deck.review_answer_mode
 	}
-	return profile?.review_answer_mode ?? '4-buttons'
+	return profile?.review_answer_mode ?? '2-buttons'
 }

--- a/src/features/profile/schemas.test.ts
+++ b/src/features/profile/schemas.test.ts
@@ -106,10 +106,10 @@ describe('MyProfileSchema', () => {
 		expect(result.font_preference).toBeNull()
 	})
 
-	it('defaults review_answer_mode to "4-buttons" when omitted', () => {
+	it('defaults review_answer_mode to "2-buttons" when omitted', () => {
 		const { review_answer_mode: _, ...withoutMode } = validProfile
 		const result = MyProfileSchema.parse(withoutMode)
-		expect(result.review_answer_mode).toBe('4-buttons')
+		expect(result.review_answer_mode).toBe('2-buttons')
 	})
 
 	it('preserves null review_answer_mode when explicitly null', () => {

--- a/src/features/profile/schemas.ts
+++ b/src/features/profile/schemas.ts
@@ -42,7 +42,7 @@ export const MyProfileSchema = PublicProfileSchema.extend({
 	languages_known: LanguagesKnownSchema,
 	updated_at: z.string().nullable(),
 	font_preference: FontPreferenceSchema.nullable().default('default'),
-	review_answer_mode: ReviewAnswerModeSchema.nullable().default('4-buttons'),
+	review_answer_mode: ReviewAnswerModeSchema.nullable().default('2-buttons'),
 	sound_enabled: z.boolean().default(true),
 })
 

--- a/src/routes/_user/learn/$lang.deck-settings.tsx
+++ b/src/routes/_user/learn/$lang.deck-settings.tsx
@@ -527,7 +527,7 @@ const reviewAnswerModeOptions: Array<FancySelectOption> = [
 	{
 		value: '2-buttons',
 		label: 'Show 2 answer choices',
-		description: 'Forgot, Correct!',
+		description: 'Try Again, Correct!',
 		Icon: Columns2,
 	},
 ]
@@ -596,7 +596,7 @@ function ReviewAnswerModeForm({
 }) {
 	const userId = useUserId()
 	const { data: profile } = useProfile()
-	const profileMode = profile?.review_answer_mode ?? '4-buttons'
+	const profileMode = profile?.review_answer_mode ?? '2-buttons'
 	const [selected, setSelected] = useState<string | null>(review_answer_mode)
 
 	const isDirty = selected !== review_answer_mode
@@ -680,7 +680,7 @@ function ReviewAnswerModeForm({
 					:	'Currently using profile default: '}
 					<strong>
 						{profileMode === '2-buttons' ?
-							'2 buttons (Forgot, Correct!)'
+							'2 buttons (Try Again, Correct!)'
 						:	'4 buttons (Again, Hard, Good, Easy)'}
 					</strong>
 				</p>

--- a/src/routes/_user/learn/-deck-card.tsx
+++ b/src/routes/_user/learn/-deck-card.tsx
@@ -1,6 +1,12 @@
 import { Link } from '@tanstack/react-router'
 
-import { Archive, CircleCheck, Rocket, Logs, TableProperties } from 'lucide-react'
+import {
+	Archive,
+	CircleCheck,
+	Rocket,
+	Logs,
+	TableProperties,
+} from 'lucide-react'
 import {
 	Card,
 	CardContent,
@@ -28,7 +34,9 @@ function ReviewButton({ lang }: { lang: string }) {
 			params={{ lang }}
 			aria-label={isDone ? 'Review complete' : 'Start review'}
 		>
-			{isDone ? <CircleCheck /> : <Rocket />}
+			{isDone ?
+				<CircleCheck />
+			:	<Rocket />}
 		</Link>
 	)
 }
@@ -57,8 +65,7 @@ export function DeckCard({ deck }: { deck: DeckMetaType }) {
 								<Archive />
 								Archived
 							</Badge>
-						:	<ReviewButton lang={deck.lang} />
-						}
+						:	<ReviewButton lang={deck.lang} />}
 					</span>
 				</CardHeader>
 

--- a/src/routes/_user/profile/-display-preferences.tsx
+++ b/src/routes/_user/profile/-display-preferences.tsx
@@ -198,7 +198,7 @@ function SoundPreferenceSection({ profile }: { profile: MyProfileType }) {
 }
 
 function ReviewAnswerModeSection({ profile }: { profile: MyProfileType }) {
-	const currentMode = profile.review_answer_mode ?? '4-buttons'
+	const currentMode = profile.review_answer_mode ?? '2-buttons'
 
 	const updateAnswerMode = useMutation({
 		mutationFn: async (review_answer_mode: ReviewAnswerModeType) => {
@@ -279,7 +279,7 @@ function ReviewAnswerModeSection({ profile }: { profile: MyProfileType }) {
 					<div>
 						<span className="block font-medium">Show 2 answer choices</span>
 						<span className="text-muted-foreground text-sm">
-							Forgot, Correct!
+							Try Again, Correct!
 						</span>
 					</div>
 				</button>

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -2199,6 +2199,7 @@ export type Database = {
 					created_at: string | null
 					id: string
 					last_accessed_at: string | null
+					level: number | null
 					metadata: Json | null
 					name: string | null
 					owner: string | null
@@ -2213,6 +2214,7 @@ export type Database = {
 					created_at?: string | null
 					id?: string
 					last_accessed_at?: string | null
+					level?: number | null
 					metadata?: Json | null
 					name?: string | null
 					owner?: string | null
@@ -2227,6 +2229,7 @@ export type Database = {
 					created_at?: string | null
 					id?: string
 					last_accessed_at?: string | null
+					level?: number | null
 					metadata?: Json | null
 					name?: string | null
 					owner?: string | null
@@ -2239,6 +2242,38 @@ export type Database = {
 				Relationships: [
 					{
 						foreignKeyName: 'objects_bucketId_fkey'
+						columns: ['bucket_id']
+						isOneToOne: false
+						referencedRelation: 'buckets'
+						referencedColumns: ['id']
+					},
+				]
+			}
+			prefixes: {
+				Row: {
+					bucket_id: string
+					created_at: string | null
+					level: number
+					name: string
+					updated_at: string | null
+				}
+				Insert: {
+					bucket_id: string
+					created_at?: string | null
+					level?: number
+					name: string
+					updated_at?: string | null
+				}
+				Update: {
+					bucket_id?: string
+					created_at?: string | null
+					level?: number
+					name?: string
+					updated_at?: string | null
+				}
+				Relationships: [
+					{
+						foreignKeyName: 'prefixes_bucketId_fkey'
 						columns: ['bucket_id']
 						isOneToOne: false
 						referencedRelation: 'buckets'
@@ -2393,17 +2428,28 @@ export type Database = {
 			[_ in never]: never
 		}
 		Functions: {
+			add_prefixes: {
+				Args: { _bucket_id: string; _name: string }
+				Returns: undefined
+			}
 			can_insert_object: {
 				Args: { bucketid: string; metadata: Json; name: string; owner: string }
 				Returns: undefined
 			}
+			delete_leaf_prefixes: {
+				Args: { bucket_ids: string[]; names: string[] }
+				Returns: undefined
+			}
+			delete_prefix: {
+				Args: { _bucket_id: string; _name: string }
+				Returns: boolean
+			}
 			extension: { Args: { name: string }; Returns: string }
 			filename: { Args: { name: string }; Returns: string }
 			foldername: { Args: { name: string }; Returns: string[] }
-			get_common_prefix: {
-				Args: { p_delimiter: string; p_key: string; p_prefix: string }
-				Returns: string
-			}
+			get_level: { Args: { name: string }; Returns: number }
+			get_prefix: { Args: { name: string }; Returns: string }
+			get_prefixes: { Args: { name: string }; Returns: string[] }
 			get_size_by_bucket: {
 				Args: never
 				Returns: {
@@ -2428,25 +2474,64 @@ export type Database = {
 			}
 			list_objects_with_delimiter: {
 				Args: {
-					_bucket_id: string
+					bucket_id: string
 					delimiter_param: string
 					max_keys?: number
 					next_token?: string
 					prefix_param: string
-					sort_order?: string
 					start_after?: string
 				}
 				Returns: {
-					created_at: string
 					id: string
-					last_accessed_at: string
 					metadata: Json
 					name: string
 					updated_at: string
 				}[]
 			}
+			lock_top_prefixes: {
+				Args: { bucket_ids: string[]; names: string[] }
+				Returns: undefined
+			}
 			operation: { Args: never; Returns: string }
-			search: {
+			search:
+				| {
+						Args: {
+							bucketname: string
+							levels?: number
+							limits?: number
+							offsets?: number
+							prefix: string
+						}
+						Returns: {
+							created_at: string
+							id: string
+							last_accessed_at: string
+							metadata: Json
+							name: string
+							updated_at: string
+						}[]
+				  }
+				| {
+						Args: {
+							bucketname: string
+							levels?: number
+							limits?: number
+							offsets?: number
+							prefix: string
+							search?: string
+							sortcolumn?: string
+							sortorder?: string
+						}
+						Returns: {
+							created_at: string
+							id: string
+							last_accessed_at: string
+							metadata: Json
+							name: string
+							updated_at: string
+						}[]
+				  }
+			search_legacy_v1: {
 				Args: {
 					bucketname: string
 					levels?: number
@@ -2466,48 +2551,65 @@ export type Database = {
 					updated_at: string
 				}[]
 			}
-			search_by_timestamp: {
+			search_v1_optimised: {
 				Args: {
-					p_bucket_id: string
-					p_level: number
-					p_limit: number
-					p_prefix: string
-					p_sort_column: string
-					p_sort_column_after: string
-					p_sort_order: string
-					p_start_after: string
-				}
-				Returns: {
-					created_at: string
-					id: string
-					key: string
-					last_accessed_at: string
-					metadata: Json
-					name: string
-					updated_at: string
-				}[]
-			}
-			search_v2: {
-				Args: {
-					bucket_name: string
+					bucketname: string
 					levels?: number
 					limits?: number
+					offsets?: number
 					prefix: string
-					sort_column?: string
-					sort_column_after?: string
-					sort_order?: string
-					start_after?: string
+					search?: string
+					sortcolumn?: string
+					sortorder?: string
 				}
 				Returns: {
 					created_at: string
 					id: string
-					key: string
 					last_accessed_at: string
 					metadata: Json
 					name: string
 					updated_at: string
 				}[]
 			}
+			search_v2:
+				| {
+						Args: {
+							bucket_name: string
+							levels?: number
+							limits?: number
+							prefix: string
+							start_after?: string
+						}
+						Returns: {
+							created_at: string
+							id: string
+							key: string
+							metadata: Json
+							name: string
+							updated_at: string
+						}[]
+				  }
+				| {
+						Args: {
+							bucket_name: string
+							levels?: number
+							limits?: number
+							prefix: string
+							sort_column?: string
+							sort_column_after?: string
+							sort_order?: string
+							start_after?: string
+						}
+						Returns: {
+							created_at: string
+							id: string
+							key: string
+							last_accessed_at: string
+							metadata: Json
+							name: string
+							updated_at: string
+						}[]
+				  }
 		}
 		Enums: {
 			buckettype: 'STANDARD' | 'ANALYTICS' | 'VECTOR'

--- a/supabase/migrations/20260418120000_default_review_answer_mode_2_buttons.sql
+++ b/supabase/migrations/20260418120000_default_review_answer_mode_2_buttons.sql
@@ -1,0 +1,4 @@
+-- Switch the default review_answer_mode for new profiles to the 2-button format.
+alter table "public"."user_profile"
+alter column "review_answer_mode"
+set default '2-buttons'::text;

--- a/supabase/schemas/base.sql
+++ b/supabase/schemas/base.sql
@@ -36,8 +36,6 @@ create extension if not exists "pg_net"
 with
 	schema "extensions";
 
-create extension if not exists "pgsodium";
-
 alter schema "public" owner to "postgres";
 
 create extension if not exists "pg_graphql"
@@ -1632,7 +1630,7 @@ create table if not exists "public"."user_profile" (
 	"avatar_path" "text",
 	"languages_known" "jsonb" default '[]'::"jsonb" not null,
 	"font_preference" "text" default 'default'::"text",
-	"review_answer_mode" "text" default '4-buttons'::"text",
+	"review_answer_mode" "text" default '2-buttons'::"text",
 	"sound_enabled" boolean default true not null,
 	constraint "user_profile_font_preference_check" check (
 		(


### PR DESCRIPTION
## v0.22 - 2-Button Review Default & FSRS Fixes

_18 April, 2026_

### Changes

- **Default review mode is now 2-buttons** — new profiles get "Try Again / Correct" instead of the 4-button FSRS scale. Existing profiles keep their current setting.

### Fixes

- **Phase-3 FSRS values corrected** (#544) — re-reviews of "Again" cards were being stamped with fresh initial FSRS values instead of mirroring the same-session phase-1 snapshot. Since phase-3 rows are tracking-only and never feed scheduling, they now copy difficulty/stability/retrievability directly from the phase-1 review. Two data-repair scripts (`pnpm recompute-reviews`, `pnpm reclassify-phase1-duplicates`) are included to correct historical rows.

### Database

- `user_profile.review_answer_mode` default changed to `'2-buttons'`.