### PR TITLE
Migrate to @fontsource packages and clean up view transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
 	},
 	"dependencies": {
 		"@base-ui/react": "^1.3.0",
+		"@fontsource/atkinson-hyperlegible": "^5.2.8",
+		"@fontsource/opendyslexic": "^5.2.5",
 		"@hookform/resolvers": "^5.2.2",
 		"@supabase/supabase-js": "^2.87.3",
 		"@tanstack/db": "^0.6.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@base-ui/react':
         specifier: ^1.3.0
         version: 1.3.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@fontsource/atkinson-hyperlegible':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource/opendyslexic':
+        specifier: ^5.2.5
+        version: 5.2.5
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.68.0(react@19.2.3))
@@ -611,6 +617,12 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource/atkinson-hyperlegible@5.2.8':
+    resolution: {integrity: sha512-HciLcJ5DIK/OVOdo71EbEN4NnvDFlp6/SpAxtcbWf2aAdcsOuPqITxj5KNEXb48qSPSdnnZdGGnSJChPKi3/bA==}
+
+  '@fontsource/opendyslexic@5.2.5':
+    resolution: {integrity: sha512-NNS9aaPQx2TlaTvb3vTEjw3xz8lKj23mBc+6rM00mSNFDygdoll0/nLMHFtDKKrBT6sMfY6TFFPOR0D9ktdspg==}
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -3861,6 +3873,10 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource/atkinson-hyperlegible@5.2.8': {}
+
+  '@fontsource/opendyslexic@5.2.5': {}
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.68.0(react@19.2.3))':
     dependencies:

--- a/src/components/cards/card-result-simple.tsx
+++ b/src/components/cards/card-result-simple.tsx
@@ -6,7 +6,6 @@ import {
 	PhraseFullFullType,
 } from '@/features/phrases/schemas'
 import { CardlikeFlashcard } from '@/components/ui/card-like'
-import { CSSProperties } from 'react'
 
 export function CardResultSimple({
 	phrase,
@@ -16,10 +15,7 @@ export function CardResultSimple({
 	nonInteractive?: boolean
 }) {
 	return (
-		<CardlikeFlashcard
-			className="flex max-w-120 flex-row gap-2 py-0 ps-4 pe-1"
-			style={{ viewTransitionName: `phrase-${phrase.id}` } as CSSProperties}
-		>
+		<CardlikeFlashcard className="flex max-w-120 flex-row gap-2 py-0 ps-4 pe-1">
 			<div className="grow py-6">
 				<div className="space-x-2 pb-2">
 					<LangBadge lang={phrase.lang} />

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -8,8 +8,15 @@ const DropdownMenu = ({ ...props }: MenuPrimitive.Root.Props) => (
 	<MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
 )
 
-const DropdownMenuTrigger = (props: MenuPrimitive.Trigger.Props) => (
-	<MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+const DropdownMenuTrigger = ({
+	nativeButton = false,
+	...props
+}: MenuPrimitive.Trigger.Props) => (
+	<MenuPrimitive.Trigger
+		data-slot="dropdown-menu-trigger"
+		nativeButton={nativeButton}
+		{...props}
+	/>
 )
 
 const DropdownMenuGroup = ({ ...props }: MenuPrimitive.Group.Props) => (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,5 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&display=swap');
-@import url('https://fonts.cdnfonts.com/css/opendyslexic');
+@import '@fontsource/atkinson-hyperlegible/400.css';
+@import '@fontsource/atkinson-hyperlegible/700.css';
+@import '@fontsource/atkinson-hyperlegible/400-italic.css';
+@import '@fontsource/atkinson-hyperlegible/700-italic.css';
+@import '@fontsource/opendyslexic/index.css';
 @import 'tailwindcss';
 @import 'tailwind-oklch';
 


### PR DESCRIPTION
## Summary
This PR migrates font imports from external CDNs to the `@fontsource` npm packages and removes unused view transition styling code.

## Key Changes
- **Font imports**: Replaced Google Fonts and cdnfonts CDN imports with `@fontsource/atkinson-hyperlegible` and `@fontsource/opendyslexic` packages
  - Split Atkinson Hyperlegible into separate imports for each weight and style variant (400, 700, 400-italic, 700-italic)
  - Imported OpenDyslexic from the fontsource package index
- **Removed unused code**: Deleted unused `CSSProperties` import and `viewTransitionName` style prop from `CardResultSimple` component
- **Minor refactor**: Reordered props in `DropdownMenuTrigger` for consistency and added `nativeButton={false}` prop to `MenuPrimitive.Trigger`
- **Dependencies**: Added `@fontsource/atkinson-hyperlegible` and `@fontsource/opendyslexic` to package.json

## Benefits
- Self-hosted fonts improve performance and reduce external CDN dependencies
- Cleaner component code by removing unused styling
- Better control over font loading and caching through npm packages

https://claude.ai/code/session_01G9nBJp13q5f72c7yUxf694