### PR TITLE
Implement bury-siblings policy for review cards

### DIFF
--- a/src/features/review/bury-siblings.test.ts
+++ b/src/features/review/bury-siblings.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect } from 'vitest'
+import {
+	decideBuryDirection,
+	partitionBuriedSiblings,
+	type BurySiblingCandidate,
+} from './bury-siblings'
+import type { CardReviewType } from './schemas'
+
+const P1 = '11111111-1111-4111-8111-111111111111'
+const P2 = '22222222-2222-4222-8222-222222222222'
+const UID = '33333333-3333-4333-8333-333333333333'
+
+const NOW = new Date('2026-04-28T12:00:00Z')
+
+function dayBefore(now: Date, days: number): string {
+	const d = new Date(now)
+	d.setDate(d.getDate() - days)
+	return d.toISOString()
+}
+
+function makeReview(
+	overrides: Partial<CardReviewType> & {
+		phrase_id: string
+		direction: 'forward' | 'reverse'
+		created_at: string
+	}
+): CardReviewType {
+	return {
+		id: crypto.randomUUID(),
+		uid: UID,
+		day_session: overrides.created_at.slice(0, 10),
+		lang: 'hin',
+		score: 3,
+		day_first_review: true,
+		difficulty: 5,
+		review_time_retrievability: null,
+		stability: 3,
+		updated_at: null,
+		...overrides,
+	}
+}
+
+function makeCandidate(
+	overrides: Partial<BurySiblingCandidate> & {
+		phrase_id: string
+		direction: 'forward' | 'reverse'
+	}
+): BurySiblingCandidate {
+	return {
+		last_reviewed_at: null,
+		stability: null,
+		...overrides,
+	}
+}
+
+describe('decideBuryDirection — Rule 1 (reverse failed twice)', () => {
+	it('buries reverse when its two most recent phase-1 reviews both scored 1', () => {
+		const forward = makeCandidate({
+			phrase_id: P1,
+			direction: 'forward',
+			last_reviewed_at: dayBefore(NOW, 5),
+			stability: 8,
+		})
+		const reverse = makeCandidate({
+			phrase_id: P1,
+			direction: 'reverse',
+			last_reviewed_at: dayBefore(NOW, 1),
+			stability: 1,
+		})
+		const reviews = [
+			makeReview({
+				phrase_id: P1,
+				direction: 'reverse',
+				created_at: dayBefore(NOW, 4),
+				score: 1,
+			}),
+			makeReview({
+				phrase_id: P1,
+				direction: 'reverse',
+				created_at: dayBefore(NOW, 1),
+				score: 1,
+			}),
+		]
+		expect(decideBuryDirection(forward, reverse, reviews, NOW)).toBe('reverse')
+	})
+
+	it('does not bury reverse when only the most recent review was a failure', () => {
+		// Recent: 1; previous: 3. Falls through to Rule 2 / fallback.
+		const forward = makeCandidate({
+			phrase_id: P1,
+			direction: 'forward',
+			last_reviewed_at: dayBefore(NOW, 100),
+			stability: 0.5, // forward decayed massively
+		})
+		const reverse = makeCandidate({
+			phrase_id: P1,
+			direction: 'reverse',
+			last_reviewed_at: dayBefore(NOW, 1),
+			stability: 1,
+		})
+		const reviews = [
+			makeReview({
+				phrase_id: P1,
+				direction: 'reverse',
+				created_at: dayBefore(NOW, 4),
+				score: 3,
+			}),
+			makeReview({
+				phrase_id: P1,
+				direction: 'reverse',
+				created_at: dayBefore(NOW, 1),
+				score: 1,
+			}),
+		]
+		// Rule 2: forward retrievability tomorrow << reverse — bury reverse.
+		// (We're testing here that Rule 1 didn't fire on a single failure;
+		// the actual buried direction follows Rule 2.)
+		expect(decideBuryDirection(forward, reverse, reviews, NOW)).toBe('reverse')
+	})
+
+	it('ignores phase-3 (re-review) rows when checking for two failures', () => {
+		// Two phase-3 score=1 rows are not a chain of failures — only phase-1
+		// counts. Falls through to Rule 2 / fallback.
+		const forward = makeCandidate({
+			phrase_id: P1,
+			direction: 'forward',
+			last_reviewed_at: dayBefore(NOW, 5),
+			stability: 8,
+		})
+		const reverse = makeCandidate({
+			phrase_id: P1,
+			direction: 'reverse',
+			last_reviewed_at: dayBefore(NOW, 5),
+			stability: 8,
+		})
+		const reviews = [
+			makeReview({
+				phrase_id: P1,
+				direction: 'reverse',
+				created_at: dayBefore(NOW, 5),
+				score: 3,
+				day_first_review: true,
+			}),
+			makeReview({
+				phrase_id: P1,
+				direction: 'reverse',
+				created_at: dayBefore(NOW, 5),
+				score: 1,
+				day_first_review: false,
+			}),
+			makeReview({
+				phrase_id: P1,
+				direction: 'reverse',
+				created_at: dayBefore(NOW, 5),
+				score: 1,
+				day_first_review: false,
+			}),
+		]
+		// Identical FSRS state on both → Rule 2 ties to forward (bury reverse).
+		// What we're really asserting is that Rule 1 didn't fire.
+		expect(decideBuryDirection(forward, reverse, reviews, NOW)).toBe('reverse')
+	})
+
+	it('only counts the reverse card — forward failures do not trigger Rule 1', () => {
+		const forward = makeCandidate({
+			phrase_id: P1,
+			direction: 'forward',
+			last_reviewed_at: dayBefore(NOW, 5),
+			stability: 8,
+		})
+		const reverse = makeCandidate({
+			phrase_id: P1,
+			direction: 'reverse',
+			last_reviewed_at: dayBefore(NOW, 5),
+			stability: 8,
+		})
+		const reviews = [
+			makeReview({
+				phrase_id: P1,
+				direction: 'forward',
+				created_at: dayBefore(NOW, 4),
+				score: 1,
+			}),
+			makeReview({
+				phrase_id: P1,
+				direction: 'forward',
+				created_at: dayBefore(NOW, 1),
+				score: 1,
+			}),
+		]
+		expect(decideBuryDirection(forward, reverse, reviews, NOW)).toBe('reverse')
+	})
+})
+
+describe('decideBuryDirection — Rule 2 (tomorrow retrievability)', () => {
+	it('buries the sibling with HIGHER retrievability tomorrow (less overdue)', () => {
+		// Forward: stability 5, reviewed 4 days ago → tomorrow t/S = 5/5 = 1.0
+		//   retrievability ≈ 0.9
+		// Reverse: stability 50, reviewed 4 days ago → tomorrow t/S = 5/50 = 0.1
+		//   retrievability ≈ 0.989
+		// Reverse is much LESS overdue tomorrow → bury reverse.
+		const forward = makeCandidate({
+			phrase_id: P1,
+			direction: 'forward',
+			last_reviewed_at: dayBefore(NOW, 4),
+			stability: 5,
+		})
+		const reverse = makeCandidate({
+			phrase_id: P1,
+			direction: 'reverse',
+			last_reviewed_at: dayBefore(NOW, 4),
+			stability: 50,
+		})
+		expect(decideBuryDirection(forward, reverse, [], NOW)).toBe('reverse')
+	})
+
+	it('buries forward when forward will be less overdue tomorrow', () => {
+		// Forward stable & freshly reviewed; reverse decayed and overdue.
+		const forward = makeCandidate({
+			phrase_id: P1,
+			direction: 'forward',
+			last_reviewed_at: dayBefore(NOW, 1),
+			stability: 50,
+		})
+		const reverse = makeCandidate({
+			phrase_id: P1,
+			direction: 'reverse',
+			last_reviewed_at: dayBefore(NOW, 30),
+			stability: 5,
+		})
+		expect(decideBuryDirection(forward, reverse, [], NOW)).toBe('forward')
+	})
+
+	it('keeps the steeper-decay card even when retrievabilities are close today', () => {
+		// Documents the example from the policy: 0.90 vs 0.89 today, but the
+		// 0.89 card decays more gradually — so tomorrow forward (0.90 today)
+		// drops below reverse (0.89 today). Bury reverse, keep forward.
+		// Forward: stability 5 — fast decay
+		// Reverse: stability 80 — slow decay
+		// Today: forward t/S ≈ 0.97 (just above 0.9), reverse t/S ≈ 0.06 (≈0.99 today)
+		// We pick numbers such that forward is more overdue tomorrow.
+		const forward = makeCandidate({
+			phrase_id: P1,
+			direction: 'forward',
+			last_reviewed_at: dayBefore(NOW, 5),
+			stability: 5,
+		})
+		const reverse = makeCandidate({
+			phrase_id: P1,
+			direction: 'reverse',
+			last_reviewed_at: dayBefore(NOW, 1),
+			stability: 80,
+		})
+		expect(decideBuryDirection(forward, reverse, [], NOW)).toBe('reverse')
+	})
+
+	it('breaks ties (equal tomorrow retrievability) toward burying reverse', () => {
+		const forward = makeCandidate({
+			phrase_id: P1,
+			direction: 'forward',
+			last_reviewed_at: dayBefore(NOW, 4),
+			stability: 8,
+		})
+		const reverse = makeCandidate({
+			phrase_id: P1,
+			direction: 'reverse',
+			last_reviewed_at: dayBefore(NOW, 4),
+			stability: 8,
+		})
+		expect(decideBuryDirection(forward, reverse, [], NOW)).toBe('reverse')
+	})
+})
+
+describe('decideBuryDirection — fallback (no FSRS state)', () => {
+	it('buries reverse when both siblings are brand-new (no last_reviewed_at)', () => {
+		const forward = makeCandidate({ phrase_id: P1, direction: 'forward' })
+		const reverse = makeCandidate({ phrase_id: P1, direction: 'reverse' })
+		expect(decideBuryDirection(forward, reverse, [], NOW)).toBe('reverse')
+	})
+
+	it('buries reverse when one sibling is new and the other is reviewed', () => {
+		// Mixed state — can't compare retrievability — default to recognition.
+		const forward = makeCandidate({
+			phrase_id: P1,
+			direction: 'forward',
+			last_reviewed_at: dayBefore(NOW, 10),
+			stability: 5,
+		})
+		const reverse = makeCandidate({ phrase_id: P1, direction: 'reverse' })
+		expect(decideBuryDirection(forward, reverse, [], NOW)).toBe('reverse')
+	})
+})
+
+describe('partitionBuriedSiblings', () => {
+	it('keeps a solo sibling without any pairing', () => {
+		// Forward only — no reverse to bury against.
+		const forward = makeCandidate({ phrase_id: P1, direction: 'forward' })
+		const { kept, buried } = partitionBuriedSiblings([forward], [], NOW)
+		expect(kept).toEqual([forward])
+		expect(buried).toEqual([])
+	})
+
+	it('buries one sibling per phrase that has both directions present', () => {
+		const forward1 = makeCandidate({ phrase_id: P1, direction: 'forward' })
+		const reverse1 = makeCandidate({ phrase_id: P1, direction: 'reverse' })
+		const forward2 = makeCandidate({ phrase_id: P2, direction: 'forward' })
+		const { kept, buried } = partitionBuriedSiblings(
+			[forward1, reverse1, forward2],
+			[],
+			NOW
+		)
+		expect(kept).toContain(forward1)
+		expect(kept).toContain(forward2)
+		expect(buried).toEqual([reverse1])
+	})
+
+	it('preserves input order in the kept array', () => {
+		const c1 = makeCandidate({ phrase_id: P1, direction: 'forward' })
+		const c2 = makeCandidate({ phrase_id: P2, direction: 'forward' })
+		const c3 = makeCandidate({ phrase_id: P1, direction: 'reverse' })
+		const { kept } = partitionBuriedSiblings([c1, c2, c3], [], NOW)
+		expect(kept).toEqual([c1, c2])
+	})
+
+	it('applies Rule 1 across multiple phrases independently', () => {
+		const f1 = makeCandidate({
+			phrase_id: P1,
+			direction: 'forward',
+			last_reviewed_at: dayBefore(NOW, 5),
+			stability: 8,
+		})
+		const r1 = makeCandidate({
+			phrase_id: P1,
+			direction: 'reverse',
+			last_reviewed_at: dayBefore(NOW, 1),
+			stability: 1,
+		})
+		const f2 = makeCandidate({ phrase_id: P2, direction: 'forward' })
+		const r2 = makeCandidate({ phrase_id: P2, direction: 'reverse' })
+		const reviews = [
+			makeReview({
+				phrase_id: P1,
+				direction: 'reverse',
+				created_at: dayBefore(NOW, 4),
+				score: 1,
+			}),
+			makeReview({
+				phrase_id: P1,
+				direction: 'reverse',
+				created_at: dayBefore(NOW, 1),
+				score: 1,
+			}),
+		]
+		const { kept, buried } = partitionBuriedSiblings(
+			[f1, r1, f2, r2],
+			reviews,
+			NOW
+		)
+		// P1: Rule 1 fires — reverse buried.
+		// P2: brand-new pair → fallback buries reverse.
+		expect(kept).toEqual([f1, f2])
+		expect(buried).toEqual([r1, r2])
+	})
+})

