### PR TITLE
Improve dialog component UX with close button and focus management

### DIFF
--- a/src/components/intro-sheet.tsx
+++ b/src/components/intro-sheet.tsx
@@ -118,6 +118,7 @@ export function IntroSheet({
 			<DialogContent
 				data-testid={testId ?? 'intro-message-section'}
 				className="max-h-[85vh] overflow-y-auto sm:max-w-lg"
+				hideClose={requireAffirmation}
 			>
 				<DialogHeader>
 					<DialogTitle>{title}</DialogTitle>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -71,10 +71,12 @@ const DialogOverlay = ({
 const DialogContent = ({
 	className,
 	children,
+	hideClose = false,
 	onInteractOutside: _onInteractOutside,
 	onEscapeKeyDown: _onEscapeKeyDown,
 	...props
 }: DialogPrimitive.Popup.Props & {
+	hideClose?: boolean
 	onInteractOutside?: unknown
 	onEscapeKeyDown?: unknown
 }) => (
@@ -88,15 +90,17 @@ const DialogContent = ({
 			)}
 			{...props}
 		>
-			<div className="pointer-events-none sticky top-0 z-20 -mx-6 -mt-6 h-0">
-				<DialogPrimitive.Close
-					data-testid="close-dialog-button"
-					className="bg-card/50 text-foreground/70 hover:text-foreground focus:ring-ring pointer-events-auto absolute top-4 right-4 rounded-sm p-1 backdrop-blur-sm transition-colors focus:ring-2 focus:outline-hidden disabled:pointer-events-none"
-				>
-					<X className="size-4" />
-					<span className="sr-only">Close</span>
-				</DialogPrimitive.Close>
-			</div>
+			{!hideClose && (
+				<div className="pointer-events-none sticky top-0 z-20 -mx-6 -mt-6 h-0">
+					<DialogPrimitive.Close
+						data-testid="close-dialog-button"
+						className="bg-card/50 text-foreground/70 hover:text-foreground focus:ring-ring pointer-events-auto absolute top-4 right-4 rounded-sm p-1 backdrop-blur-sm transition-colors focus:ring-2 focus:outline-hidden disabled:pointer-events-none"
+					>
+						<X className="size-4" />
+						<span className="sr-only">Close</span>
+					</DialogPrimitive.Close>
+				</div>
+			)}
 			{children}
 		</DialogPrimitive.Popup>
 	</DialogPortal>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -88,14 +88,16 @@ const DialogContent = ({
 			)}
 			{...props}
 		>
+			<div className="pointer-events-none sticky top-0 z-20 -mx-6 -mt-6 h-0">
+				<DialogPrimitive.Close
+					data-testid="close-dialog-button"
+					className="bg-card/50 text-foreground/70 hover:text-foreground focus:ring-ring pointer-events-auto absolute top-4 right-4 rounded-sm p-1 backdrop-blur-sm transition-colors focus:ring-2 focus:outline-hidden disabled:pointer-events-none"
+				>
+					<X className="size-4" />
+					<span className="sr-only">Close</span>
+				</DialogPrimitive.Close>
+			</div>
 			{children}
-			<DialogPrimitive.Close
-				data-testid="close-dialog-button"
-				className="ring-offset-background focus:ring-ring data-[open]:bg-accent data-[open]:text-muted-foreground absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
-			>
-				<X className="size-4" />
-				<span className="sr-only">Close</span>
-			</DialogPrimitive.Close>
 		</DialogPrimitive.Popup>
 	</DialogPortal>
 )

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -79,32 +79,41 @@ const DialogContent = ({
 	hideClose?: boolean
 	onInteractOutside?: unknown
 	onEscapeKeyDown?: unknown
-}) => (
-	<DialogPortal>
-		<DialogOverlay />
-		<DialogPrimitive.Popup
-			data-slot="dialog-content"
-			className={cn(
-				'bg-card data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[min(50rem,96%)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded border p-6 shadow-lg duration-200',
-				className
-			)}
-			{...props}
-		>
-			{!hideClose && (
-				<div className="pointer-events-none sticky top-0 z-20 -mx-6 -mt-6 h-0">
-					<DialogPrimitive.Close
-						data-testid="close-dialog-button"
-						className="bg-card/50 text-foreground/70 hover:text-foreground focus:ring-ring pointer-events-auto absolute top-4 right-4 rounded-sm p-1 backdrop-blur-sm transition-colors focus:ring-2 focus:outline-hidden disabled:pointer-events-none"
-					>
-						<X className="size-4" />
-						<span className="sr-only">Close</span>
-					</DialogPrimitive.Close>
-				</div>
-			)}
-			{children}
-		</DialogPrimitive.Popup>
-	</DialogPortal>
-)
+}) => {
+	const popupRef = React.useRef<HTMLDivElement>(null)
+	return (
+		<DialogPortal>
+			<DialogOverlay />
+			<DialogPrimitive.Popup
+				ref={popupRef}
+				data-slot="dialog-content"
+				initialFocus={() =>
+					popupRef.current?.querySelector<HTMLElement>(
+						'[data-slot="dialog-title"]'
+					) ?? popupRef.current
+				}
+				className={cn(
+					'bg-card data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[min(50rem,96%)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded border p-6 shadow-lg duration-200',
+					className
+				)}
+				{...props}
+			>
+				{!hideClose && (
+					<div className="pointer-events-none sticky top-0 z-20 -mx-6 -mt-6 h-0">
+						<DialogPrimitive.Close
+							data-testid="close-dialog-button"
+							className="bg-card/50 text-foreground/70 hover:text-foreground focus:ring-ring pointer-events-auto absolute top-4 right-4 rounded-sm p-1 backdrop-blur-sm transition-colors focus:ring-2 focus:outline-hidden disabled:pointer-events-none"
+						>
+							<X className="size-4" />
+							<span className="sr-only">Close</span>
+						</DialogPrimitive.Close>
+					</div>
+				)}
+				{children}
+			</DialogPrimitive.Popup>
+		</DialogPortal>
+	)
+}
 
 const DialogHeader = ({
 	className,
@@ -132,8 +141,9 @@ const DialogFooter = ({
 const DialogTitle = ({ className, ...props }: DialogPrimitive.Title.Props) => (
 	<DialogPrimitive.Title
 		data-slot="dialog-title"
+		tabIndex={-1}
 		className={cn(
-			'text-foreground/90 text-lg leading-none font-semibold tracking-tight',
+			'text-foreground/90 text-lg leading-none font-semibold tracking-tight focus:outline-hidden',
 			className
 		)}
 		{...props}


### PR DESCRIPTION
## Summary
Enhanced the dialog component with better accessibility and UX improvements, including an optional close button with improved styling, automatic focus management, and the ability to hide the close button when needed.

## Key Changes
- **Close button improvements**: Redesigned close button with better styling (backdrop blur, improved contrast) and wrapped in a sticky container for better positioning
- **Focus management**: Added `initialFocus` prop to automatically focus the dialog title on open, improving keyboard navigation
- **Optional close button**: Added `hideClose` prop to `DialogContent` to allow hiding the close button (useful for required affirmation dialogs)
- **DialogTitle accessibility**: Added `tabIndex={-1}` and `focus:outline-hidden` to the title for proper focus management
- **IntroSheet integration**: Updated `IntroSheet` component to hide close button when `requireAffirmation` is true, preventing users from dismissing required dialogs

## Implementation Details
- The close button is now wrapped in a `pointer-events-none` sticky container with a `pointer-events-auto` close button inside, allowing it to stay visible while scrolling
- The dialog now uses a ref to track the popup element and sets initial focus to the title element if available
- Styling improvements include semi-transparent background (`bg-card/50`), backdrop blur effect, and better color contrast for the close button

https://claude.ai/code/session_01JLcPbvCGvLfDaZrYAnABW4