### PR TITLE
Consolidate UI preferences management into shared module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,7 +351,7 @@ const mutation = useMutation({
   - `use-smart-search.ts` - `useSmartSearch()`: server-side trigram similarity search via `search_phrases_smart` RPC with debounce and local collection hydration
   - `links.ts` - `useLinks()`: returns route paths with navigation metadata and status badges for sidebar
   - `use-debounce.ts` - `useDebounce()`, `usePrevious()`, `useIntersectionObserver()`: generic React utilities
-  - `use-font-preference.ts` - `useFontPreference()`: applies dyslexic/normal font from the user's profile to document body (defaults to standard font when no preference is set)
+  - `use-font-preference.ts` - `useFontPreference()`: applies dyslexic/normal font to document body. Reads from profile when authenticated, falls back to localStorage (`sunlo-font-preference`) for first-paint before profile loads. Cleared on logout via `resetUiPrefs()` so a new user on the same device gets the standard default.
   - `use-intro-seen.ts` - `useIntro()`: manages intro/training dialog state ('unseen'/'seen'/'affirmed') via localStorage. Used for onboarding, review intro, deck settings intro
   - `use-mobile.tsx` - `useIsMobile()`: viewport width < 768px detection
   - `use-require-auth.ts` - `useRequireAuth()`: wraps actions with auth check, shows toast and redirects if not authenticated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,7 +351,7 @@ const mutation = useMutation({
   - `use-smart-search.ts` - `useSmartSearch()`: server-side trigram similarity search via `search_phrases_smart` RPC with debounce and local collection hydration
   - `links.ts` - `useLinks()`: returns route paths with navigation metadata and status badges for sidebar
   - `use-debounce.ts` - `useDebounce()`, `usePrevious()`, `useIntersectionObserver()`: generic React utilities
-  - `use-font-preference.ts` - `useFontPreference()`: applies dyslexic/normal font from profile or localStorage to document body
+  - `use-font-preference.ts` - `useFontPreference()`: applies dyslexic/normal font from the user's profile to document body (defaults to standard font when no preference is set)
   - `use-intro-seen.ts` - `useIntro()`: manages intro/training dialog state ('unseen'/'seen'/'affirmed') via localStorage. Used for onboarding, review intro, deck settings intro
   - `use-mobile.tsx` - `useIsMobile()`: viewport width < 768px detection
   - `use-require-auth.ts` - `useRequireAuth()`: wraps actions with auth check, shows toast and redirects if not authenticated

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -5,6 +5,7 @@ import {
 	useEffect,
 	useState,
 } from 'react'
+import { THEME_KEY, onUiPrefsReset } from '@/lib/ui-prefs'
 
 type Theme = 'dark' | 'light' | 'system'
 
@@ -28,8 +29,8 @@ const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
 
 export function ThemeProvider({
 	children,
-	defaultTheme = 'system',
-	storageKey = 'vite-ui-theme',
+	defaultTheme = 'light',
+	storageKey = THEME_KEY,
 	...props
 }: ThemeProviderProps) {
 	const [theme, setTheme] = useState<Theme>(
@@ -42,10 +43,10 @@ export function ThemeProvider({
 		root.classList.remove('light', 'dark')
 
 		if (theme === 'system') {
-			const systemTheme =
-				window.matchMedia('(prefers-color-scheme: dark)').matches ?
-					'dark'
-				:	'light'
+			const systemTheme = window.matchMedia('(prefers-color-scheme: dark)')
+				.matches
+				? 'dark'
+				: 'light'
 
 			root.classList.add(systemTheme)
 			return
@@ -53,6 +54,8 @@ export function ThemeProvider({
 
 		root.classList.add(theme)
 	}, [theme])
+
+	useEffect(() => onUiPrefsReset(() => setTheme(defaultTheme)), [defaultTheme])
 
 	const value = {
 		theme,

--- a/src/hooks/use-font-preference.ts
+++ b/src/hooks/use-font-preference.ts
@@ -1,14 +1,22 @@
 import { useEffect } from 'react'
 import { useProfile } from '@/features/profile/hooks'
+import { FONT_PREF_KEY } from '@/lib/ui-prefs'
 
 export function useFontPreference() {
 	const { data: profile } = useProfile()
 
 	useEffect(() => {
-		if (profile?.font_preference === 'dyslexic') {
+		const fontPref =
+			profile?.font_preference ?? localStorage.getItem(FONT_PREF_KEY)
+
+		if (fontPref === 'dyslexic') {
 			document.body.classList.add('font-dyslexic')
 		} else {
 			document.body.classList.remove('font-dyslexic')
+		}
+
+		if (profile?.font_preference) {
+			localStorage.setItem(FONT_PREF_KEY, profile.font_preference)
 		}
 	}, [profile?.font_preference])
 }

--- a/src/hooks/use-font-preference.ts
+++ b/src/hooks/use-font-preference.ts
@@ -1,43 +1,14 @@
 import { useEffect } from 'react'
 import { useProfile } from '@/features/profile/hooks'
 
-const FONT_PREF_KEY = 'sunlo-font-preference'
-
-/**
- * Applies the user's font preference to the document body.
- * Uses localStorage for immediate application on page load,
- * then syncs with profile data when available.
- */
 export function useFontPreference() {
 	const { data: profile } = useProfile()
 
 	useEffect(() => {
-		// Get preference from profile or localStorage
-		const fontPref =
-			profile?.font_preference ?? localStorage.getItem(FONT_PREF_KEY)
-
-		// Apply the font class
-		if (fontPref === 'dyslexic') {
+		if (profile?.font_preference === 'dyslexic') {
 			document.body.classList.add('font-dyslexic')
 		} else {
 			document.body.classList.remove('font-dyslexic')
 		}
-
-		// Sync localStorage with profile preference
-		if (profile?.font_preference) {
-			localStorage.setItem(FONT_PREF_KEY, profile.font_preference)
-		}
 	}, [profile?.font_preference])
-}
-
-/**
- * For use in non-authenticated contexts - applies font from localStorage only
- */
-export function useLocalFontPreference() {
-	useEffect(() => {
-		const fontPref = localStorage.getItem(FONT_PREF_KEY)
-		if (fontPref === 'dyslexic') {
-			document.body.classList.add('font-dyslexic')
-		}
-	}, [])
 }

--- a/src/lib/collections/clear-user.ts
+++ b/src/lib/collections/clear-user.ts
@@ -17,8 +17,14 @@ import { phraseRequestUpvotesCollection } from '@/features/requests/collections'
 import { phrasePlaylistUpvotesCollection } from '@/features/playlists/collections'
 import { notificationsCollection } from '@/features/notifications/collections'
 import { queryClient } from '@/lib/query-client'
+import { resetUiPrefs } from '@/lib/ui-prefs'
 
 export const clearUser = async () => {
+	// Drop device-local UI prefs (font, theme) so a new user on the same
+	// device sees the standard defaults rather than inheriting the previous
+	// user's accessibility/theme choices.
+	resetUiPrefs()
+
 	// Refetch (don't cleanup) each user collection. Post-logout the client has
 	// no JWT so RLS returns empty, the collection clears, and any active live
 	// queries simply see rows removed. Calling .cleanup() instead would fire

--- a/src/lib/collections/clear-user.ts
+++ b/src/lib/collections/clear-user.ts
@@ -20,9 +20,6 @@ import { queryClient } from '@/lib/query-client'
 import { resetUiPrefs } from '@/lib/ui-prefs'
 
 export const clearUser = async () => {
-	// Drop device-local UI prefs (font, theme) so a new user on the same
-	// device sees the standard defaults rather than inheriting the previous
-	// user's accessibility/theme choices.
 	resetUiPrefs()
 
 	// Refetch (don't cleanup) each user collection. Post-logout the client has

--- a/src/lib/ui-prefs.ts
+++ b/src/lib/ui-prefs.ts
@@ -1,0 +1,18 @@
+export const FONT_PREF_KEY = 'sunlo-font-preference'
+export const THEME_KEY = 'vite-ui-theme'
+
+const resetListeners = new Set<() => void>()
+
+export function onUiPrefsReset(cb: () => void): () => void {
+	resetListeners.add(cb)
+	return () => {
+		resetListeners.delete(cb)
+	}
+}
+
+export function resetUiPrefs() {
+	localStorage.removeItem(FONT_PREF_KEY)
+	localStorage.removeItem(THEME_KEY)
+	document.body.classList.remove('font-dyslexic')
+	for (const cb of resetListeners) cb()
+}


### PR DESCRIPTION
## Summary
Refactored UI preferences (font and theme) into a centralized module with a unified reset mechanism. This ensures consistent behavior across preference types and simplifies cleanup on logout.

## Key Changes
- **New `src/lib/ui-prefs.ts` module**: Centralized constants and utilities for UI preferences
  - Exports `FONT_PREF_KEY` and `THEME_KEY` constants
  - Implements `resetUiPrefs()` to clear all UI preferences from localStorage and DOM
  - Provides `onUiPrefsReset()` callback system for components to react to preference resets

- **Simplified `use-font-preference.ts`**:
  - Removed `useLocalFontPreference()` hook (no longer needed)
  - Removed redundant JSDoc comments
  - Imports `FONT_PREF_KEY` from centralized module
  - Updated documentation to clarify fallback behavior and logout cleanup

- **Updated `theme-provider.tsx`**:
  - Uses `THEME_KEY` constant from `ui-prefs` module
  - Changed default theme from `'system'` to `'light'`
  - Added effect hook to reset theme to default when UI preferences are cleared
  - Minor formatting improvements to ternary operator

- **Updated `clear-user.ts`**:
  - Calls `resetUiPrefs()` on logout to clear all UI preferences
  - Ensures new users on the same device get standard defaults

- **Updated `CLAUDE.md`**:
  - Enhanced documentation for `useFontPreference()` to explain profile/localStorage fallback and logout behavior

## Implementation Details
The new callback system in `ui-prefs.ts` allows components (like `ThemeProvider`) to subscribe to preference resets without creating circular dependencies. When a user logs out, `resetUiPrefs()` clears localStorage, removes DOM classes, and notifies all subscribers to reset their state.

https://claude.ai/code/session_011WFgF4eB2prGfC8xSikWAV