--- a/src/features/review/bury-siblings.test.ts
+++ b/src/features/review/bury-siblings.test.ts
@@ -271,15 +271,16 @@ describe('decideBuryDirection — Rule 2 (tomorrow retrievability)', () => {
 	})
 })
 
-describe('decideBuryDirection — fallback (no FSRS state)', () => {
-	it('buries reverse when both siblings are brand-new (no last_reviewed_at)', () => {
+describe('decideBuryDirection — Rule 0 (first-day exception)', () => {
+	it('returns null when both siblings are brand-new (keep both, recognition then recall)', () => {
 		const forward = makeCandidate({ phrase_id: P1, direction: 'forward' })
 		const reverse = makeCandidate({ phrase_id: P1, direction: 'reverse' })
-		expect(decideBuryDirection(forward, reverse, [], NOW)).toBe('reverse')
+		expect(decideBuryDirection(forward, reverse, [], NOW)).toBeNull()
 	})
+})
 
-	it('buries reverse when one sibling is new and the other is reviewed', () => {
-		// Mixed state — can't compare retrievability — default to recognition.
+describe('decideBuryDirection — fallback (mixed FSRS state)', () => {
+	it('buries reverse when forward is reviewed but reverse is not', () => {
 		const forward = makeCandidate({
 			phrase_id: P1,
 			direction: 'forward',
@@ -287,6 +288,17 @@ describe('decideBuryDirection — fallback (no FSRS state)', () => {
 			stability: 5,
 		})
 		const reverse = makeCandidate({ phrase_id: P1, direction: 'reverse' })
+		expect(decideBuryDirection(forward, reverse, [], NOW)).toBe('reverse')
+	})
+
+	it('buries reverse when reverse is reviewed but forward is not', () => {
+		const forward = makeCandidate({ phrase_id: P1, direction: 'forward' })
+		const reverse = makeCandidate({
+			phrase_id: P1,
+			direction: 'reverse',
+			last_reviewed_at: dayBefore(NOW, 10),
+			stability: 5,
+		})
 		expect(decideBuryDirection(forward, reverse, [], NOW)).toBe('reverse')
 	})
 })
@@ -300,9 +312,32 @@ describe('partitionBuriedSiblings', () => {
 		expect(buried).toEqual([])
 	})
 
-	it('buries one sibling per phrase that has both directions present', () => {
-		const forward1 = makeCandidate({ phrase_id: P1, direction: 'forward' })
-		const reverse1 = makeCandidate({ phrase_id: P1, direction: 'reverse' })
+	it('keeps both siblings of a brand-new pair (first-day exception)', () => {
+		const forward = makeCandidate({ phrase_id: P1, direction: 'forward' })
+		const reverse = makeCandidate({ phrase_id: P1, direction: 'reverse' })
+		const { kept, buried } = partitionBuriedSiblings(
+			[forward, reverse],
+			[],
+			NOW
+		)
+		expect(kept).toEqual([forward, reverse])
+		expect(buried).toEqual([])
+	})
+
+	it('buries one sibling per phrase once both have been reviewed', () => {
+		// Identical FSRS state on each pair → ties go to burying reverse.
+		const forward1 = makeCandidate({
+			phrase_id: P1,
+			direction: 'forward',
+			last_reviewed_at: dayBefore(NOW, 5),
+			stability: 8,
+		})
+		const reverse1 = makeCandidate({
+			phrase_id: P1,
+			direction: 'reverse',
+			last_reviewed_at: dayBefore(NOW, 5),
+			stability: 8,
+		})
 		const forward2 = makeCandidate({ phrase_id: P2, direction: 'forward' })
 		const { kept, buried } = partitionBuriedSiblings(
 			[forward1, reverse1, forward2],
@@ -315,14 +350,26 @@ describe('partitionBuriedSiblings', () => {
 	})
 
 	it('preserves input order in the kept array', () => {
-		const c1 = makeCandidate({ phrase_id: P1, direction: 'forward' })
+		const c1 = makeCandidate({
+			phrase_id: P1,
+			direction: 'forward',
+			last_reviewed_at: dayBefore(NOW, 5),
+			stability: 8,
+		})
 		const c2 = makeCandidate({ phrase_id: P2, direction: 'forward' })
-		const c3 = makeCandidate({ phrase_id: P1, direction: 'reverse' })
+		const c3 = makeCandidate({
+			phrase_id: P1,
+			direction: 'reverse',
+			last_reviewed_at: dayBefore(NOW, 5),
+			stability: 8,
+		})
 		const { kept } = partitionBuriedSiblings([c1, c2, c3], [], NOW)
 		expect(kept).toEqual([c1, c2])
 	})
 
-	it('applies Rule 1 across multiple phrases independently', () => {
+	it('applies Rule 1 and Rule 0 across multiple phrases independently', () => {
+		// P1: reverse failed twice → bury reverse.
+		// P2: brand-new pair → first-day exception, keep both.
 		const f1 = makeCandidate({
 			phrase_id: P1,
 			direction: 'forward',
@@ -356,9 +403,7 @@ describe('partitionBuriedSiblings', () => {
 			reviews,
 			NOW
 		)
-		// P1: Rule 1 fires — reverse buried.
-		// P2: brand-new pair → fallback buries reverse.
-		expect(kept).toEqual([f1, f2])
-		expect(buried).toEqual([r1, r2])
+		expect(kept).toEqual([f1, f2, r2])
+		expect(buried).toEqual([r1])
 	})
 })

--- a/src/features/review/bury-siblings.ts
+++ b/src/features/review/bury-siblings.ts
@@ -9,6 +9,11 @@
  *
  * Rules, in order:
  *
+ *   0. First-day exception: when BOTH siblings are unreviewed, keep both.
+ *      The very first encounter pairs recognition then recall in one session
+ *      to anchor the new phrase; standard bury-siblings kicks in starting on
+ *      the second session.
+ *
  *   1. If the reverse sibling's two most recent phase-1 reviews both scored 1
  *      (Again), bury the reverse and show the forward today. Piling on a
  *      third failure attempt isn't useful — let the user re-anchor recognition
@@ -21,9 +26,9 @@
  *      tomorrow if the second decays more gradually, in which case we still
  *      keep the first.)
  *
- *   3. Fallback when retrievability can't be compared (one or both siblings
- *      have no FSRS state yet — e.g. brand-new cards): bury the reverse and
- *      show the forward. Recognition before recall is the safer default.
+ *   3. Fallback when retrievability can't be compared (one sibling reviewed
+ *      and one not, so no apples-to-apples retrievability): bury the reverse
+ *      and show the forward. Recognition before recall is the safer default.
  */
 
 import type { CardReviewType } from './schemas'
@@ -41,14 +46,21 @@ export interface BurySiblingCandidate {
 
 /**
  * Decide which sibling to bury when both forward and reverse are eligible.
- * Returns the direction that should be DROPPED from the manifest.
+ * Returns the direction that should be DROPPED from the manifest, or `null`
+ * when both should be kept (first-day exception).
  */
 export function decideBuryDirection(
 	forward: BurySiblingCandidate,
 	reverse: BurySiblingCandidate,
 	reviews: ReadonlyArray<CardReviewType>,
 	now: Date = new Date()
-): CardDirectionType {
+): CardDirectionType | null {
+	// Rule 0: brand-new pair — keep both so recognition and recall happen
+	// in the same first session.
+	if (!forward.last_reviewed_at && !reverse.last_reviewed_at) {
+		return null
+	}
+
 	if (reverseFailedTwiceInARow(reverse.phrase_id, reviews)) {
 		return 'reverse'
 	}
@@ -143,6 +155,7 @@ export function partitionBuriedSiblings<T extends BurySiblingCandidate>(
 	for (const { forward, reverse } of byPhrase.values()) {
 		if (!forward || !reverse) continue
 		const buryDir = decideBuryDirection(forward, reverse, reviews, now)
+		if (buryDir === null) continue
 		buriedSet.add(buryDir === 'forward' ? forward : reverse)
 	}
 

--- a/src/features/review/bury-siblings.ts
+++ b/src/features/review/bury-siblings.ts
@@ -1,0 +1,156 @@
+/**
+ * Bury-siblings policy: when a phrase has both forward and reverse cards
+ * eligible for today's review, only one should appear in the manifest.
+ * Showing both wastes attention — having just answered "house → casa", being
+ * asked "casa → house" a few cards later isn't a meaningful retrieval.
+ *
+ * The other sibling isn't recorded as deferred anywhere; we just leave it out
+ * of today's manifest and it falls back into normal scheduling tomorrow.
+ *
+ * Rules, in order:
+ *
+ *   1. If the reverse sibling's two most recent phase-1 reviews both scored 1
+ *      (Again), bury the reverse and show the forward today. Piling on a
+ *      third failure attempt isn't useful — let the user re-anchor recognition
+ *      first and try recall again on a later session.
+ *
+ *   2. Otherwise, bury whichever sibling will be LESS overdue tomorrow — the
+ *      one whose retrievability at t+1 day is HIGHER. The card that decays
+ *      faster has the greater cost-of-deferring, so we keep it. (Concretely:
+ *      two cards with retrievabilities 0.90 and 0.89 today might invert by
+ *      tomorrow if the second decays more gradually, in which case we still
+ *      keep the first.)
+ *
+ *   3. Fallback when retrievability can't be compared (one or both siblings
+ *      have no FSRS state yet — e.g. brand-new cards): bury the reverse and
+ *      show the forward. Recognition before recall is the safer default.
+ */
+
+import type { CardReviewType } from './schemas'
+import type { CardDirectionType } from '@/features/deck/schemas'
+import type { uuid } from '@/types/main'
+import { retrievability } from './fsrs'
+import { dateDiff } from '@/lib/utils'
+
+export interface BurySiblingCandidate {
+	phrase_id: uuid
+	direction: CardDirectionType
+	last_reviewed_at: string | null
+	stability: number | null
+}
+
+/**
+ * Decide which sibling to bury when both forward and reverse are eligible.
+ * Returns the direction that should be DROPPED from the manifest.
+ */
+export function decideBuryDirection(
+	forward: BurySiblingCandidate,
+	reverse: BurySiblingCandidate,
+	reviews: ReadonlyArray<CardReviewType>,
+	now: Date = new Date()
+): CardDirectionType {
+	if (reverseFailedTwiceInARow(reverse.phrase_id, reviews)) {
+		return 'reverse'
+	}
+
+	const tomorrowBury = decideBuryByTomorrowRetrievability(forward, reverse, now)
+	if (tomorrowBury) return tomorrowBury
+
+	return 'reverse'
+}
+
+/**
+ * True when the reverse card's two most recent phase-1 reviews both scored 1.
+ * Phase-3 (re-review) rows are excluded — the chain only counts first-of-day
+ * reviews. Sorting keys on (day_session, created_at) so multiple phase-1 rows
+ * within a single legacy session still order deterministically.
+ */
+function reverseFailedTwiceInARow(
+	phrase_id: uuid,
+	reviews: ReadonlyArray<CardReviewType>
+): boolean {
+	const recent = reviews
+		.filter(
+			(r) =>
+				r.phrase_id === phrase_id &&
+				r.direction === 'reverse' &&
+				r.day_first_review === true
+		)
+		.toSorted((a, b) =>
+			a.day_session === b.day_session
+				? a.created_at.localeCompare(b.created_at)
+				: a.day_session.localeCompare(b.day_session)
+		)
+	if (recent.length < 2) return false
+	const last = recent[recent.length - 1]
+	const prev = recent[recent.length - 2]
+	return last.score === 1 && prev.score === 1
+}
+
+/**
+ * Bury the sibling with the higher tomorrow-retrievability (less overdue
+ * tomorrow → cheaper to defer). Returns undefined when at least one sibling
+ * lacks the FSRS state needed to compute retrievability.
+ */
+function decideBuryByTomorrowRetrievability(
+	forward: BurySiblingCandidate,
+	reverse: BurySiblingCandidate,
+	now: Date
+): CardDirectionType | undefined {
+	if (
+		!forward.last_reviewed_at ||
+		forward.stability == null ||
+		!reverse.last_reviewed_at ||
+		reverse.stability == null
+	) {
+		return undefined
+	}
+	const tomorrow = new Date(now)
+	tomorrow.setDate(tomorrow.getDate() + 1)
+
+	const forwardR = retrievability(
+		dateDiff(forward.last_reviewed_at, tomorrow),
+		forward.stability
+	)
+	const reverseR = retrievability(
+		dateDiff(reverse.last_reviewed_at, tomorrow),
+		reverse.stability
+	)
+	// Bury the higher retrievability (less overdue tomorrow). Ties go to
+	// burying reverse so the user gets recognition rather than recall.
+	return forwardR > reverseR ? 'forward' : 'reverse'
+}
+
+/**
+ * Partition a candidate set into kept vs. buried. A candidate is buried only
+ * when its sibling (same phrase_id, opposite direction) is also a candidate;
+ * solo siblings are always kept.
+ */
+export function partitionBuriedSiblings<T extends BurySiblingCandidate>(
+	candidates: ReadonlyArray<T>,
+	reviews: ReadonlyArray<CardReviewType>,
+	now: Date = new Date()
+): { kept: Array<T>; buried: Array<T> } {
+	const byPhrase = new Map<uuid, { forward?: T; reverse?: T }>()
+	for (const c of candidates) {
+		const entry = byPhrase.get(c.phrase_id) ?? {}
+		if (c.direction === 'forward') entry.forward = c
+		else entry.reverse = c
+		byPhrase.set(c.phrase_id, entry)
+	}
+
+	const buriedSet = new Set<T>()
+	for (const { forward, reverse } of byPhrase.values()) {
+		if (!forward || !reverse) continue
+		const buryDir = decideBuryDirection(forward, reverse, reviews, now)
+		buriedSet.add(buryDir === 'forward' ? forward : reverse)
+	}
+
+	const kept: Array<T> = []
+	const buried: Array<T> = []
+	for (const c of candidates) {
+		if (buriedSet.has(c)) buried.push(c)
+		else kept.push(c)
+	}
+	return { kept, buried }
+}

--- a/src/features/review/index.ts
+++ b/src/features/review/index.ts
@@ -60,3 +60,10 @@ export {
 	retrievability,
 	type Score,
 } from './fsrs'
+
+// Bury-siblings policy
+export {
+	decideBuryDirection,
+	partitionBuriedSiblings,
+	type BurySiblingCandidate,
+} from './bury-siblings'

--- a/src/routes/_user/learn/$lang.review.index.tsx
+++ b/src/routes/_user/learn/$lang.review.index.tsx
@@ -10,6 +10,11 @@ import { useDeckCards } from '@/features/deck/hooks'
 import { isDueCard } from '@/features/deck/is-due-card'
 import { phrasesCollection } from '@/features/phrases/collections'
 import {
+	partitionBuriedSiblings,
+	type BurySiblingCandidate,
+} from '@/features/review/bury-siblings'
+import { eq, useLiveQuery } from '@tanstack/react-db'
+import {
 	BookOpen,
 	CalendarClock,
 	MessageSquare,
@@ -47,7 +52,10 @@ import { useCompositePids } from '@/hooks/composite-pids'
 import { CardMetaSchema } from '@/features/deck/schemas'
 import { DailyReviewStateSchema } from '@/features/review/schemas'
 import { cardsCollection, decksCollection } from '@/features/deck/collections'
-import { reviewDaysCollection } from '@/features/review/collections'
+import {
+	cardReviewsCollection,
+	reviewDaysCollection,
+} from '@/features/review/collections'
 import { useIntro } from '@/hooks/use-intro-seen'
 import { ReviewIntro, ReviewCallout } from '@/components/intros'
 
@@ -177,14 +185,64 @@ function ReviewPageContent() {
 	// Get full card data for card-level manifest building
 	const { data: deckCards } = useDeckCards(lang)
 
+	// Reviews scoped to this language — used by bury-siblings Rule 1, which
+	// looks at the reverse card's two most recent phase-1 reviews to decide
+	// whether to defer recall after consecutive failures.
+	const { data: reviewsForLang } = useLiveQuery(
+		(q) =>
+			q
+				.from({ review: cardReviewsCollection })
+				.where(({ review }) => eq(review.lang, lang)),
+		[lang]
+	)
+
 	// Sets for O(1) lookups in filters below
 	const freshSet = new Set(freshCards)
 	const allPhraseSet = new Set(allPhraseIdsForToday)
 
-	// Mirror manifest construction so display counts match the session exactly.
-	// A card enters the manifest if its phrase is in today's set AND it is
-	// active AND (due OR unreviewed). Unreviewed siblings on scheduled phrases
-	// count toward "Scheduled" — they ride along with a due sibling.
+	// One unified candidate list, then bury siblings exactly once. Both the
+	// display counts AND the manifest persisted on Start derive from `kept`,
+	// so users never see counts that don't match the session they're about
+	// to start.
+	type ReviewCandidate = BurySiblingCandidate & { bucket: 'due' | 'fresh' }
+	const candidates: Array<ReviewCandidate> = []
+
+	for (const card of deckCards ?? []) {
+		if (!allPhraseSet.has(card.phrase_id)) continue
+		if (card.status !== 'active') continue
+		const isUnreviewed = !card.last_reviewed_at
+		if (!isUnreviewed && !isDueCard(card)) continue
+		candidates.push({
+			phrase_id: card.phrase_id,
+			direction: card.direction,
+			last_reviewed_at: card.last_reviewed_at,
+			stability: card.stability,
+			bucket: isUnreviewed && freshSet.has(card.phrase_id) ? 'fresh' : 'due',
+		})
+	}
+
+	// Brand-new cards (not yet in deckCards) — always treated as fresh. We
+	// still record both directions here so bury-siblings can pick which one
+	// actually goes on today's manifest; the buried sibling's user_card row
+	// is still inserted so it can come up in a future session.
+	for (const pid of cardsToCreate) {
+		const phrase = phrasesCollection.get(pid)
+		for (const direction of directionsForPhrase(phrase?.only_reverse)) {
+			candidates.push({
+				phrase_id: pid,
+				direction,
+				last_reviewed_at: null,
+				stability: null,
+				bucket: 'fresh',
+			})
+		}
+	}
+
+	const { kept: keptCandidates } = partitionBuriedSiblings(
+		candidates,
+		reviewsForLang ?? []
+	)
+
 	let scheduledForward = 0
 	let scheduledReverse = 0
 	let newForward = 0
@@ -196,41 +254,23 @@ function ReviewPageContent() {
 	const schedForwardPhrases = new Set<string>()
 	const schedReversePhrases = new Set<string>()
 
-	for (const card of deckCards ?? []) {
-		if (!allPhraseSet.has(card.phrase_id)) continue
-		if (card.status !== 'active') continue
-		const isUnreviewed = !card.last_reviewed_at
-		if (!isUnreviewed && !isDueCard(card)) continue
-		const isFresh = isUnreviewed && freshSet.has(card.phrase_id)
-		if (card.direction === 'forward') {
+	for (const c of keptCandidates) {
+		const isFresh = c.bucket === 'fresh'
+		if (c.direction === 'forward') {
 			if (isFresh) {
 				newForward++
-				newForwardPhrases.add(card.phrase_id)
+				newForwardPhrases.add(c.phrase_id)
 			} else {
 				scheduledForward++
-				schedForwardPhrases.add(card.phrase_id)
+				schedForwardPhrases.add(c.phrase_id)
 			}
 		} else {
 			if (isFresh) {
 				newReverse++
-				newReversePhrases.add(card.phrase_id)
+				newReversePhrases.add(c.phrase_id)
 			} else {
 				scheduledReverse++
-				schedReversePhrases.add(card.phrase_id)
-			}
-		}
-	}
-
-	// Newly-created cards (not yet in deckCards) — always counted as new
-	for (const pid of cardsToCreate) {
-		const phrase = phrasesCollection.get(pid)
-		for (const d of directionsForPhrase(phrase?.only_reverse)) {
-			if (d === 'forward') {
-				newForward++
-				newForwardPhrases.add(pid)
-			} else {
-				newReverse++
-				newReversePhrases.add(pid)
+				schedReversePhrases.add(c.phrase_id)
 			}
 		}
 	}
@@ -299,40 +339,20 @@ function ReviewPageContent() {
 							.select()
 							.throwOnError()
 
-			// Build manifest from card-level data.
+			// Build manifest from the bury-siblings-filtered candidate set.
 			// 4 buckets: forward due → forward new → reverse due → reverse new
 			const forwardDue: Array<ManifestEntry> = []
 			const forwardNew: Array<ManifestEntry> = []
 			const reverseDue: Array<ManifestEntry> = []
 			const reverseNew: Array<ManifestEntry> = []
 
-			const allPhraseSet = new Set(allPhraseIdsForToday)
-
-			// Existing cards: due (retrievability ≤ 0.9) or unreviewed fresh
-			for (const card of deckCards ?? []) {
-				if (!allPhraseSet.has(card.phrase_id)) continue
-				if (card.status !== 'active') continue
-
-				const isUnreviewed = !card.last_reviewed_at
-				if (!isUnreviewed && !isDueCard(card)) continue
-
-				const entry = toManifestEntry(card.phrase_id, card.direction)
-				const isFresh = isUnreviewed && freshSet.has(card.phrase_id)
-
-				if (card.direction === 'forward') {
+			for (const c of keptCandidates) {
+				const entry = toManifestEntry(c.phrase_id, c.direction)
+				const isFresh = c.bucket === 'fresh'
+				if (c.direction === 'forward') {
 					;(isFresh ? forwardNew : forwardDue).push(entry)
 				} else {
 					;(isFresh ? reverseNew : reverseDue).push(entry)
-				}
-			}
-
-			// Add newly created cards (not yet in deckCards)
-			for (const insert of cardInserts) {
-				const entry = toManifestEntry(insert.phrase_id, insert.direction)
-				if (insert.direction === 'forward') {
-					forwardNew.push(entry)
-				} else {
-					reverseNew.push(entry)
 				}
 			}
 


### PR DESCRIPTION
## Summary

Implements a bury-siblings policy that prevents both forward and reverse cards of the same phrase from appearing in the same review session. When both directions are eligible, the system intelligently decides which one to defer based on a prioritized set of rules.

## Key Changes

- **New module `bury-siblings.ts`**: Implements the core bury-siblings logic with three decision rules:
  - **Rule 0**: First-day exception — keep both siblings when both are unreviewed (recognition + recall in first session)
  - **Rule 1**: Defer reverse after consecutive failures — if the reverse card's two most recent phase-1 reviews both scored 1, bury it to let the user re-anchor recognition first
  - **Rule 2**: Defer by tomorrow retrievability — bury whichever sibling will be less overdue tomorrow (higher retrievability at t+1), keeping the card that decays faster
  - **Fallback**: When FSRS state can't be compared, default to burying reverse (recognition before recall)

- **Comprehensive test suite**: 409 lines of tests covering all rules, edge cases, and the partition function with multiple phrases

- **Integration in review manifest**: Modified `$lang.review.index.tsx` to:
  - Query all reviews for the current language (needed for Rule 1 failure detection)
  - Build a unified candidate list from both existing and newly-created cards
  - Apply `partitionBuriedSiblings()` exactly once to filter the manifest
  - Ensure display counts match the actual session manifest

- **Public API export**: Added bury-siblings exports to `review/index.ts` for use across the codebase

## Implementation Details

- The policy operates on a `BurySiblingCandidate` interface containing phrase_id, direction, last_reviewed_at, and stability — minimal data needed for decision-making
- Rule 1 specifically filters for phase-1 reviews (day_first_review=true) to avoid counting re-review attempts
- Tomorrow's retrievability is computed using the existing FSRS `retrievability()` function with date differences
- Buried siblings are simply omitted from the manifest; their user_card rows are still created so they can appear in future sessions
- Input order is preserved in the kept array for consistent display ordering

https://claude.ai/code/session_013hv1NTx3PY1DBgMzppJTNj