### PR TITLE
Rename review types: "forward/reverse" to "recognise/recall"

### DIFF
--- a/src/components/cards/big-phrase-card.tsx
+++ b/src/components/cards/big-phrase-card.tsx
@@ -85,7 +85,7 @@ export function BigPhraseCard({ pid }: { pid: uuid }) {
 								<LangBadge lang={phrase.lang} />
 								{phrase.only_reverse && (
 									<Badge variant="outline" className="gap-1">
-										🧠 Recall only
+										Recall only 🧠
 									</Badge>
 								)}
 							</div>

--- a/src/components/cards/big-phrase-card.tsx
+++ b/src/components/cards/big-phrase-card.tsx
@@ -1,6 +1,7 @@
 import { type CSSProperties, useState } from 'react'
 import { Link, useRouter } from '@tanstack/react-router'
 import {
+	Brain,
 	ChevronsUpDown,
 	MessagesSquare,
 	ListMusic,
@@ -85,7 +86,7 @@ export function BigPhraseCard({ pid }: { pid: uuid }) {
 								<LangBadge lang={phrase.lang} />
 								{phrase.only_reverse && (
 									<Badge variant="outline" className="gap-1">
-										Recall only 🧠
+										Recall only <Brain className="size-3" />
 									</Badge>
 								)}
 							</div>

--- a/src/components/cards/big-phrase-card.tsx
+++ b/src/components/cards/big-phrase-card.tsx
@@ -7,7 +7,6 @@ import {
 	Users,
 	Edit,
 	Trash2,
-	RefreshCcwDot,
 } from 'lucide-react'
 
 import type { uuid } from '@/types/main'
@@ -86,8 +85,7 @@ export function BigPhraseCard({ pid }: { pid: uuid }) {
 								<LangBadge lang={phrase.lang} />
 								{phrase.only_reverse && (
 									<Badge variant="outline" className="gap-1">
-										<RefreshCcwDot className="h-3 w-3" />
-										Recall only
+										🧠 Recall only
 									</Badge>
 								)}
 							</div>

--- a/src/components/cards/big-phrase-card.tsx
+++ b/src/components/cards/big-phrase-card.tsx
@@ -87,7 +87,7 @@ export function BigPhraseCard({ pid }: { pid: uuid }) {
 								{phrase.only_reverse && (
 									<Badge variant="outline" className="gap-1">
 										<RefreshCcwDot className="h-3 w-3" />
-										Reverse only
+										Recall only
 									</Badge>
 								)}
 							</div>

--- a/src/components/phrases/inline-phrase-creator.tsx
+++ b/src/components/phrases/inline-phrase-creator.tsx
@@ -266,7 +266,7 @@ function InlinePhraseForm({
 						htmlFor="inline-only-reverse"
 						className="text-muted-foreground cursor-pointer text-sm font-normal"
 					>
-						Only reverse reviews make sense
+						Only recall reviews make sense
 					</Label>
 				</div>
 

--- a/src/components/review/review-single-card.tsx
+++ b/src/components/review/review-single-card.tsx
@@ -206,7 +206,7 @@ export function ReviewSingleCard({
 						variant="outline"
 						className="absolute top-4 left-4 gap-1 text-xs"
 					>
-						{isReverse ? '🧠 Recall' : '💡 Recognise'}
+						{isReverse ? 'Recall 🧠' : 'Recognise 💡'}
 					</Badge>
 					<div className="pt-16">{questionContent}</div>
 					<Separator />

--- a/src/components/review/review-single-card.tsx
+++ b/src/components/review/review-single-card.tsx
@@ -210,10 +210,10 @@ export function ReviewSingleCard({
 					>
 						{isReverse ?
 							<>
-								<ArrowLeft className="size-3" /> Reverse
+								<ArrowLeft className="size-3" /> Recall
 							</>
 						:	<>
-								Forward <ArrowRight className="size-3" />
+								Recognise <ArrowRight className="size-3" />
 							</>
 						}
 					</Badge>

--- a/src/components/review/review-single-card.tsx
+++ b/src/components/review/review-single-card.tsx
@@ -210,10 +210,10 @@ export function ReviewSingleCard({
 					>
 						{isReverse ?
 							<>
-								<ArrowLeft className="size-3" /> Recall
+								<ArrowLeft className="size-3" /> 🧠 Recall
 							</>
 						:	<>
-								Recognise <ArrowRight className="size-3" />
+								💡 Recognise <ArrowRight className="size-3" />
 							</>
 						}
 					</Badge>

--- a/src/components/review/review-single-card.tsx
+++ b/src/components/review/review-single-card.tsx
@@ -6,6 +6,8 @@ import { useMutation } from '@tanstack/react-query'
 import {
 	BookmarkCheck,
 	BookmarkX,
+	Brain,
+	Lightbulb,
 	MoreVertical,
 	Play,
 	Send,
@@ -206,7 +208,14 @@ export function ReviewSingleCard({
 						variant="outline"
 						className="absolute top-4 left-4 gap-1 text-xs"
 					>
-						{isReverse ? 'Recall 🧠' : 'Recognise 💡'}
+						{isReverse ?
+							<>
+								Recall <Brain className="size-3" />
+							</>
+						:	<>
+								Recognition <Lightbulb className="size-3" />
+							</>
+						}
 					</Badge>
 					<div className="pt-16">{questionContent}</div>
 					<Separator />

--- a/src/components/review/review-single-card.tsx
+++ b/src/components/review/review-single-card.tsx
@@ -4,8 +4,6 @@ import { playReviewSound } from '@/lib/review-sounds'
 import { useSoundEnabled } from '@/features/profile'
 import { useMutation } from '@tanstack/react-query'
 import {
-	ArrowRight,
-	ArrowLeft,
 	BookmarkCheck,
 	BookmarkX,
 	MoreVertical,
@@ -208,14 +206,7 @@ export function ReviewSingleCard({
 						variant="outline"
 						className="absolute top-4 left-4 gap-1 text-xs"
 					>
-						{isReverse ?
-							<>
-								<ArrowLeft className="size-3" /> 🧠 Recall
-							</>
-						:	<>
-								💡 Recognise <ArrowRight className="size-3" />
-							</>
-						}
+						{isReverse ? '🧠 Recall' : '💡 Recognise'}
 					</Badge>
 					<div className="pt-16">{questionContent}</div>
 					<Separator />

--- a/src/routes/_user/learn/$lang.phrases.new.tsx
+++ b/src/routes/_user/learn/$lang.phrases.new.tsx
@@ -344,7 +344,7 @@ function AddPhraseTab() {
 											className={`bg-card rounded-lg border p-3 transition-opacity ${onlyReverse ? 'opacity-40' : ''}`}
 										>
 											<div className="text-muted-foreground mb-2 flex items-center justify-between text-xs font-medium tracking-wide uppercase">
-												<span>💡 Recognise Review</span>
+												<span>Recognise Review 💡</span>
 												{onlyReverse && (
 													<span className="text-muted-foreground text-xs normal-case">
 														(disabled)
@@ -371,7 +371,7 @@ function AddPhraseTab() {
 										{/* Reverse card preview */}
 										<div className="bg-card rounded-lg border p-3">
 											<div className="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
-												🧠 Recall Review
+												Recall Review 🧠
 											</div>
 											<div className="space-y-2">
 												<div className="text-foreground font-medium">

--- a/src/routes/_user/learn/$lang.phrases.new.tsx
+++ b/src/routes/_user/learn/$lang.phrases.new.tsx
@@ -344,7 +344,7 @@ function AddPhraseTab() {
 											className={`bg-card rounded-lg border p-3 transition-opacity ${onlyReverse ? 'opacity-40' : ''}`}
 										>
 											<div className="text-muted-foreground mb-2 flex items-center justify-between text-xs font-medium tracking-wide uppercase">
-												<span>Forward Review</span>
+												<span>Recognise Review</span>
 												{onlyReverse && (
 													<span className="text-muted-foreground text-xs normal-case">
 														(disabled)
@@ -371,7 +371,7 @@ function AddPhraseTab() {
 										{/* Reverse card preview */}
 										<div className="bg-card rounded-lg border p-3">
 											<div className="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
-												Reverse Review
+												Recall Review
 											</div>
 											<div className="space-y-2">
 												<div className="text-foreground font-medium">
@@ -409,7 +409,7 @@ function AddPhraseTab() {
 											htmlFor="only_reverse"
 											className="text-muted-foreground cursor-pointer text-sm font-normal"
 										>
-											Only reverse reviews make sense for this phrase
+											Only recall reviews make sense for this phrase
 										</Label>
 									</div>
 								</div>

--- a/src/routes/_user/learn/$lang.phrases.new.tsx
+++ b/src/routes/_user/learn/$lang.phrases.new.tsx
@@ -344,7 +344,7 @@ function AddPhraseTab() {
 											className={`bg-card rounded-lg border p-3 transition-opacity ${onlyReverse ? 'opacity-40' : ''}`}
 										>
 											<div className="text-muted-foreground mb-2 flex items-center justify-between text-xs font-medium tracking-wide uppercase">
-												<span>Recognise Review</span>
+												<span>💡 Recognise Review</span>
 												{onlyReverse && (
 													<span className="text-muted-foreground text-xs normal-case">
 														(disabled)
@@ -371,7 +371,7 @@ function AddPhraseTab() {
 										{/* Reverse card preview */}
 										<div className="bg-card rounded-lg border p-3">
 											<div className="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
-												Recall Review
+												🧠 Recall Review
 											</div>
 											<div className="space-y-2">
 												<div className="text-foreground font-medium">

--- a/src/routes/_user/learn/$lang.phrases.new.tsx
+++ b/src/routes/_user/learn/$lang.phrases.new.tsx
@@ -6,7 +6,7 @@ import * as z from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
 import { useDebounce } from '@/hooks/use-debounce'
-import { NotebookPen, Search } from 'lucide-react'
+import { Brain, Lightbulb, NotebookPen, Search } from 'lucide-react'
 
 import type { Tables } from '@/types/supabase'
 import type { uuid } from '@/types/main'
@@ -344,7 +344,9 @@ function AddPhraseTab() {
 											className={`bg-card rounded-lg border p-3 transition-opacity ${onlyReverse ? 'opacity-40' : ''}`}
 										>
 											<div className="text-muted-foreground mb-2 flex items-center justify-between text-xs font-medium tracking-wide uppercase">
-												<span>Recognise Review 💡</span>
+												<span className="inline-flex items-center gap-1">
+													Recognition Review <Lightbulb className="size-3" />
+												</span>
 												{onlyReverse && (
 													<span className="text-muted-foreground text-xs normal-case">
 														(disabled)
@@ -370,8 +372,8 @@ function AddPhraseTab() {
 
 										{/* Reverse card preview */}
 										<div className="bg-card rounded-lg border p-3">
-											<div className="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
-												Recall Review 🧠
+											<div className="text-muted-foreground mb-2 inline-flex items-center gap-1 text-xs font-medium tracking-wide uppercase">
+												Recall Review <Brain className="size-3" />
 											</div>
 											<div className="space-y-2">
 												<div className="text-foreground font-medium">

--- a/src/routes/_user/learn/$lang.review.index.tsx
+++ b/src/routes/_user/learn/$lang.review.index.tsx
@@ -11,7 +11,9 @@ import { isDueCard } from '@/features/deck/is-due-card'
 import { phrasesCollection } from '@/features/phrases/collections'
 import {
 	BookOpen,
+	Brain,
 	CalendarClock,
+	Lightbulb,
 	MessageSquare,
 	MessageSquarePlus,
 	Rocket,
@@ -413,14 +415,23 @@ function ReviewPageContent() {
 											<BookOpen />
 											{totalCardsForToday}
 										</p>
-										<p className="text-muted-foreground">
+										<p className="text-muted-foreground inline-flex items-center gap-1">
 											{forwardCount > 0 && reverseCount > 0 ?
 												<>
-													{forwardCount} recognise 💡 · {reverseCount} recall 🧠
+													{forwardCount} recognition{' '}
+													<Lightbulb className="size-3" /> · {reverseCount}{' '}
+													recall <Brain className="size-3" />
 												</>
 											: forwardCount > 0 ?
-												<>{forwardCount} recognise cards 💡</>
-											:	<>{reverseCount} recall cards 🧠</>}
+												<>
+													{forwardCount} recognition cards{' '}
+													<Lightbulb className="size-3" />
+												</>
+											:	<>
+													{reverseCount} recall cards{' '}
+													<Brain className="size-3" />
+												</>
+											}
 										</p>
 									</CardContent>
 								</Card>

--- a/src/routes/_user/learn/$lang.review.index.tsx
+++ b/src/routes/_user/learn/$lang.review.index.tsx
@@ -416,11 +416,11 @@ function ReviewPageContent() {
 										<p className="text-muted-foreground">
 											{forwardCount > 0 && reverseCount > 0 ?
 												<>
-													{forwardCount} → forward · {reverseCount} ← reverse
+													{forwardCount} → recognise · {reverseCount} ← recall
 												</>
 											: forwardCount > 0 ?
-												<>{forwardCount} forward cards</>
-											:	<>{reverseCount} reverse cards</>}
+												<>{forwardCount} recognise cards</>
+											:	<>{reverseCount} recall cards</>}
 										</p>
 									</CardContent>
 								</Card>

--- a/src/routes/_user/learn/$lang.review.index.tsx
+++ b/src/routes/_user/learn/$lang.review.index.tsx
@@ -416,11 +416,11 @@ function ReviewPageContent() {
 										<p className="text-muted-foreground">
 											{forwardCount > 0 && reverseCount > 0 ?
 												<>
-													{forwardCount} → recognise · {reverseCount} ← recall
+													💡 {forwardCount} recognise · 🧠 {reverseCount} recall
 												</>
 											: forwardCount > 0 ?
-												<>{forwardCount} recognise cards</>
-											:	<>{reverseCount} recall cards</>}
+												<>💡 {forwardCount} recognise cards</>
+											:	<>🧠 {reverseCount} recall cards</>}
 										</p>
 									</CardContent>
 								</Card>

--- a/src/routes/_user/learn/$lang.review.index.tsx
+++ b/src/routes/_user/learn/$lang.review.index.tsx
@@ -416,11 +416,11 @@ function ReviewPageContent() {
 										<p className="text-muted-foreground">
 											{forwardCount > 0 && reverseCount > 0 ?
 												<>
-													💡 {forwardCount} recognise · 🧠 {reverseCount} recall
+													{forwardCount} recognise 💡 · {reverseCount} recall 🧠
 												</>
 											: forwardCount > 0 ?
-												<>💡 {forwardCount} recognise cards</>
-											:	<>🧠 {reverseCount} recall cards</>}
+												<>{forwardCount} recognise cards 💡</>
+											:	<>{reverseCount} recall cards 🧠</>}
 										</p>
 									</CardContent>
 								</Card>


### PR DESCRIPTION
## Summary
This PR updates the terminology used throughout the learning interface to replace "forward/reverse" review types with more descriptive terms: "recognise" and "recall".

## Key Changes
- **Review type labels**: Changed "Forward Review" → "Recognise Review" and "Reverse Review" → "Recall Review"
- **Review badges**: Updated badge text in the review card component from "Forward/Reverse" to "Recognise/Recall"
- **Card indicators**: Changed "Reverse only" badge to "Recall only" in phrase cards
- **UI text**: Updated all user-facing text including:
  - Review statistics display (e.g., "forward cards" → "recognise cards")
  - Checkbox labels for review type preferences
  - Inline phrase creator form labels

## Implementation Details
The changes are purely cosmetic/UX improvements that rename the review type terminology across multiple components:
- `src/routes/_user/learn/$lang.phrases.new.tsx` - Phrase creation form
- `src/routes/_user/learn/$lang.review.index.tsx` - Review statistics display
- `src/components/review/review-single-card.tsx` - Review card badges
- `src/components/cards/big-phrase-card.tsx` - Phrase card indicators
- `src/components/phrases/inline-phrase-creator.tsx` - Inline phrase form

This terminology better reflects the cognitive processes involved: "recognise" for identifying the target language from the source, and "recall" for producing the target language from the source.

https://claude.ai/code/session_01FYsmfefQapfpGehtjAN8c1