### PR TITLE
Loosen SQL prettier expressionWidth from 64 to 120

### DIFF
--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -13,7 +13,7 @@ const config = {
 	identifierCase: 'lower',
 	indentStyle: 'standard',
 	logicalOperatorNewline: 'before',
-	expressionWidth: 64,
+	expressionWidth: 120,
 	denseOperators: false,
 	database: 'postgresql',
 }


### PR DESCRIPTION
## Summary

- Bumps `expressionWidth` in `prettier.config.mjs` from 64 to 120 so prettier-plugin-sql stops splitting short value tuples across multiple lines.
- Before: each `('Zulu', 'zul', null)` row in seed inserts spanned 5 lines. After: stays on one line; long expressions still wrap.

## Notes

- Only the config is committed. Existing SQL files were not bulk-reformatted, so `pnpm format:check` will report them as unformatted until they're touched in normal work or someone runs `pnpm format` deliberately.
- Reformatting the whole tree affected 53 files (~1600 line deletions, mostly already-applied migrations) — left out of this PR to keep the diff reviewable.

## Test plan

- [ ] `pnpm format` reformats `supabase/seed.sql` so the language inserts (e.g. `('Zulu', 'zul', null)`) collapse to a single line per row.
- [ ] Confirm long expressions / multi-column inserts still wrap reasonably.

https://claude.ai/code/session_01SrLtyQdaFdhRZN1qZpscPm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrLtyQdaFdhRZN1qZpscPm)_