### PR TITLE
Self-heal review manifest mismatches before session starts

### DIFF
--- a/src/features/review/hooks.ts
+++ b/src/features/review/hooks.ts
@@ -21,7 +21,7 @@ import {
 } from './schemas'
 import { calculateFSRS, type Score } from './fsrs'
 import type { CardDirectionType } from '@/features/deck/schemas'
-import type { ManifestEntry } from './manifest'
+import { toManifestEntry, type ManifestEntry } from './manifest'
 import {
 	buildReviewsMap,
 	findChainPredecessor,
@@ -229,6 +229,39 @@ export function useReviewDay(
 				.findOne(),
 		[lang, day_session]
 	)
+}
+
+/**
+ * The manifest is the authoritative list of cards for a review session —
+ * it's persisted server-side, so any device loading today's session sees
+ * the same set. Local `cardsCollection` can drift from that (long-lived
+ * PWA without refetches, server-side data migrations, sessions authored
+ * on another device), and if the manifest references a card the local
+ * collection has never heard of, the review mutation can't find it when
+ * syncing FSRS state. Refetch once to self-heal before the session starts.
+ */
+export async function ensureManifestCardsInCollection(
+	lang: string,
+	day_session: string
+) {
+	const reviewDay = reviewDaysCollection.toArray.find(
+		(d) => d.lang === lang && d.day_session === day_session
+	)
+	if (!reviewDay?.manifest?.length) return
+
+	const present = new Set<string>(
+		cardsCollection.toArray.map((c) =>
+			toManifestEntry(c.phrase_id, c.direction)
+		)
+	)
+	const missing = reviewDay.manifest.some((entry) => !present.has(entry))
+	if (missing) {
+		console.warn(
+			`Review manifest references cards not in local cardsCollection; refetching to self-heal.`,
+			{ lang, day_session }
+		)
+		await cardsCollection.utils.refetch()
+	}
 }
 
 export function useOneReviewToday(

--- a/src/features/review/hooks.ts
+++ b/src/features/review/hooks.ts
@@ -460,32 +460,53 @@ export function useReviewMutation(
 		},
 		onSuccess: (data) => {
 			console.log(`mutation returns:`, data)
-			if (data.action === 'update') {
-				cardReviewsCollection.utils.writeUpdate(
-					CardReviewSchema.parse(data.row)
-				)
-			}
-			if (data.action === 'insert') {
-				cardReviewsCollection.utils.writeInsert(
-					CardReviewSchema.parse(data.row)
-				)
-			}
+			// The DB write has already succeeded. Any failure below is a local
+			// sync problem, not a review-posting problem — isolate it so a misleading
+			// "error posting your review" toast never fires, and so the slide
+			// transition always runs and the user isn't stuck on the same card.
+			try {
+				if (data.action === 'update') {
+					cardReviewsCollection.utils.writeUpdate(
+						CardReviewSchema.parse(data.row)
+					)
+				}
+				if (data.action === 'insert') {
+					cardReviewsCollection.utils.writeInsert(
+						CardReviewSchema.parse(data.row)
+					)
+				}
 
-			// Only sync card scheduling state from phase-1 reviews.
-			// Phase-3 reviews are for tracking only — their FSRS values are
-			// throwaway initial values that would corrupt the scheduling chain.
-			if (data.row.day_first_review) {
-				const existingCard = cardsCollection.toArray.find(
-					(c) =>
-						c.phrase_id === data.row.phrase_id &&
-						c.direction === data.row.direction
+				// Only sync card scheduling state from phase-1 reviews.
+				// Phase-3 reviews are for tracking only — their FSRS values are
+				// throwaway initial values that would corrupt the scheduling chain.
+				if (data.row.day_first_review) {
+					const existingCard = cardsCollection.toArray.find(
+						(c) =>
+							c.phrase_id === data.row.phrase_id &&
+							c.direction === data.row.direction
+					)
+					if (existingCard) {
+						cardsCollection.utils.writeUpdate({
+							id: existingCard.id,
+							last_reviewed_at: data.row.created_at,
+							difficulty: data.row.difficulty,
+							stability: data.row.stability,
+						})
+					} else {
+						console.warn(
+							`Review saved to DB, but no matching card found in local cardsCollection to update.`,
+							{
+								phrase_id: data.row.phrase_id,
+								direction: data.row.direction,
+							}
+						)
+					}
+				}
+			} catch (err) {
+				console.error(
+					`Review saved, but failed to sync local collections:`,
+					err
 				)
-				cardsCollection.utils.writeUpdate({
-					id: existingCard!.id,
-					last_reviewed_at: data.row.created_at,
-					difficulty: data.row.difficulty,
-					stability: data.row.stability,
-				})
 			}
 
 			triggerSlide(() => {

--- a/src/routes/_user/learn/$lang.review.go.tsx
+++ b/src/routes/_user/learn/$lang.review.go.tsx
@@ -9,7 +9,11 @@ import {
 	useReviewLang,
 	useReviewStage,
 } from '@/features/review/store'
-import { useNextValid, useReviewDay } from '@/features/review/hooks'
+import {
+	ensureManifestCardsInCollection,
+	useNextValid,
+	useReviewDay,
+} from '@/features/review/hooks'
 import { Loader } from '@/components/ui/loader'
 import { WhenComplete } from '@/components/review/when-review-complete-screen'
 import { ReviewSingleCard } from '@/components/review/review-single-card'
@@ -23,6 +27,7 @@ import {
 	type ManifestEntry,
 } from '@/features/review/manifest'
 import { useCheck, should } from '@scenetest/checks-react'
+import { todayString } from '@/lib/utils'
 
 export const Route = createFileRoute('/_user/learn/$lang/review/go')({
 	beforeLoad: () => ({
@@ -31,12 +36,13 @@ export const Route = createFileRoute('/_user/learn/$lang/review/go')({
 		fixedHeight: true,
 	}),
 	component: ReviewPage,
-	loader: async ({ context }) => {
+	loader: async ({ context, params }) => {
 		if (!context.auth.isAuth) return
 		await Promise.all([
 			reviewDaysCollection.preload(),
 			cardReviewsCollection.preload(),
 		])
+		await ensureManifestCardsInCollection(params.lang, todayString())
 	},
 })
 
@@ -99,7 +105,7 @@ function FlashCardReviewSession({
 		>
 			<div className="flex flex-col items-center justify-center gap-2">
 				<div className="flex min-h-10 flex-row items-center justify-center">
-					{!atTheEnd && reviewStage === 1 ?
+					{!atTheEnd && reviewStage === 1 ? (
 						<>
 							<Button
 								size="icon"
@@ -123,7 +129,7 @@ function FlashCardReviewSession({
 								<ChevronRight className="size-4" />
 							</Button>
 						</>
-					: !atTheEnd && (reviewStage ?? 0) > 1 ?
+					) : !atTheEnd && (reviewStage ?? 0) > 1 ? (
 						<Button
 							size="sm"
 							variant="ghost"
@@ -135,7 +141,7 @@ function FlashCardReviewSession({
 						>
 							Skip for today <ChevronRight className="size-4" />
 						</Button>
-					: reviewStage === 1 ?
+					) : reviewStage === 1 ? (
 						<Button
 							size="sm"
 							variant="ghost"
@@ -145,13 +151,14 @@ function FlashCardReviewSession({
 						>
 							<ChevronLeft className="size-4" /> Back one card
 						</Button>
-					:	null}
+					) : null}
 				</div>
 			</div>
 			<div className="-mx-4 -mb-4 min-h-0 flex-1 overflow-y-auto px-4 pt-2 pb-4">
-				{atTheEnd ?
+				{atTheEnd ? (
 					<WhenComplete />
-				:	(() => {
+				) : (
+					(() => {
 						const { phraseId, direction } = parseManifestEntry(
 							manifest[currentCardIndex]
 						)
@@ -170,7 +177,7 @@ function FlashCardReviewSession({
 							</div>
 						)
 					})()
-				}
+				)}
 			</div>
 		</div>
 	)

--- a/src/routes/_user/learn/$lang.review.preview.tsx
+++ b/src/routes/_user/learn/$lang.review.preview.tsx
@@ -4,13 +4,17 @@ import {
 	useReviewLang,
 	useReviewStage,
 } from '@/features/review/store'
-import { useReviewDay } from '@/features/review/hooks'
+import {
+	ensureManifestCardsInCollection,
+	useReviewDay,
+} from '@/features/review/hooks'
 import { Loader } from '@/components/ui/loader'
 import { NewCardsPreview } from '@/components/review/new-cards-preview'
 import {
 	cardReviewsCollection,
 	reviewDaysCollection,
 } from '@/features/review/collections'
+import { todayString } from '@/lib/utils'
 
 export const Route = createFileRoute('/_user/learn/$lang/review/preview')({
 	beforeLoad: () => ({
@@ -18,12 +22,13 @@ export const Route = createFileRoute('/_user/learn/$lang/review/preview')({
 		focusMode: true,
 	}),
 	component: PreviewPage,
-	loader: async ({ context }) => {
+	loader: async ({ context, params }) => {
 		if (!context.auth.isAuth) return
 		await Promise.all([
 			reviewDaysCollection.preload(),
 			cardReviewsCollection.preload(),
 		])
+		await ensureManifestCardsInCollection(params.lang, todayString())
 	},
 })
 


### PR DESCRIPTION
## Summary
This PR adds defensive logic to detect and recover from situations where a review session's manifest references cards that don't exist in the local collection, which can cause review mutations to fail during sync.

## Key Changes

- **New `ensureManifestCardsInCollection()` function**: Checks if the review manifest contains any cards not present in the local `cardsCollection`. If mismatches are detected, it triggers a refetch to self-heal before the review session begins.

- **Manifest preload in route loaders**: Both the review session (`review.go`) and preview (`review.preview`) routes now call `ensureManifestCardsInCollection()` during their loader phase, ensuring the local collection is synchronized before the user starts reviewing.

- **Improved error isolation in review mutation**: Wrapped the local collection sync logic in a try-catch block to isolate sync failures from the actual review posting. This prevents misleading error toasts when the DB write succeeds but local sync fails, and ensures the slide transition always runs so users aren't stuck on the same card.

- **Better error messaging**: Added console warnings and errors to help diagnose collection sync issues without surfacing them as user-facing failures.

- **Code formatting fixes**: Corrected ternary operator formatting in the review session component for consistency.

## Implementation Details

The manifest serves as the authoritative card list for a review session (persisted server-side), while the local `cardsCollection` can drift due to long-lived PWAs, server migrations, or sessions authored on other devices. By proactively refetching when mismatches are detected, we prevent downstream failures during the review mutation's FSRS state sync.

https://claude.ai/code/session_01LpfQciEBMJfKxRrAxaLSQf