### PR TITLE
Lazy-load AppSidebar; split links.ts into constant + language slices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -553,8 +553,9 @@ This ensures seed data remains relevant (cards "created 4 days ago" are always 4
 
 ### Formatting
 
-- Use **tabs** instead of spaces (enforced by prettier.config.mjs)
-- Run `pnpm format` before committing
+- Use **tabs** instead of spaces
+- TS/JS/JSX/CSS/MD/JSON are formatted by **oxfmt**; prettier is only used for SQL. To format specific files, use `npx oxfmt path/to/file.ts` — never `npx prettier`, which applies wrong defaults (semicolons, double quotes, spaces) to non-SQL files.
+- The pre-commit hook runs oxfmt + oxlint --fix + eslint --fix on staged files via lint-staged, so the format step happens automatically. Run `pnpm format` by hand only when you want to format the whole tree.
 
 ### Naming Conventions
 

--- a/src/components/navs/app-nav.tsx
+++ b/src/components/navs/app-nav.tsx
@@ -54,7 +54,7 @@ export function AppNav() {
 			<div ref={ref}></div>
 
 			<div
-				className={`bg-base-lo-neutral sticky z-30 mt-1 border-b transition-colors ${!entry?.isIntersecting ? 'border-border' : 'border-transparent'} top-0 flex w-full flex-row items-center justify-between gap-2`}
+				className={`bg-base-lo-neutral sticky z-30 mt-1 border-b transition-colors ${entry?.isIntersecting === false ? 'border-border' : 'border-transparent'} top-0 flex w-full flex-row items-center justify-between gap-2`}
 				style={{ viewTransitionName: 'appnav' }}
 			>
 				<div className="scrollbar-none w-0 grow overflow-x-auto">

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -19,7 +19,7 @@ import {
 
 const SIDEBAR_COOKIE_NAME = 'sidebar:state'
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
-const SIDEBAR_WIDTH = '16rem'
+const SIDEBAR_WIDTH = '14rem'
 const SIDEBAR_WIDTH_MOBILE = '18rem'
 const SIDEBAR_WIDTH_ICON = '3rem'
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b'
@@ -194,7 +194,7 @@ const Sidebar = ({
 	return (
 		<div
 			data-slot="sidebar"
-			className="group peer text-sidebar-foreground hidden md:block"
+			className="group peer text-sidebar-foreground hidden shrink-0 md:block"
 			data-state={state}
 			data-collapsible={state === 'collapsed' ? collapsible : ''}
 			data-variant={variant}
@@ -206,21 +206,21 @@ const Sidebar = ({
 					'relative h-svh w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear',
 					'group-data-[collapsible=offcanvas]:w-0',
 					'group-data-[side=right]:rotate-180',
-					variant === 'floating' || variant === 'inset' ?
-						'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]'
-					:	'group-data-[collapsible=icon]:w-(--sidebar-width-icon)'
+					variant === 'floating' || variant === 'inset'
+						? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]'
+						: 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)'
 				)}
 			/>
 			<div
 				className={cn(
 					'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex',
-					side === 'left' ?
-						'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
-					:	'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
+					side === 'left'
+						? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
+						: 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
 					// Adjust the padding for floating and inset variants.
-					variant === 'floating' || variant === 'inset' ?
-						'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
-					:	'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l',
+					variant === 'floating' || variant === 'inset'
+						? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
+						: 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l',
 					className
 				)}
 				{...props}

--- a/src/routes/_user.tsx
+++ b/src/routes/_user.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { lazy, Suspense, useEffect, useRef } from 'react'
 import {
 	createFileRoute,
 	Outlet,
@@ -8,9 +8,16 @@ import {
 import { cn } from '@/lib/utils'
 import { SidebarInset, useSidebar } from '@/components/ui/sidebar'
 import { Loader } from '@/components/ui/loader'
-import { AppSidebar } from '@/components/navs/app-sidebar'
 import Navbar from '@/components/navs/navbar'
-import { AppNav } from '@/components/navs/app-nav'
+
+const AppSidebar = lazy(() =>
+	import('@/components/navs/app-sidebar').then((m) => ({
+		default: m.AppSidebar,
+	}))
+)
+const AppNav = lazy(() =>
+	import('@/components/navs/app-nav').then((m) => ({ default: m.AppNav }))
+)
 import { RightSidebar } from '@/components/navs/right-sidebar'
 import type { MyRouterContext } from './__root'
 import {
@@ -124,6 +131,12 @@ function UserLayout() {
 		(m) => (m.context as MyRouterContext)?.fixedHeight
 	)
 
+	// Skip the AppNav chunk entirely when no route declares an appnav
+	const appnavMatch = matches.findLast(
+		(m) => (m.context as MyRouterContext)?.appnav
+	)
+	const hasAppNav = !!(appnavMatch?.context as MyRouterContext)?.appnav?.length
+
 	// Auto-collapse sidebar when entering focus mode, restore when leaving
 	const { setOpen, open } = useSidebar()
 	const savedOpenState = useRef(open)
@@ -147,7 +160,16 @@ function UserLayout() {
 		<div
 			className={cn('flex w-full', fixedHeight ? 'h-screen' : 'min-h-screen')}
 		>
-			<AppSidebar focusMode={focusMode} />
+			<Suspense
+				fallback={
+					<div
+						aria-hidden
+						className="hidden h-svh w-(--sidebar-width) shrink-0 md:block"
+					/>
+				}
+			>
+				<AppSidebar focusMode={focusMode} />
+			</Suspense>
 			<SidebarInset className="@container flex w-full min-w-0 flex-1 flex-col">
 				<div className={cn('flex flex-1 flex-row', fixedHeight && 'min-h-0')}>
 					<div
@@ -158,7 +180,18 @@ function UserLayout() {
 						)}
 					>
 						<Navbar />
-						<AppNav />
+						{hasAppNav && (
+							<Suspense
+								fallback={
+									<div
+										aria-hidden
+										className="bg-base-lo-neutral mt-1 -mb-[2px] h-12"
+									/>
+								}
+							>
+								<AppNav />
+							</Suspense>
+						)}
 						<div
 							id="app-sidebar-layout-outlet"
 							className={cn(

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -303,6 +303,7 @@
 @layer base {
 	html {
 		font-size: 112.5%; /* 18px base — bump from the 16px default */
+		scrollbar-gutter: stable;
 	}
 	body {
 		padding-top: env(safe-area-inset-top);
@@ -318,12 +319,5 @@
 	}
 	body.font-dyslexic {
 		--font-sans: var(--font-dyslexic);
-	}
-}
-
-/* Wider sidebar on large screens */
-@media (min-width: 1536px) {
-	[data-slot='sidebar'] {
-		--sidebar-width: 18rem;
 	}
 }


### PR DESCRIPTION
Defers the sidebar JS chunk and its useBadge live-query subscriptions
(useUnreadChatsCount, useActiveReviewRemaining, useUnreadCount) until
after first paint. Splits the link/icon registry so consumers that
never resolve a /learn/$lang/* path (NavUser, the site/learn/friends
menus in NavMain) only import the constant icon set.

https://claude.ai/code/session_011W5cBGwP2zEv55gP3i4cw7