### PR TITLE
Wrap scenetest CLI to properly exit on test failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"format": "oxfmt . && prettier --write 'supabase/**/*.sql'",
 		"check": "tsc -b",
 		"format:check": "oxfmt --check . && prettier --check 'supabase/**/*.sql'",
-		"scene": "scenetest",
+		"scene": "node scenetest/run.mjs",
 		"test": "playwright test",
 		"test:unit": "vitest run",
 		"test:nav": "SKIP_DB_RESET=1 playwright test e2e/navigations e2e/example.spec.ts e2e/login-flow.spec.ts --fully-parallel",

--- a/scenetest/run.mjs
+++ b/scenetest/run.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// The scenetest CLI (as of @scenetest/scenes@0.8.1) never exits non-zero on
+// scene or assertion failures — only on thrown errors. That made our CI step
+// report success even when scenes failed. This wrapper runs the real CLI,
+// then inspects the JSON report it wrote and exits non-zero if anything
+// didn't complete cleanly. Remove this once scenetest honours failures in
+// its own exit code.
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const reportDir = path.resolve(__dirname, '.reports')
+const cli = path.resolve(
+	__dirname,
+	'..',
+	'node_modules',
+	'@scenetest',
+	'scenes',
+	'dist',
+	'cli.js'
+)
+
+const rawArgs = process.argv.slice(2)
+const subcommand = rawArgs[0]
+const isSubcommand = subcommand === 'init' || subcommand === 'prompt'
+const isUiMode = rawArgs.includes('--ui')
+const isInfoFlag = rawArgs.some(
+	(a) => a === '--help' || a === '-h' || a === '--version' || a === '-V'
+)
+const shouldVerifyReport = !isSubcommand && !isUiMode && !isInfoFlag
+
+let childArgs = rawArgs
+if (shouldVerifyReport) {
+	const hasFormat = rawArgs.some(
+		(a) => a === '--format' || a.startsWith('--format=')
+	)
+	if (!hasFormat) childArgs = [...rawArgs, '--format', 'both']
+}
+
+const existingReports = new Set(
+	fs.existsSync(reportDir) ? fs.readdirSync(reportDir) : []
+)
+
+const child = spawn(process.execPath, [cli, ...childArgs], {
+	stdio: 'inherit',
+})
+
+child.on('error', (err) => {
+	console.error('Failed to run scenetest:', err)
+	process.exit(1)
+})
+
+child.on('exit', (code, signal) => {
+	if (signal) {
+		process.kill(process.pid, signal)
+		return
+	}
+	const cliExit = code ?? 1
+	if (!shouldVerifyReport || cliExit !== 0) {
+		process.exit(cliExit)
+		return
+	}
+
+	const newJsonReports = fs.existsSync(reportDir)
+		? fs
+				.readdirSync(reportDir)
+				.filter((f) => f.endsWith('.json') && !existingReports.has(f))
+				.toSorted()
+		: []
+
+	if (newJsonReports.length === 0) {
+		console.error(
+			'\n❌ scenetest produced no JSON report — cannot verify pass/fail'
+		)
+		process.exit(1)
+		return
+	}
+
+	let hasFailure = false
+	for (const file of newJsonReports) {
+		const report = JSON.parse(
+			fs.readFileSync(path.join(reportDir, file), 'utf8')
+		)
+		const { scenes, completed, failed, assertions } = report.summary
+		const notCompleted = scenes - completed
+		if (failed > 0 || notCompleted > 0 || assertions.failed > 0) {
+			hasFailure = true
+			console.error(
+				`\n❌ ${file}: ${failed} scene(s) failed, ${notCompleted} not completed, ${assertions.failed} assertion(s) failed`
+			)
+		}
+	}
+
+	process.exit(hasFailure ? 1 : 0)
+})


### PR DESCRIPTION
## Summary
Add a wrapper script for the scenetest CLI that properly exits with a non-zero code when scenes or assertions fail. The upstream scenetest CLI (v0.8.1) only exits non-zero on thrown errors, not on test failures, which causes CI to incorrectly report success.

## Changes
- **New file: `scenetest/run.mjs`** - Node.js wrapper script that:
  - Spawns the real scenetest CLI with all passed arguments
  - Automatically adds `--format both` flag when running tests (to ensure JSON report generation)
  - Parses the generated JSON report after the CLI exits
  - Inspects the report summary for failed scenes, incomplete scenes, or failed assertions
  - Exits with code 1 if any failures are detected, otherwise exits with code 0
  - Preserves original behavior for subcommands (`init`, `prompt`), UI mode, and info flags (`--help`, `--version`)

- **Modified: `package.json`** - Update the `scene` script to use the wrapper instead of calling scenetest directly

## Implementation Details
- The wrapper detects new JSON reports by tracking which files existed before the CLI ran
- It only verifies the report when running actual tests (not for subcommands, UI mode, or info flags)
- Properly handles child process signals and errors
- Provides clear error messages indicating which assertions or scenes failed

https://claude.ai/code/session_014WKLeKX6LKukUDEpB9Pwq5