### PR TITLE
Refactor card status updates to use optimistic local mutations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,31 +287,67 @@ export const useDeckCards = (lang: string) =>
 
 ### Mutations Pattern
 
-**Always use `useMutation`** for any server state changes (including login/logout), even when there's no form.
-
-Standard approach:
-
-1. Return updated/inserted rows from mutation with `.select()`
-2. Update local collection in `onSuccess` with `utils.writeInsert/writeUpdate`
-3. For complex server-side changes, use `invalidateQueries()` instead
-
-Two update patterns:
-
-1. **Direct collection updates** (optimistic UI):
+**Standard:** define persistence on the collection itself via `onInsert / onUpdate / onDelete` handlers, then call `collection.insert / update / delete` from components. The optimistic update lands in the same tick; throwing from the handler rolls it back automatically. Attach success/error UX to the returned `Transaction.isPersisted.promise`.
 
 ```typescript
-phrasePlaylistsCollection.utils.writeInsert(PhrasePlaylistSchema.parse(data))
+// features/<domain>/collections.ts — persistence lives here
+export const cardsCollection = createCollection(
+	queryCollectionOptions({
+		// ...id, queryKey, queryFn, getKey, schema...
+		onUpdate: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map((m) =>
+					supabase
+						.from('user_card')
+						.update(m.changes)
+						.eq('id', m.original.id)
+						.throwOnError()
+				)
+			)
+			return { refetch: false } // optimistic value matches server; skip reload
+		},
+	})
+)
+
+// component — declare the optimistic intent, react to collection state
+const { data: card } = useMyCard(phrase.id)
+
+const setCardStatus = (status: CardStatus) => {
+	if (!card) return
+	const tx = cardsCollection.update(card.id, (draft) => {
+		draft.status = status
+	})
+	tx.isPersisted.promise.then(
+		() => toastSuccess(STATUS_TOAST_MESSAGES[status]),
+		(err) => {
+			toastError('Failed to update card status')
+			console.error('rolled back', err)
+		}
+	)
+}
 ```
 
