### PR TITLE
Add lint job to CI with PR comments and failure on new issues

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,6 +99,102 @@ jobs:
             exit 1
           fi
 
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Collect PR branch lint errors
+        run: |
+          pnpm exec oxlint . -f unix > /tmp/pr-oxlint.txt 2>&1 || true
+          pnpm exec eslint . -f unix > /tmp/pr-eslint.txt 2>&1 || true
+          cat /tmp/pr-oxlint.txt /tmp/pr-eslint.txt \
+            | grep -E '^[^:[:space:]][^:]*:[0-9]+:[0-9]+:' \
+            | sort -u > /tmp/pr-lint.txt || true
+
+      - name: Collect base branch lint errors
+        run: |
+          git worktree add /tmp/base-branch origin/${{ github.base_ref }}
+          cd /tmp/base-branch
+          pnpm install --frozen-lockfile --silent
+          pnpm exec oxlint . -f unix > /tmp/base-oxlint.txt 2>&1 || true
+          pnpm exec eslint . -f unix > /tmp/base-eslint.txt 2>&1 || true
+          cat /tmp/base-oxlint.txt /tmp/base-eslint.txt \
+            | grep -E '^[^:[:space:]][^:]*:[0-9]+:[0-9]+:' \
+            | sort -u > /tmp/base-lint.txt || true
+          cd $GITHUB_WORKSPACE
+          git worktree remove --force /tmp/base-branch
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const baseErrors = fs.readFileSync('/tmp/base-lint.txt', 'utf8').trim().split('\n').filter(Boolean);
+            const prErrors   = fs.readFileSync('/tmp/pr-lint.txt',   'utf8').trim().split('\n').filter(Boolean);
+
+            const baseSet = new Set(baseErrors);
+            const prSet   = new Set(prErrors);
+            const newErrors = prErrors.filter(e => !baseSet.has(e));
+            const resolved  = baseErrors.filter(e => !prSet.has(e));
+
+            const summary = `**Before:** ${baseErrors.length} issue(s) → **After:** ${prErrors.length} issue(s)` +
+              (newErrors.length || resolved.length
+                ? ` (+${newErrors.length} new, −${resolved.length} resolved)`
+                : ' (no change)');
+
+            const lines = ['### Lint (oxlint + eslint)', '', summary];
+            if (newErrors.length > 0)
+              lines.push(`\n**New (${newErrors.length}):**\n\`\`\`\n${newErrors.slice(0, 50).join('\n')}\n${newErrors.length > 50 ? `… and ${newErrors.length - 50} more` : ''}\n\`\`\``);
+            if (resolved.length > 0)
+              lines.push(`\n**Resolved (${resolved.length}):**\n\`\`\`\n${resolved.slice(0, 50).join('\n')}\n${resolved.length > 50 ? `… and ${resolved.length - 50} more` : ''}\n\`\`\``);
+            const body = lines.join('\n');
+
+            const marker = '### Lint (oxlint + eslint)';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: context.issue.number, body,
+              });
+            }
+
+      - name: Fail on new issues
+        run: |
+          NEW=$(comm -13 /tmp/base-lint.txt /tmp/pr-lint.txt | wc -l | tr -d ' ')
+          if [ "$NEW" -gt 0 ]; then
+            echo "❌ $NEW new lint issue(s) introduced — see PR comment for details"
+            exit 1
+          fi
+
   unit:
     runs-on: ubuntu-latest
     timeout-minutes: 3


### PR DESCRIPTION
## Summary
This PR adds a new `lint` job to the CI workflow that runs oxlint and eslint, compares results against the base branch, and automatically comments on pull requests with a summary of lint issues.

## Key Changes
- **New lint CI job** that runs on pull requests only
  - Installs dependencies and runs both oxlint and eslint on the PR branch
  - Checks out the base branch in a git worktree and runs the same linters for comparison
  - Collects and deduplicates lint errors from both tools

- **Automated PR comments** with lint status
  - Posts a summary showing total issues before/after with counts of new and resolved issues
  - Displays up to 50 new and resolved issues inline, with a note if there are more
  - Updates existing lint comments instead of creating duplicates

- **Workflow enforcement**
  - Fails the job if any new lint issues are introduced in the PR
  - Allows the PR to pass if only existing issues remain or if issues are resolved

## Implementation Details
- Uses `git worktree` to efficiently check out the base branch without affecting the current working directory
- Filters lint output using regex to extract only file-based errors (ignoring summary lines)
- Deduplicates errors across oxlint and eslint output
- Uses `actions/github-script` to manage PR comments via the GitHub API
- 10-minute timeout with Node.js 22 and pnpm for dependency management

https://claude.ai/code/session_01B6vCAjWnLY83HqYhPVqV4M