### PR TITLE
Handle Supabase connection errors gracefully

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -199,7 +199,7 @@ There's no built-in undo. Your options:
 
    ```sql
    truncate user_card_review;
-   
+
    insert into
    	user_card_review
    select

--- a/src/components/auth-context.tsx
+++ b/src/components/auth-context.tsx
@@ -7,7 +7,7 @@ import {
 import type { AuthChangeEvent, Session } from '@supabase/supabase-js'
 
 import type { RolesEnum } from '@/types/main'
-import supabase from '@/lib/supabase-client'
+import supabase, { pingSupabase } from '@/lib/supabase-client'
 import { myProfileCollection } from '@/features/profile/collections'
 import { decksCollection } from '@/features/deck/collections'
 import {
@@ -63,24 +63,31 @@ export function AuthProvider({ children }: PropsWithChildren) {
 	)
 
 	useLayoutEffect(() => {
-		void supabase.auth
-			.getSession()
-			.then(({ data: { session }, error }) => {
-				if (error) {
-					console.error('Supabase getSession error:', error)
-					setConnectionError(error)
-					setIsLoaded(true)
-					setIsReady(true)
-					return
+		// Ping Supabase and read the session in parallel. The ping catches
+		// "backend unreachable" (e.g. local Docker offline) because
+		// getSession() resolves from localStorage without any network call
+		// when no session is cached.
+		void Promise.all([pingSupabase(), supabase.auth.getSession()])
+			.then(
+				([
+					,
+					{
+						data: { session },
+						error,
+					},
+				]) => {
+					if (error) {
+						console.error('Supabase getSession error:', error)
+						setConnectionError(error)
+						setIsLoaded(true)
+						setIsReady(true)
+						return
+					}
+					handleNewAuthState('GET_SESSION', session)
 				}
-				handleNewAuthState('GET_SESSION', session)
-			})
+			)
 			.catch((error: unknown) => {
-				// Network-level failures (e.g. Supabase unreachable because
-				// Docker is offline) reject the promise rather than returning
-				// an error field — surface them so the app can show guidance
-				// instead of hanging on the loading screen.
-				console.error('Supabase getSession failed:', error)
+				console.error('Supabase unreachable:', error)
 				setConnectionError(
 					error instanceof Error ? error : new Error('Unknown connection error')
 				)

--- a/src/components/auth-context.tsx
+++ b/src/components/auth-context.tsx
@@ -21,6 +21,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
 	const [sessionState, setSessionState] = useState<Session | null>(null)
 	const [isLoaded, setIsLoaded] = useState(false)
 	const [isReady, setIsReady] = useState(false)
+	const [connectionError, setConnectionError] = useState<Error | null>(null)
 
 	const handleNewAuthState = useEffectEvent(
 		(event: AuthChangeEvent | 'GET_SESSION', session: Session | null) => {
@@ -62,10 +63,30 @@ export function AuthProvider({ children }: PropsWithChildren) {
 	)
 
 	useLayoutEffect(() => {
-		void supabase.auth.getSession().then(({ data: { session }, error }) => {
-			if (error) throw error
-			handleNewAuthState('GET_SESSION', session)
-		})
+		void supabase.auth
+			.getSession()
+			.then(({ data: { session }, error }) => {
+				if (error) {
+					console.error('Supabase getSession error:', error)
+					setConnectionError(error)
+					setIsLoaded(true)
+					setIsReady(true)
+					return
+				}
+				handleNewAuthState('GET_SESSION', session)
+			})
+			.catch((error: unknown) => {
+				// Network-level failures (e.g. Supabase unreachable because
+				// Docker is offline) reject the promise rather than returning
+				// an error field — surface them so the app can show guidance
+				// instead of hanging on the loading screen.
+				console.error('Supabase getSession failed:', error)
+				setConnectionError(
+					error instanceof Error ? error : new Error('Unknown connection error')
+				)
+				setIsLoaded(true)
+				setIsReady(true)
+			})
 		const { data: listener } =
 			supabase.auth.onAuthStateChange(handleNewAuthState)
 
@@ -83,8 +104,9 @@ export function AuthProvider({ children }: PropsWithChildren) {
 				userRole:
 					(sessionState?.user?.user_metadata?.role as RolesEnum) ?? null,
 				isLoaded: true,
+				connectionError,
 			} as AuthLoaded)
-		: emptyAuth
+		: { ...emptyAuth, connectionError }
 
 	return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }

--- a/src/components/awaiting-auth-loader.tsx
+++ b/src/components/awaiting-auth-loader.tsx
@@ -1,9 +1,13 @@
 import { CSSProperties, useEffect, useState } from 'react'
 import { Loader } from '@/components/ui/loader'
+import { Button } from '@/components/ui/button'
+import { ShowErrorDontLog } from '@/components/errors'
+import { useAuth } from '@/lib/use-auth'
 
 const style = { viewTransitionName: `main-area` } as CSSProperties
 
 export function AwaitingAuthLoader() {
+	const { connectionError } = useAuth()
 	const [time, setTime] = useState(0)
 	useEffect(() => {
 		const interval = setInterval(() => {
@@ -11,6 +15,10 @@ export function AwaitingAuthLoader() {
 		}, 1000)
 		return () => clearInterval(interval)
 	}, [])
+
+	if (connectionError) {
+		return <ConnectionErrorScreen error={connectionError} />
+	}
 
 	return (
 		<div
@@ -43,6 +51,41 @@ export function AwaitingAuthLoader() {
 					or get in touch with Em directly (it may be affecting others too).
 				</p>
 			</div>
+		</div>
+	)
+}
+
+function ConnectionErrorScreen({ error }: { error: Error }) {
+	const isDev = import.meta.env.DEV
+	return (
+		<div
+			className="mx-auto flex h-full w-full max-w-160 flex-col items-center justify-center gap-4 px-4 py-10"
+			style={style}
+			data-testid="connection-error-screen"
+		>
+			<ShowErrorDontLog
+				error={error}
+				text="Can't reach Supabase"
+				className="w-full"
+			/>
+			<div className="max-w-120 space-y-3 text-center">
+				<p>
+					The app couldn't connect to its backend. Check your internet
+					connection and try again.
+				</p>
+				{isDev ? (
+					<p className="text-muted-foreground text-sm">
+						<strong>Dev tip:</strong> make sure Docker Desktop is running and
+						<code className="bg-muted mx-1 rounded px-1">supabase start</code>
+						has finished, then confirm your{' '}
+						<code className="bg-muted rounded px-1">.env</code> values match the
+						CLI output.
+					</p>
+				) : null}
+			</div>
+			<Button variant="default" onClick={() => window.location.reload()}>
+				Retry
+			</Button>
 		</div>
 	)
 }

--- a/src/components/awaiting-auth-loader.tsx
+++ b/src/components/awaiting-auth-loader.tsx
@@ -63,15 +63,11 @@ function ConnectionErrorScreen({ error }: { error: Error }) {
 			style={style}
 			data-testid="connection-error-screen"
 		>
-			<ShowErrorDontLog
-				error={error}
-				text="Can't reach Supabase"
-				className="w-full"
-			/>
+			<ShowErrorDontLog error={error} text="Unable to contact the Server" />
 			<div className="max-w-120 space-y-3 text-center">
 				<p>
-					The app couldn't connect to its backend. Check your internet
-					connection and try again.
+					The app couldn't connect to the backend, (where the database lives).
+					Please check your internet connection and try again.
 				</p>
 				{isDev ? (
 					<p className="text-muted-foreground text-sm">

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -1,8 +1,14 @@
 import { createClient } from '@supabase/supabase-js'
 import type { Database } from '@/types/supabase'
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string
-const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined
+const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined
+
+if (!supabaseUrl || !anonKey) {
+	throw new Error(
+		'Missing Supabase credentials. Copy .env.example to .env and populate VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY from `supabase start` output.'
+	)
+}
 
 const supabase = createClient<Database>(supabaseUrl, anonKey)
 

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -12,4 +12,17 @@ if (!supabaseUrl || !anonKey) {
 
 const supabase = createClient<Database>(supabaseUrl, anonKey)
 
+// getSession() reads localStorage without hitting the network when no
+// session is cached, so it can't tell us that Supabase is down. Ping a
+// cheap unauthenticated endpoint at boot so we can show a real error
+// instead of letting every subsequent query fail with ERR_CONNECTION_REFUSED.
+export async function pingSupabase(): Promise<void> {
+	const res = await fetch(`${supabaseUrl}/auth/v1/health`, {
+		headers: { apikey: anonKey as string },
+	})
+	if (!res.ok) {
+		throw new Error(`Supabase health check returned ${res.status}`)
+	}
+}
+
 export default supabase

--- a/src/lib/use-auth.ts
+++ b/src/lib/use-auth.ts
@@ -9,6 +9,7 @@ export const emptyAuth = {
 	userId: null,
 	userEmail: null,
 	userRole: null,
+	connectionError: null as Error | null,
 }
 
 type AuthNotLoaded = Readonly<typeof emptyAuth>
@@ -20,6 +21,7 @@ type AuthNotLoggedIn = {
 	userId: null
 	userEmail: null
 	userRole: null
+	connectionError: Error | null
 }
 type AuthLoggedIn = {
 	isLoaded: true
@@ -28,6 +30,7 @@ type AuthLoggedIn = {
 	userId: uuid
 	userEmail: string
 	userRole: RolesEnum
+	connectionError: Error | null
 }
 
 export type AuthLoaded = AuthNotLoggedIn | AuthLoggedIn

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -8,7 +8,9 @@ export default function Routes({ router }: Register) {
 	const auth = useAuth()
 	const queryClient = useQueryClient()
 	const context: MyRouterContext = { auth: auth, queryClient }
-	return auth.isLoaded ?
-			<RouterProvider router={router} context={context} />
-		:	<AwaitingAuthLoader />
+	return auth.isLoaded && !auth.connectionError ? (
+		<RouterProvider router={router} context={context} />
+	) : (
+		<AwaitingAuthLoader />
+	)
 }


### PR DESCRIPTION
## Summary
This PR adds proper error handling for Supabase connection failures, allowing the app to display a helpful error screen instead of hanging on the loading screen when the backend is unreachable.

## Key Changes
- **Error state management**: Added `connectionError` state to `AuthContext` to track connection failures during authentication initialization
- **Connection error detection**: Enhanced `getSession()` call in `AuthProvider` to catch both API-level errors and network-level failures (e.g., when Docker/Supabase is offline)
- **Error UI**: Created `ConnectionErrorScreen` component that displays connection error details with user-friendly messaging and a retry button
- **Dev guidance**: Added development-specific tips in the error screen to help developers troubleshoot local Supabase setup issues
- **Environment validation**: Added validation in `supabase-client.ts` to ensure required environment variables are present at startup
- **Type safety**: Updated `AuthContext` types to include `connectionError` field across all auth states

## Implementation Details
- Network-level failures (promise rejections) are now distinguished from API-level errors and both are properly surfaced to the UI
- The error screen is shown when `auth.isLoaded` is true but `auth.connectionError` is set, preventing the app from attempting to render routes
- Error logging is preserved for debugging while the UI provides actionable guidance to users
- The retry button uses `window.location.reload()` to allow users to recover from transient connection issues

https://claude.ai/code/session_01862wXGpQMcLe6fLuWhk7Mq