### PR TITLE
Add comment ownership gating test and seed data for comment-crud

### DIFF
--- a/scenetest/actors/default.ts
+++ b/scenetest/actors/default.ts
@@ -10,6 +10,21 @@ export default defineTeam({
 		nocard_phrase: 'aa110007-7777-4aaa-bbbb-cccccccccccc',
 		// A seed comment on the Hindi request used in comments-and-answers.spec.md.
 		seed_comment: 'c0000005-5555-4666-8777-888888888888',
+		// Request in [team.lang] used by comment-crud.spec.md. Must exist and be
+		// open for friend + learner to comment on.
+		comment_crud_request: 'e40e53ce-0b24-4b5d-9cf4-5c1ac16d4f96',
+		// Seeded phrase-linked comment on [team.comment_crud_request], owned by learner2.
+		// Required invariants for comment-crud.spec.md:
+		//   1. Has a comment_phrase_link row attached.
+		//   2. upvote_count > all sibling comments on the request, so it sorts FIRST
+		//      in the live query (orderBy upvote_count desc). Currently set to 5,
+		//      while the next-highest sibling sits at 3. Don't lower this.
+		// The spec then asserts friend's own badge as `comment-phrase-link-badge #2`.
+		phrase_linked_seed_comment: '800d41d1-3161-4a22-9d6f-dd0dcb29374a',
+		// A phrase in [team.lang] that friend attaches to their comment in
+		// comment-crud.spec.md. Must be searchable from the phrase picker by
+		// the substring 'dosa'.
+		attach_phrase: 'b0fbbe1d-705e-4d93-a231-ac55263fcfee',
 	},
 	actors: {
 		visitor: {
@@ -58,7 +73,8 @@ export default defineTeam({
 
 		// Tertiary actor; comments + replies.
 		// Comments: c0000002 (reply on hin e0d3a74e), c0000003 (kan e40e53ce),
-		//   c0000005 = team.seed_comment (on hin 3f8c9e2a)
+		//   c0000005 = team.seed_comment (on hin 3f8c9e2a),
+		//   800d41d1 = team.phrase_linked_seed_comment (on team.comment_crud_request)
 		learner2: {
 			email: 'sunloapp+1@gmail.com',
 			password: 'password',

--- a/scenetest/scenes/comment-crud.spec.md
+++ b/scenetest/scenes/comment-crud.spec.md
@@ -5,12 +5,12 @@
 // Finally deletes the comment to clean up.
 
 cleanup: supabase.from('comment_phrase_link').delete().eq('uid', '[friend.key]')
-cleanup: supabase.from('request_comment').delete().eq('uid', '[friend.key]').eq('request_id', 'e40e53ce-0b24-4b5d-9cf4-5c1ac16d4f96')
+cleanup: supabase.from('request_comment').delete().eq('uid', '[friend.key]').eq('request_id', '[team.comment_crud_request]')
 
 friend:
 
 - login
-- openTo /learn/kan/requests/e40e53ce-0b24-4b5d-9cf4-5c1ac16d4f96
+- openTo /learn/[team.lang]/requests/[team.comment_crud_request]
 - up
 - up
 - see request-detail-page
@@ -32,7 +32,7 @@ friend:
 - scope comment-dialog
 - click attach-phrase-button
 - typeInto phrase-search-input dosa
-- click phrase-picker-item b0fbbe1d-705e-4d93-a231-ac55263fcfee
+- click phrase-picker-item [team.attach_phrase]
 - see remove-phrase-button
 - up
 - typeInto edit-comment-content-input 'Updated: here is the phrase you need'
@@ -40,8 +40,9 @@ friend:
 - up
 
 // Verify the phrase badge is visible on the saved comment.
-// The seeded comment 800d41d1 also has a phrase link (with high upvote_count
-// so it sorts above friend's), so friend's badge is the second in DOM order.
+// [team.phrase_linked_seed_comment] also has a phrase link and is seeded with a
+// high upvote_count so it sorts above friend's, so friend's badge is the
+// second in DOM order. (See actors/default.ts for the invariant.)
 
 - see request-detail-page
 - see comment-phrase-link-badge #2
@@ -74,12 +75,12 @@ friend:
 // learner opens the request page, waits for collections to load,
 // then navigates to the reply URL to open the reply dialog.
 
-cleanup: supabase.from('request_comment').delete().eq('uid', '[learner.key]').eq('request_id', 'e40e53ce-0b24-4b5d-9cf4-5c1ac16d4f96').neq('id', 'c0000004-4444-4555-8666-777777777777')
+cleanup: supabase.from('request_comment').delete().eq('uid', '[learner.key]').eq('request_id', '[team.comment_crud_request]').neq('id', 'c0000004-4444-4555-8666-777777777777')
 
 learner:
 
 - login
-- openTo /learn/kan/requests/e40e53ce-0b24-4b5d-9cf4-5c1ac16d4f96
+- openTo /learn/[team.lang]/requests/[team.comment_crud_request]
 - up
 - see request-detail-page
 - click comment-item c0000003-3333-4444-8555-666666666666 show-replies-button

--- a/scenetest/scenes/comment-crud.spec.md
+++ b/scenetest/scenes/comment-crud.spec.md
@@ -110,3 +110,19 @@ learner:
 - see delete-comment-dialog
 - click confirm-delete-comment-button
 - up
+
+# friend cannot edit or delete learner2's seeded comment
+
+// Ownership gating: viewing someone else's comment, the edit and delete
+// controls must not render. Pairs with the RLS policies on request_comment
+// (Users can update/delete own comments) for defense in depth.
+
+friend:
+
+- login
+- openTo /learn/[team.lang]/requests/[team.comment_crud_request]
+- up
+- see request-detail-page
+- scope comment-item [team.phrase_linked_seed_comment]
+- notSee edit-comment-button
+- notSee delete-comment-button

--- a/scenetest/scenes/comment-crud.spec.md
+++ b/scenetest/scenes/comment-crud.spec.md
@@ -39,10 +39,12 @@ friend:
 - click save-comment-button
 - up
 
-// Verify the phrase badge is visible on the saved comment
+// Verify the phrase badge is visible on the saved comment.
+// The seeded comment 800d41d1 also has a phrase link (with high upvote_count
+// so it sorts above friend's), so friend's badge is the second in DOM order.
 
 - see request-detail-page
-- see comment-phrase-link-badge
+- see comment-phrase-link-badge #2
 - up
 
 // Edit again to remove the phrase link

--- a/scenetest/scenes/comment-crud.spec.md
+++ b/scenetest/scenes/comment-crud.spec.md
@@ -83,9 +83,7 @@ learner:
 - openTo /learn/[team.lang]/requests/[team.comment_crud_request]
 - up
 - see request-detail-page
-- click comment-item c0000003-3333-4444-8555-666666666666 show-replies-button
-- up
-- click comment-item c0000003-3333-4444-8555-666666666666 add-reply-inline
+- click comment-item c0000003-3333-4444-8555-666666666666 reply-link
 - scope reply-dialog
 - typeInto reply-content-input 'Thanks for the tip about dosas!'
 - click post-reply-button

--- a/scenetest/scenes/comment-crud.spec.md
+++ b/scenetest/scenes/comment-crud.spec.md
@@ -102,7 +102,7 @@ learner:
 // Delete the reply
 
 - see request-detail-page
-- see comment-reply
+- scope comment-reply
 - click delete-comment-button
 - up
 - see delete-comment-dialog

--- a/supabase/seed-comments.sql
+++ b/supabase/seed-comments.sql
@@ -53,7 +53,7 @@ values
 		'You just say "give one" like this',
 		now() - interval '23 hours',
 		now() - interval '23 hours',
-		0
+		5
 	);
 
 --

--- a/supabase/seed-comments.sql
+++ b/supabase/seed-comments.sql
@@ -45,6 +45,10 @@ values
 		now() - interval '1 days 23 hours',
 		0
 	),
+	-- team.phrase_linked_seed_comment (see scenetest/actors/default.ts).
+	-- comment-crud.spec.md depends on this comment having a phrase link AND
+	-- a higher upvote_count than every other comment on this request, so it
+	-- reliably sorts first in the live query. Don't drop the count below 4.
 	(
 		'800d41d1-3161-4a22-9d6f-dd0dcb29374a',
 		'e40e53ce-0b24-4b5d-9cf4-5c1ac16d4f96',


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for comment CRUD operations and ownership gating, along with the necessary seed data to support these tests.

## Key Changes

- **New test scenario**: Added "friend cannot edit or delete learner2's seeded comment" test case to verify that ownership gating prevents users from editing or deleting comments they don't own
- **Parameterized test data**: Replaced hardcoded UUIDs with team-level variables (`[team.comment_crud_request]`, `[team.attach_phrase]`, `[team.phrase_linked_seed_comment]`) for better maintainability and reusability
- **Enhanced seed data**: 
  - Added `phrase_linked_seed_comment` (800d41d1...) with upvote_count of 5 to ensure it sorts first in the live query
  - Added comment_phrase_link relationship to the seeded comment
  - Documented critical invariants for the seeded comment's upvote_count to maintain consistent test behavior
- **Improved test documentation**: Added clarifying comments explaining why the phrase badge assertion uses `#2` selector (accounting for the seeded comment sorting first)
- **Actor documentation**: Updated learner2 actor comments to reference the new phrase_linked_seed_comment

## Notable Implementation Details

- The seeded comment's upvote_count (5) is intentionally set higher than sibling comments (max 3) to guarantee it sorts first in the live query, making the test assertions deterministic
- The ownership gating test pairs with RLS policies on the request_comment table for defense-in-depth security validation
- All hardcoded IDs are now centralized in the team configuration for easier test data management

https://claude.ai/code/session_0147QxkNjXAGiEoT6d79DsE6