### PR TITLE
Add architecture review skill and domain modeling guides

### DIFF
--- a/.claude/skills/domain-model/ADR-FORMAT.md
+++ b/.claude/skills/domain-model/ADR-FORMAT.md
@@ -1,0 +1,21 @@
+# ADR Format Overview
+
+This guide describes how to create and maintain Architecture Decision Records (ADRs) in a `docs/adr/` directory using sequential numbering.
+
+## Core Structure
+
+ADRs follow a minimal template: a short title plus 1-3 sentences explaining the context, decision, and rationale. As the guide notes, "The value is in recording _that_ a decision was made and _why_" rather than exhaustive documentation.
+
+## When ADRs Matter
+
+Record a decision as an ADR only when all three conditions apply:
+
+1. **Hard to reverse** — changing course later carries real costs
+2. **Surprising without context** — future readers will question the approach
+3. **Result of trade-offs** — genuine alternatives existed and one was chosen deliberately
+
+Examples of decisions worth documenting include architectural choices, technology selections with lock-in potential, integration patterns between system components, and deliberate deviations from conventional approaches that might otherwise appear as bugs to future maintainers.
+
+## Optional Enhancements
+
+Status frontmatter, considered options, and consequences sections should only appear when they genuinely add value. Most ADRs won't require all elements.

--- a/.claude/skills/domain-model/CONTEXT-FORMAT.md
+++ b/.claude/skills/domain-model/CONTEXT-FORMAT.md
@@ -1,0 +1,77 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+A customer's request to purchase one or more items.
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+
+## Relationships
+
+- An **Order** produces one or more **Invoices**
+- An **Invoice** belongs to exactly one **Customer**
+
+## Example dialogue
+
+> **Dev:** "When a **Customer** places an **Order**, do we create the **Invoice** immediately?"
+> **Domain expert:** "No — an **Invoice** is only generated once a **Fulfillment** is confirmed."
+
+## Flagged ambiguities
+
+- "account" was used to mean both **Customer** and **User** — resolved: these are distinct concepts.
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others as aliases to avoid.
+- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in "Flagged ambiguities" with a clear resolution.
+- **Keep definitions tight.** One sentence max. Define what it IS, not what it does.
+- **Show relationships.** Use bold term names and express cardinality where obvious.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+- **Write an example dialogue.** A conversation between a dev and a domain expert that demonstrates how the terms interact naturally and clarifies boundaries between related concepts.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/.claude/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
+++ b/.claude/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
@@ -1,0 +1,27 @@
+# Interface Design Process Summary
+
+This document outlines a structured approach for exploring multiple interface designs for a chosen module using parallel sub-agents.
+
+## Core Methodology
+
+The process follows "Design It Twice" principles, recognizing that initial concepts rarely prove optimal. It uses consistent architectural vocabulary from companion documents (LANGUAGE.md, DEEPENING.md, CONTEXT.md).
+
+## Three-Step Workflow
+
+**Step 1: Frame the Problem**
+Present users with a grounded explanation covering constraints, dependencies, and illustrative code sketches—without proposing solutions. This allows users to think while work proceeds in parallel.
+
+**Step 2: Spawn Sub-Agents**
+Launch 3+ agents with distinct design briefs, each optimizing for different priorities:
+
+- Minimalist approach (1–3 entry points, maximum leverage)
+- Flexible approach (many use cases, extensibility)
+- Pragmatic approach (optimize common caller patterns)
+- Ports & adapters approach (cross-seam dependencies)
+
+Each agent delivers interface specifications, usage examples, implementation details, dependency strategies, and trade-off analysis.
+
+**Step 3: Present and Compare**
+Sequentially show designs, then compare by depth, locality, and seam placement. Provide opinionated recommendations, potentially proposing hybrids combining strong elements from multiple designs.
+
+This methodology emphasizes exploration grounded in project-specific vocabulary and coupling patterns.

