### PR TITLE
Add bundle size diff to CI comments & fix bundle-size problem/regression

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -195,6 +195,102 @@ jobs:
             exit 1
           fi
 
+  bundle-size:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Set up dummy env for build
+        run: |
+          echo "VITE_SUPABASE_URL=http://127.0.0.1:54321" >> $GITHUB_ENV
+          echo "VITE_SUPABASE_ANON_KEY=dummy" >> $GITHUB_ENV
+
+      - name: Install dependencies (PR)
+        run: pnpm install --frozen-lockfile
+
+      - name: Build PR branch
+        run: pnpm build
+
+      - name: Measure PR bundle
+        run: |
+          PR_FILE=$(ls -S dist/assets/index-*.js | head -1)
+          echo "PR_RAW=$(stat -c%s "$PR_FILE")" >> $GITHUB_ENV
+          echo "PR_GZ=$(gzip -c "$PR_FILE" | wc -c)" >> $GITHUB_ENV
+
+      - name: Build base branch
+        run: |
+          git worktree add /tmp/base-branch origin/${{ github.base_ref }}
+          cd /tmp/base-branch
+          pnpm install --frozen-lockfile --silent
+          pnpm build
+          BASE_FILE=$(ls -S dist/assets/index-*.js | head -1)
+          echo "BASE_RAW=$(stat -c%s "$BASE_FILE")" >> $GITHUB_ENV
+          echo "BASE_GZ=$(gzip -c "$BASE_FILE" | wc -c)" >> $GITHUB_ENV
+          cd $GITHUB_WORKSPACE
+          git worktree remove --force /tmp/base-branch
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fmt = (n) => (n / 1024).toFixed(2) + ' kB';
+            const diff = (pr, base) => {
+              const d = pr - base;
+              const pct = base ? ((d / base) * 100).toFixed(2) : '0.00';
+              const sign = d > 0 ? '+' : '';
+              const emoji = d > 0 ? '🔺' : d < 0 ? '🟢' : '➖';
+              return `${emoji} ${sign}${(d / 1024).toFixed(2)} kB (${sign}${pct}%)`;
+            };
+            const prRaw = parseInt(process.env.PR_RAW);
+            const prGz = parseInt(process.env.PR_GZ);
+            const baseRaw = parseInt(process.env.BASE_RAW);
+            const baseGz = parseInt(process.env.BASE_GZ);
+
+            const body = [
+              '### Main bundle size',
+              '',
+              '`dist/assets/index-*.js` (largest chunk)',
+              '',
+              '|         | Base            | PR              | Δ                    |',
+              '|---------|-----------------|-----------------|----------------------|',
+              `| Raw     | ${fmt(baseRaw).padEnd(15)} | ${fmt(prRaw).padEnd(15)} | ${diff(prRaw, baseRaw)} |`,
+              `| Gzipped | ${fmt(baseGz).padEnd(15)} | ${fmt(prGz).padEnd(15)} | ${diff(prGz, baseGz)} |`,
+            ].join('\n');
+
+            const marker = '### Main bundle size';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: context.issue.number, body,
+              });
+            }
+
   unit:
     runs-on: ubuntu-latest
     timeout-minutes: 3

--- a/src/routes/_user/learn/$lang.contributions.tsx
+++ b/src/routes/_user/learn/$lang.contributions.tsx
@@ -2,7 +2,8 @@ import { createFileRoute } from '@tanstack/react-router'
 import languages from '@/lib/languages'
 import { phraseRequestsCollection } from '@/features/requests/collections'
 
-import { UserContributions, UserContributionsTabs } from './-contributions'
+import { UserContributions } from './-contributions'
+import { UserContributionsTabs } from './-contributions-tabs'
 import type { CSSProperties } from 'react'
 
 export const Route = createFileRoute('/_user/learn/$lang/contributions')({

--- a/src/routes/_user/learn/-contributions-tabs.ts
+++ b/src/routes/_user/learn/-contributions-tabs.ts
@@ -1,0 +1,7 @@
+import * as z from 'zod'
+
+export const UserContributionsTabs = z.object({
+	contributionsTab: z
+		.enum(['requests', 'phrases', 'playlists', 'answers', 'comments'])
+		.optional(),
+})

--- a/src/routes/_user/learn/-contributions.tsx
+++ b/src/routes/_user/learn/-contributions.tsx
@@ -9,8 +9,6 @@ import {
 	MessagesSquare,
 	type LucideIcon,
 } from 'lucide-react'
-import * as z from 'zod'
-
 import { Button, buttonVariants } from '@/components/ui/button'
 import {
 	DropdownMenu,
@@ -43,12 +41,6 @@ import Callout from '@/components/ui/callout'
 import { PlusMenu } from '@/components/plus-menu'
 import { UidPermalinkInline } from '@/components/card-pieces/user-permalink'
 import { Markdown } from '@/components/my-markdown'
-
-export const UserContributionsTabs = z.object({
-	contributionsTab: z
-		.enum(['requests', 'phrases', 'playlists', 'answers', 'comments'])
-		.optional(),
-})
 
 type viewTabName = 'requests' | 'phrases' | 'playlists' | 'answers' | 'comments'
 

--- a/src/routes/_user/learn/contributions.tsx
+++ b/src/routes/_user/learn/contributions.tsx
@@ -1,6 +1,7 @@
 import { useUserId } from '@/lib/use-auth'
 import { createFileRoute } from '@tanstack/react-router'
-import { UserContributions, UserContributionsTabs } from './-contributions'
+import { UserContributions } from './-contributions'
+import { UserContributionsTabs } from './-contributions-tabs'
 
 export const Route = createFileRoute('/_user/learn/contributions')({
 	validateSearch: UserContributionsTabs,


### PR DESCRIPTION
## Summary
This PR adds a CI job to build the main bundle before and after the PR and report back in a comment if it got bigger or smaller. This was to diagnose a problem where our main bundle had gone from ~1,000 kb to ~1,500. While we were in there we found the problem so this PR also refactors the `UserContributionsTabs` Zod schema definition by extracting it from the contributions component into a dedicated module, improving code organization and reducing bundle size.

## Key Changes to CI
- **Added bundle size monitoring** via GitHub Actions workflow to track main bundle size changes on pull requests, with automated comments comparing raw and gzipped sizes against the base branch

## Key Changes to Bundle Size
- **Created new module** `src/routes/_user/learn/-contributions-tabs.ts` containing the `UserContributionsTabs` schema definition
- **Removed schema definition** from `src/routes/_user/learn/-contributions.tsx` and removed unused `zod` import
- **Updated imports** in route files (`$lang.contributions.tsx` and `contributions.tsx`) to import the schema from the new dedicated module

## Implementation Details
The schema extraction follows a common pattern of separating validation logic from component logic, making the schema reusable and reducing the component file's complexity. The new `-contributions-tabs.ts` file follows the existing naming convention for shared utilities in the route directory.

https://claude.ai/code/session_013GgWCiLF3ktDyMPWEa55AT