-2. **React Query mutations** (typical pattern):
+The component subscribes to the collection via `useLiveQuery` (here through `useMyCard`), so the menu / button state reflects the optimistic value immediately and flips back if the server rejects.
+
+See PR #623 (`cardsCollection.onUpdate` + review context-menu) for a worked example. See also the [TanStack DB optimistic-mutations skill](node_modules/@tanstack/db/skills/db-core/mutations-optimistic/SKILL.md) for `createOptimisticAction` (multi-collection atomic mutations) and `createPacedMutations` (auto-save / debounce / throttle).
+
+**Reasonable exceptions:**
+
+- **Realtime sync handlers** writing supabase channel events into a collection (`chatMessagesCollection.utils.writeInsert(...)` inside a `postgres_changes` callback) — that's sync, not a mutation.
+- **Mutations whose server-side transformation can't be predicted client-side** (e.g. FSRS scheduling on review submission) — evaluate case-by-case; may need `createOptimisticAction` with a best-guess optimistic update, or may legitimately keep the React Query pattern.
+
+**Deprecated** — do not use for new code, and migrate when touching old code (tracked by the `transform` label):
 
 ```typescript
+// ❌ useMutation calling supabase directly + manual local sync in onSuccess.
+// React Query routes onSuccess errors to onError, so a successful DB write
+// whose post-success sync throws surfaces as a misleading "Failed to X" toast.
 const mutation = useMutation({
 	mutationFn: async (values) => {
 		const { data } = await supabase
 			.from('phrase')
 			.insert(values)
-			.select() // Always return the data
+			.select()
 			.throwOnError()
 		return data[0]
 	},
@@ -846,37 +882,13 @@ Use `await Promise.all([...])` when the route needs the data before first render
 
 ### Mutation Best Practices
 
-- **Always use `useMutation`** for any server state changes (including login/logout)
-- **Return updated/inserted rows** from mutations with `.select()`
-- **Update local collections** in `onSuccess` using `collection.utils.writeInsert/writeUpdate`
-- Use `toast.success()` in onSuccess, `toast.error()` and `console.log('Error', error)` in onError
-- For complex server-side updates, it's fine to just `invalidateQueries()` instead
+- **Persistence lives on the collection** via `onInsert/onUpdate/onDelete` handlers; call sites use `collection.insert / update / delete` for optimistic local state
+- **Throw from the handler** to roll the optimistic state back; **return `{ refetch: false }`** from a `queryCollectionOptions` handler when the optimistic value already matches what the server confirmed (skip the post-handler full refetch)
+- **Wire success/error toasts to `Transaction.isPersisted.promise`** at the call site — `onSuccess` errors won't masquerade as mutation errors anymore
+- **Subscribe to collection state with `useLiveQuery`** so the UI reflects the optimistic value (and snaps back on rollback) without ad-hoc local state
+- For mutations whose server-side effect can't be predicted client-side, see `createOptimisticAction` in the TanStack DB optimistic-mutations skill
 
-### Complete Mutation Example
-
-```typescript
-const mutation = useMutation<DeckRow, PostgrestError, DeckGoalFormInputs>({
-	mutationKey: ['user', lang, 'deck', 'settings', 'goal'],
-	mutationFn: async (values) => {
-		const { data } = await supabase
-			.from('user_deck')
-			.update(values)
-			.eq('lang', lang)
-			.eq('uid', userId!)
-			.throwOnError()
-			.select()
-		return data[0]
-	},
-	onSuccess: (data) => {
-		toast.success('Deck settings updated!')
-		decksCollection.utils.writeUpdate(DeckMetaRawSchema.parse(data))
-	},
-	onError: (error) => {
-		toast.error('Update failed')
-		console.log('Error', error)
-	},
-})
-```
+See the "Mutations Pattern" section above for a worked example, and PR #623 / the `transform` label for the in-flight migration.
 
 ## Testing Conventions
 

--- a/src/components/review/review-single-card.tsx
+++ b/src/components/review/review-single-card.tsx
@@ -1,8 +1,13 @@
-import { type CSSProperties, useCallback, useEffect, useState } from 'react'
+import {
+	type CSSProperties,
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useState,
+} from 'react'
 import { toastError, toastNeutral, toastSuccess } from '@/components/ui/sonner'
 import { playReviewSound } from '@/lib/review-sounds'
 import { useSoundEnabled } from '@/features/profile'
-import { useMutation } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import {
 	BookmarkCheck,
@@ -13,6 +18,7 @@ import {
 	Lightbulb,
 	MoreVertical,
 	Play,
+	RotateCcw,
 	Send,
 } from 'lucide-react'
 
@@ -45,17 +51,15 @@ import {
 	PhraseFullFilteredType,
 	TranslationType,
 } from '@/features/phrases/schemas'
-import {
-	type CardDirectionType,
-	CardStatusEnumSchema,
-} from '@/features/deck/schemas'
+import { type CardDirectionType, type CardMetaType } from '@/features/deck'
 import { uuid } from '@/types/main'
 import { usePhrase } from '@/hooks/composite-phrase'
 import { CardlikeFlashcard } from '@/components/ui/card-like'
-import supabase from '@/lib/supabase-client'
-import { useUserId } from '@/lib/use-auth'
 import { cardsCollection } from '@/features/deck/collections'
+import { useMyCard } from '@/features/deck/hooks'
 import { useCheck, should } from '@scenetest/checks-react'
+
+type CardStatus = CardMetaType['status']
 
 const playAudio = (text: string) => {
 	toastNeutral(`Playing audio for: ${text}`)
@@ -404,6 +408,37 @@ export function ReviewSingleCard({
 	)
 }
 
+const STATUS_TOAST_MESSAGES: Record<CardStatus, string> = {
+	active: 'This card is back in your active reviews.',
+	learned:
+		"Great! This card is now marked as learned and won't appear in your reviews.",
+	skipped: "This card has been skipped and won't appear in your reviews.",
+}
+
+const REACTIVATE_ITEM = {
+	icon: <RotateCcw className="me-2 h-4 w-4" />,
+	label: 'Re-activate this card',
+}
+
+// One row per non-active status: the action shown when current status is
+// 'active', or "Re-activate this card" when current status already matches.
+const STATUS_TOGGLE_ITEMS: Array<{
+	target: Exclude<CardStatus, 'active'>
+	icon: ReactNode
+	label: string
+}> = [
+	{
+		target: 'learned',
+		icon: <BookmarkCheck className="me-2 h-4 w-4 text-green-600" />,
+		label: "I've learned this",
+	},
+	{
+		target: 'skipped',
+		icon: <BookmarkX className="me-2 h-4 w-4" />,
+		label: 'Skip this card',
+	},
+]
+
 function ContextMenu({
 	phrase,
 	direction,
@@ -414,44 +449,27 @@ function ContextMenu({
 	const [isOpen, setIsOpen] = useState(false)
 	const [sendChatOpen, setSendChatOpen] = useState(false)
 	const [detailsOpen, setDetailsOpen] = useState(false)
-	const userId = useUserId()
 
-	const cardStatusMutation = useMutation({
-		mutationKey: ['update-card-status', phrase.id],
-		mutationFn: async (status: 'learned' | 'skipped') => {
-			if (!userId) throw new Error('You must be logged in')
-			const { data } = await supabase
-				.from('user_card')
-				.update({ status })
-				.eq('phrase_id', phrase.id)
-				.eq('uid', userId)
-				.select()
-				.throwOnError()
-			return data
-		},
-		onSuccess: (data) => {
-			if (data) {
-				for (const card of data) {
-					cardsCollection.utils.writeUpdate({
-						id: card.id,
-						status: CardStatusEnumSchema.parse(card.status),
-						updated_at: card.updated_at!,
-					})
-				}
-				const status = data[0]?.status
-				const message =
-					status === 'learned'
-						? "Great! This card is now marked as learned and won't appear in your reviews."
-						: "This card has been skipped and won't appear in your reviews."
-				toastSuccess(message)
+	const { data: card } = useMyCard(phrase.id)
+	const currentStatus = card?.status
+
+	const setCardStatus = (status: CardStatus) => {
+		if (!card) return
+		const ids = card.sibling_id ? [card.id, card.sibling_id] : [card.id]
+		setIsOpen(false)
+		const tx = cardsCollection.update(ids, (drafts) => {
+			drafts.forEach((d) => {
+				d.status = status
+			})
+		})
+		tx.isPersisted.promise.then(
+			() => toastSuccess(STATUS_TOAST_MESSAGES[status]),
+			(err) => {
+				toastError('Failed to update card status')
+				console.error('Card status update rolled back:', err)
 			}
-			setIsOpen(false)
-		},
-		onError: (error) => {
-			toastError('Failed to update card status')
-			console.log('Error updating card status', error)
-		},
-	})
+		)
+	}
 
 	return (
 		<>
@@ -469,20 +487,18 @@ function ContextMenu({
 					<MoreVertical />
 				</DropdownMenuTrigger>
 				<DropdownMenuContent align="end" className="w-56">
-					<DropdownMenuItem
-						onClick={() => cardStatusMutation.mutate('learned')}
-						disabled={cardStatusMutation.isPending}
-					>
-						<BookmarkCheck className="me-2 h-4 w-4 text-green-600" />
-						I've learned this
-					</DropdownMenuItem>
-					<DropdownMenuItem
-						onClick={() => cardStatusMutation.mutate('skipped')}
-						disabled={cardStatusMutation.isPending}
-					>
-						<BookmarkX className="me-2 h-4 w-4" />
-						Skip this card
-					</DropdownMenuItem>
+					{STATUS_TOGGLE_ITEMS.map(({ target, icon, label }) => {
+						const isCurrent = currentStatus === target
+						return (
+							<DropdownMenuItem
+								key={target}
+								onClick={() => setCardStatus(isCurrent ? 'active' : target)}
+							>
+								{isCurrent ? REACTIVATE_ITEM.icon : icon}
+								{isCurrent ? REACTIVATE_ITEM.label : label}
+							</DropdownMenuItem>
+						)
+					})}
 					<DropdownMenuSeparator />
 					<DropdownMenuItem
 						render={

--- a/src/features/deck/collections.ts
+++ b/src/features/deck/collections.ts
@@ -58,5 +58,20 @@ export const cardsCollection = createCollection(
 		queryClient,
 		startSync: false,
 		schema: CardMetaSchema,
+		onUpdate: async ({ transaction }) => {
+			// Throwing rolls the optimistic state back. { refetch: false } keeps
+			// the confirmed value locally instead of reloading user_card_plus —
+			// safe because user_card has no triggers that change other columns.
+			await Promise.all(
+				transaction.mutations.map((m) =>
+					supabase
+						.from('user_card')
+						.update(m.changes)
+						.eq('id', m.original.id)
+						.throwOnError()
+				)
+			)
+			return { refetch: false }
+		},
 	})
 )

--- a/src/features/deck/hooks.ts
+++ b/src/features/deck/hooks.ts
@@ -84,16 +84,19 @@ export const useDecks = (): UseLiveQueryResult<DeckMetaType[]> => {
 	}
 }
 
+export type CardWithSibling = CardMetaType & { sibling_id: string | null }
+
 export const useMyCard = (
 	phraseId: string | null | undefined
-): UseLiveQueryResult<CardMetaType> => {
+): UseLiveQueryResult<CardWithSibling> => {
 	const query = useLiveQuery(
 		(q) =>
 			!phraseId
 				? undefined
 				: q
 						.from({ card: cardsCollection })
-						.where(({ card }) => eq(card.phrase_id, phraseId)),
+						.where(({ card }) => eq(card.phrase_id, phraseId))
+						.orderBy(({ card }) => card.direction, 'asc'),
 		[phraseId]
 	)
 	should(
@@ -102,7 +105,11 @@ export const useMyCard = (
 			query.data.length <= 1 ||
 			new Set(query.data.map((c) => c.status)).size === 1
 	)
-	return { ...query, data: query.data?.[0] } as UseLiveQueryResult<CardMetaType>
+	const [card, sibling] = query.data ?? []
+	return {
+		...query,
+		data: card ? { ...card, sibling_id: sibling?.id ?? null } : undefined,
+	} as UseLiveQueryResult<CardWithSibling>
 }
 
 export const useDeckCards = (


### PR DESCRIPTION
## Summary
Refactored the card status update flow in the review card context menu to use optimistic local mutations via the `cardsCollection` instead of React Query mutations with direct Supabase calls. This simplifies the code and provides better UX with immediate UI updates.

## Key Changes
- **Removed React Query mutation**: Replaced `useMutation` with direct `cardsCollection.update()` calls for updating card status
- **Replaced manual Supabase calls**: Removed direct `supabase.from('user_card').update()` calls in favor of collection-based updates
- **Added collection-level persistence**: Implemented `onUpdate` handler in `cardsCollection` to persist optimistic mutations to Supabase with automatic rollback on failure
- **Enhanced card status UI**: Added support for re-activating cards by toggling back to 'active' status from 'learned' or 'skipped' states
- **Improved sibling card handling**: Updated `useMyCard` hook to track sibling card IDs and update both cards when status changes
- **Extracted status constants**: Created `STATUS_TOAST_MESSAGES` and `STATUS_TOGGLE_ITEMS` for better maintainability and DRY principles
- **Updated imports**: Removed unused `useMutation` and `supabase` imports; added `useMyCard` hook and `RotateCcw` icon

## Notable Implementation Details
- The `setCardStatus` function now handles optimistic updates with proper error handling and rollback
- Sibling cards (bidirectional flashcards) are updated together to maintain consistency
- Toast messages are shown after successful persistence, not just optimistic updates
- The context menu now dynamically shows either the action button or a "Re-activate" button based on current card status

https://claude.ai/code/session_01VZKvnRCy1Fec1hmqdb7fxs