--- a/.claude/skills/improve-codebase-architecture/LANGUAGE.md
+++ b/.claude/skills/improve-codebase-architecture/LANGUAGE.md
@@ -1,0 +1,53 @@
+# Language
+
+Shared vocabulary for every suggestion this skill makes. Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+_Avoid_: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation**
+What's inside a module — its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth**
+Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** _(from Michael Feathers)_
+A place where you can alter behaviour without editing in that place. The _location_ at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+_Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes _role_ (what slot it fills), not substance (what's inside).
+
+**Leverage**
+What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
+
+**Locality**
+What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test _past_ the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.

--- a/.claude/skills/improve-codebase-architecture/SKILL.md
+++ b/.claude/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,71 @@
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+
+## Glossary
+
+Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
+
+- **Module** — anything with an interface and an implementation (function, class, package, slice).
+- **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature.
+- **Implementation** — the code inside.
+- **Depth** — leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.")
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+- **Leverage** — what callers get from depth.
+- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place.
+
+Key principles (see [LANGUAGE.md](LANGUAGE.md) for the full list):
+
+- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+This skill is _informed_ by the project's domain model — `CONTEXT.md` and any `docs/adr/`. The domain language gives names to good seams; ADRs record decisions the skill should not re-litigate. See [CONTEXT-FORMAT.md](../domain-model/CONTEXT-FORMAT.md) and [ADR-FORMAT.md](../domain-model/ADR-FORMAT.md).
+
+## Process
+
+### 1. Explore
+
+Read existing documentation first:
+
+- `CONTEXT.md` (or `CONTEXT-MAP.md` + each `CONTEXT.md` in a multi-context repo)
+- Relevant ADRs in `docs/adr/` (and any context-scoped `docs/adr/` directories)
+
+If any of these files don't exist, proceed silently — don't flag their absence or suggest creating them upfront.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+### 2. Present candidates
+
+Present a numbered list of deepening opportunities. For each candidate:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and also in how tests would improve
+
+**Use CONTEXT.md vocabulary for the domain, and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly (e.g. _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+
+Do NOT propose interfaces yet. Ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Side effects happen inline as decisions crystallize:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `/domain-model` (see [CONTEXT-FORMAT.md](../domain-model/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](../domain-model/ADR-FORMAT.md).
+- **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,9 @@ skills:
 - task: "Using React bindings — useLiveQuery, useLiveSuspenseQuery, useLiveInfiniteQuery, usePacedMutations from @tanstack/react-db"
   load: "node_modules/@tanstack/react-db/skills/react-db/SKILL.md"
 
+- task: "Reviewing or improving codebase architecture — surfacing shallow modules, deepening seams, improving testability and AI-navigability"
+  load: ".claude/skills/improve-codebase-architecture/SKILL.md"
+
 <!-- intent-skills:end -->
 
 ## Development Commands


### PR DESCRIPTION
## Summary

This PR introduces a new Claude skill for reviewing and improving codebase architecture, along with supporting documentation for domain modeling and architectural decision records. These materials establish a shared vocabulary and process for identifying shallow modules, deepening seams, and improving testability.

## Key Changes

- **New skill: Improve Codebase Architecture** (`.claude/skills/improve-codebase-architecture/SKILL.md`)
  - Defines a three-phase process: explore the codebase, present deepening candidates, and conduct a grilling conversation with the user
  - Integrates with domain model context (`CONTEXT.md`) and architectural decision records (`docs/adr/`) to ground suggestions in project-specific language
  - Emphasizes depth-as-leverage and locality as core metrics for architectural quality

- **Architectural language guide** (`.claude/skills/improve-codebase-architecture/LANGUAGE.md`)
  - Establishes precise definitions for module, interface, depth, seam, adapter, leverage, and locality
  - Provides consistent terminology to avoid ambiguous terms like "component," "service," or "boundary"
  - Documents key principles including the deletion test and the interface-as-test-surface

- **Interface design process** (`.claude/skills/improve-codebase-architecture/INTERFACE-DESIGN.md`)
  - Outlines a "Design It Twice" methodology for exploring multiple interface designs in parallel
  - Describes a three-step workflow: frame the problem, spawn sub-agents with distinct briefs, and compare results

- **Domain modeling format guide** (`.claude/skills/domain-model/CONTEXT-FORMAT.md`)
  - Defines the structure and rules for `CONTEXT.md` files that capture domain language and relationships
  - Covers single-context and multi-context repository patterns
  - Includes rules for opinionated term selection, relationship documentation, and example dialogues

- **ADR format guide** (`.claude/skills/domain-model/ADR-FORMAT.md`)
  - Describes when and how to record architectural decisions
  - Establishes criteria: hard to reverse, surprising without context, result of trade-offs
  - Recommends minimal templates focused on decision and rationale

- **Updated CLAUDE.md**
  - Registers the new architecture review skill in the skills manifest

## Notable Details

- The skill is designed to work _with_ existing domain documentation rather than replace it, reading `CONTEXT.md` and ADRs to ground architectural suggestions in project-specific language
- The vocabulary is deliberately scale-agnostic (module, seam, adapter) to apply equally to functions, classes, packages, or system slices
- The process emphasizes exploration and conversation over prescriptive refactoring, with side effects (updating `CONTEXT.md`, proposing ADRs) happening inline as decisions crystallize

https://claude.ai/code/session_01HUa4hrSg1YfmAy8E4et34M