### PR TITLE
Refactor ActionCard props to use discriminated union type

### DIFF
--- a/src/routes/_user/welcome.tsx
+++ b/src/routes/_user/welcome.tsx
@@ -301,6 +301,26 @@ function FeatureItem({
 	)
 }
 
+type ActionCardProps = {
+	icon: typeof WalletCards
+	title: string
+	description: string
+	linkText: string
+	variant?: 'primary' | 'secondary'
+	disabled?: boolean
+} & (
+	| {
+			onButtonClick: () => void
+			linkTo?: never
+			linkSearch?: never
+	  }
+	| {
+			onButtonClick?: never
+			linkTo: string
+			linkSearch?: Record<string, unknown>
+	  }
+)
+
 function ActionCard({
 	icon: Icon,
 	title,
@@ -311,17 +331,7 @@ function ActionCard({
 	variant = 'secondary',
 	disabled = false,
 	onButtonClick,
-}: {
-	icon: typeof WalletCards
-	title: string
-	description: string
-	linkTo?: string
-	linkSearch?: Record<string, unknown>
-	linkText: string
-	variant?: 'primary' | 'secondary'
-	disabled?: boolean
-	onButtonClick?: () => void
-}) {
+}: ActionCardProps) {
 	const isPrimary = variant === 'primary'
 
 	return (
@@ -360,7 +370,7 @@ function ActionCard({
 					</Button>
 				) : (
 					<Link
-						to={linkTo!}
+						to={linkTo}
 						search={linkSearch}
 						className={cn(
 							buttonVariants({


### PR DESCRIPTION
## Summary
Extracted the `ActionCard` component's props into a reusable `ActionCardProps` type that uses a discriminated union to enforce mutually exclusive prop combinations. This improves type safety and developer experience by preventing invalid prop combinations at compile time.

## Key Changes
- Created `ActionCardProps` type with discriminated union pattern that enforces:
  - Either `onButtonClick` callback (without `linkTo` or `linkSearch`)
  - Or `linkTo` navigation (without `onButtonClick`, with optional `linkSearch`)
- Moved inline prop type definition to named type for reusability
- Updated `ActionCard` function signature to use the new `ActionCardProps` type
- Removed non-null assertion (`!`) on `linkTo` prop since the discriminated union now guarantees it's defined when needed

## Implementation Details
The discriminated union pattern ensures that consumers of the `ActionCard` component cannot accidentally mix navigation props with callback props, eliminating a class of runtime errors and improving the API's clarity.

https://claude.ai/code/session_01BPjRxsJx7jh3v4gtMB4F4Y