### PR TITLE
Transform #625: migrate card-status-dropdown to cardsCollection optimistic ops

### DIFF
--- a/src/components/card-pieces/card-status-dropdown.tsx
+++ b/src/components/card-pieces/card-status-dropdown.tsx
@@ -9,6 +9,7 @@ import {
 	PlusCircle,
 } from 'lucide-react'
 
+import { failed, serverCheck, should } from '@scenetest/checks-react'
 import { useRequireAuth } from '@/hooks/use-require-auth'
 import {
 	DropdownMenu,
@@ -184,6 +185,32 @@ function useCardStatusMutator(
 
 		tx.isPersisted.promise.then(
 			() => {
+				// Verify (in test mode) that the DB-side state matches what we
+				// asked for — both directions of the phrase share the new status.
+				// Stripped in production by vite-plugin-scenetest.
+				serverCheck(
+					'card status persists to all sibling cards',
+					async (server, { uid, phraseId, expectedStatus }) => {
+						const { data: rows, error } = await server.supabase
+							.from('user_card')
+							.select('id, direction, status')
+							.eq('uid', uid)
+							.eq('phrase_id', phraseId)
+						if (error || !rows) {
+							failed('fetch user_card after status mutation', {
+								error: error?.message,
+							})
+							return
+						}
+						should('at least one card row exists', rows.length >= 1, { rows })
+						should(
+							'all sibling cards share the expected status',
+							rows.every((r) => r.status === expectedStatus),
+							{ rows, expected: expectedStatus }
+						)
+					},
+					() => ({ uid: userId, phraseId: phrase.id, expectedStatus: status })
+				)
 				toastSuccess(
 					card
 						? `Updated card status to "${status}"`

--- a/src/components/card-pieces/card-status-dropdown.tsx
+++ b/src/components/card-pieces/card-status-dropdown.tsx
@@ -116,6 +116,9 @@ function StatusSpan({ choice }: { choice: ShowableActions }) {
 	)
 }
 
+const isLearnerStatus = (s: LearningStatus | undefined) =>
+	s === 'active' || s === 'learned' ? 1 : 0
+
 // count_learners is server-derived (aggregated in the phrase_full view from
 // user_card status), so phrasesCollection has no direct mutation handler for
 // it — we apply the predicted delta optimistically via writeUpdate and revert
@@ -131,12 +134,12 @@ function updatePhraseCount(
 		console.error(`updatePhraseCount: no phrase ${phraseId} in collection`)
 		return
 	}
-	const counts = (s: LearningStatus | undefined) =>
-		s === 'active' || s === 'learned' ? 1 : 0
 	phrasesCollection.utils.writeUpdate({
 		id: previous.id,
 		count_learners: Math.max(
-			(previous.count_learners ?? 0) - counts(oldStatus) + counts(newStatus),
+			(previous.count_learners ?? 0) -
+				isLearnerStatus(oldStatus) +
+				isLearnerStatus(newStatus),
 			0
 		),
 	})

--- a/src/components/card-pieces/card-status-dropdown.tsx
+++ b/src/components/card-pieces/card-status-dropdown.tsx
@@ -1,18 +1,14 @@
 import { Link } from '@tanstack/react-router'
-import { useMutation } from '@tanstack/react-query'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
 import {
 	Bookmark,
 	BookmarkCheck,
 	BookmarkPlus,
 	BookmarkX,
-	CheckCircle,
 	ChevronDown,
 	PlusCircle,
 } from 'lucide-react'
 
-import supabase from '@/lib/supabase-client'
-import { PostgrestError } from '@supabase/supabase-js'
 import { useRequireAuth } from '@/hooks/use-require-auth'
 import {
 	DropdownMenu,
@@ -21,21 +17,19 @@ import {
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { useUserId } from '@/lib/use-auth'
-import { useDecks, useMyCard } from '@/features/deck/hooks'
+import {
+	useDecks,
+	useMyCard,
+	type CardWithSibling,
+} from '@/features/deck/hooks'
 import { Button } from '@/components/ui/button'
 import { phrasesCollection } from '@/features/phrases/collections'
 import { cardsCollection } from '@/features/deck/collections'
-import {
-	CardMetaSchema,
-	CardMetaType,
-	CardStatusEnumSchema,
-} from '@/features/deck/schemas'
 import { directionsForPhrase } from '@/features/deck/card-directions'
 import {
 	PhraseFullFilteredType,
 	PhraseFullFullType,
 } from '@/features/phrases/schemas'
-import { Tables } from '@/types/supabase'
 import type { ActionCopy } from '@/types/main'
 
 type AnyPhrase = PhraseFullFilteredType | PhraseFullFullType
@@ -121,106 +115,92 @@ function StatusSpan({ choice }: { choice: ShowableActions }) {
 	)
 }
 
-function updatePhraseCounts(
-	oldCard: CardMetaType | undefined,
-	newCard: Tables<'user_card'>
-) {
-	if (oldCard?.status === newCard?.status) return
-	const oldPhrase = phrasesCollection.get(newCard.phrase_id)
-	if (!oldPhrase) {
-		console.error(
-			`Odd that we have a new card but can't find the phrase for id "${newCard.phrase_id}"`
-		)
+// count_learners is server-derived (aggregated in the phrase_full view from
+// user_card status), so phrasesCollection has no direct mutation handler for
+// it — we apply the predicted delta optimistically via writeUpdate and revert
+// it manually if the card transaction rolls back.
+function updatePhraseCount(
+	phraseId: string,
+	oldStatus: LearningStatus | undefined,
+	newStatus: LearningStatus
+): (() => void) | undefined {
+	if (oldStatus === newStatus) return
+	const previous = phrasesCollection.get(phraseId)
+	if (!previous) {
+		console.error(`updatePhraseCount: no phrase ${phraseId} in collection`)
 		return
 	}
+	const counts = (s: LearningStatus | undefined) =>
+		s === 'active' || s === 'learned' ? 1 : 0
 	phrasesCollection.utils.writeUpdate({
-		id: oldPhrase.id,
+		id: previous.id,
 		count_learners: Math.max(
-			(oldPhrase?.count_learners ?? 0) -
-				(oldCard?.status === 'active' || oldCard?.status === 'learned'
-					? 1
-					: 0) +
-				(newCard.status === 'active' || newCard.status === 'learned' ? 1 : 0),
+			(previous.count_learners ?? 0) - counts(oldStatus) + counts(newStatus),
 			0
 		),
 	})
+	return () => phrasesCollection.utils.writeUpdate(previous)
 }
 
-function useCardStatusMutation(
+function useCardStatusMutator(
 	phrase: AnyPhrase,
-	card: CardMetaType | undefined
+	card: CardWithSibling | undefined
 ) {
 	const userId = useUserId()
 
-	return useMutation<
-		Array<Tables<'user_card'>>,
-		PostgrestError,
-		{ status: LearningStatus }
-	>({
-		mutationKey: ['upsert-card', phrase.id],
-		mutationFn: async ({ status }: { status: LearningStatus }) => {
-			if (!phrase)
-				throw new Error('Trying to change status of a card that does not exist')
-			if (!userId)
-				throw new Error("Trying to change card status but you're not logged in")
-			const { data } = card
-				? await supabase
-						.from('user_card')
-						.update({
-							status,
-						})
-						.eq('phrase_id', phrase.id)
-						.eq('uid', userId)
-						.select()
-						.throwOnError()
-				: await supabase
-						.from('user_card')
-						.insert(
-							directionsForPhrase(phrase.only_reverse).map((direction) => ({
-								lang: phrase.lang,
-								phrase_id: phrase.id,
-								status,
-								direction,
-							}))
-						)
-						.select()
-						.throwOnError()
-			return data
-		},
-		onSuccess: (data) => {
-			try {
-				if (data[0]) updatePhraseCounts(card, data[0])
+	return (status: LearningStatus) => {
+		if (!userId) return
+		if (card?.status === status) return
 
-				if (card) {
-					for (const c of data) {
-						cardsCollection.utils.writeUpdate({
-							id: c.id,
-							status: CardStatusEnumSchema.parse(c.status),
-							updated_at: c.updated_at!,
+		const tx = card
+			? cardsCollection.update(
+					card.sibling_id ? [card.id, card.sibling_id] : [card.id],
+					(drafts) => {
+						drafts.forEach((d) => {
+							d.status = status
 						})
 					}
-				} else {
-					for (const c of data) {
-						cardsCollection.utils.writeInsert(CardMetaSchema.parse(c))
-					}
-				}
-			} catch (e) {
-				console.error('Card saved but failed to update local collection', e)
-				toastError(
-					'Card saved, but your app may be out of date — try refreshing'
 				)
-				return
-			}
+			: (() => {
+					const nowIso = new Date().toISOString()
+					return cardsCollection.insert(
+						directionsForPhrase(phrase.only_reverse).map((direction) => ({
+							id: crypto.randomUUID(),
+							uid: userId,
+							phrase_id: phrase.id,
+							lang: phrase.lang,
+							status,
+							direction,
+							created_at: nowIso,
+							updated_at: nowIso,
+							last_reviewed_at: null,
+							difficulty: null,
+							stability: null,
+						}))
+					)
+				})()
 
-			if (card) toastSuccess(`Updated card status to "${data[0].status}"`)
-			else toastSuccess('Added this phrase to your deck')
-		},
-		onError: (error) => {
-			if (card) toastError('There was an error updating this card')
-			else toastError('There was an error adding this card to your deck')
-			console.log(`error upserting card`, error)
-		},
-	})
+		const revertCount = updatePhraseCount(phrase.id, card?.status, status)
+
+		tx.isPersisted.promise.then(
+			() => {
+				toastSuccess(
+					card
+						? `Updated card status to "${status}"`
+						: 'Added this phrase to your deck'
+				)
+			},
+			(err) => {
+				revertCount?.()
+				toastError(
+					card
+						? 'There was an error updating this card'
+						: 'There was an error adding this card to your deck'
+				)
+				console.error('Card status mutation rolled back:', err)
+			}
+		)
+	}
 }
 
 export function CardStatusDropdown({
@@ -232,7 +212,7 @@ export function CardStatusDropdown({
 	const deckPresent = decks?.some((d) => d.lang === phrase.lang) ?? false
 	const { data: card } = useMyCard(phrase.id)
 
-	const cardMutation = useCardStatusMutation(phrase, card)
+	const setCardStatus = useCardStatusMutator(phrase, card)
 
 	const choice = !deckPresent ? 'nodeck' : !card ? 'nocard' : card.status
 
@@ -247,16 +227,11 @@ export function CardStatusDropdown({
 						className="m-0 min-w-28 justify-between px-1.5"
 						data-name="card-status-dropdown"
 						data-key={phrase.id}
-						disabled={cardMutation.isPending}
 					/>
 				}
 			>
 				<span className="flex items-center justify-center [&_svg]:size-4">
-					{cardMutation.isSuccess ? (
-						<CheckCircle className="text-green-500" />
-					) : (
-						<StatusIcon choice={choice} />
-					)}{' '}
+					<StatusIcon choice={choice} />
 				</span>
 				<span className="me-1">{statusStrings[choice].name}</span>
 				<ChevronDown size={12} />
@@ -272,7 +247,7 @@ export function CardStatusDropdown({
 					</DropdownMenuItem>
 				) : !card ? (
 					<DropdownMenuItem
-						onClick={() => cardMutation.mutate({ status: 'active' })}
+						onClick={() => setCardStatus('active')}
 						data-testid="add-to-deck-option"
 					>
 						<StatusSpan choice="nocard" />
@@ -280,34 +255,22 @@ export function CardStatusDropdown({
 				) : (
 					<>
 						<DropdownMenuItem
-							onClick={() =>
-								card?.status === 'active'
-									? false
-									: cardMutation.mutate({ status: 'active' })
-							}
-							className={card?.status === 'active' ? 'bg-2-mid-primary' : ''}
+							onClick={() => setCardStatus('active')}
+							className={card.status === 'active' ? 'bg-2-mid-primary' : ''}
 							data-testid="activate-card-option"
 						>
 							<StatusSpan choice="active" />
 						</DropdownMenuItem>
 						<DropdownMenuItem
-							onClick={() =>
-								card?.status === 'learned'
-									? false
-									: cardMutation.mutate({ status: 'learned' })
-							}
-							className={card?.status === 'learned' ? 'bg-2-mid-primary' : ''}
+							onClick={() => setCardStatus('learned')}
+							className={card.status === 'learned' ? 'bg-2-mid-primary' : ''}
 							data-testid="set-learned-option"
 						>
 							<StatusSpan choice="learned" />
 						</DropdownMenuItem>
 						<DropdownMenuItem
-							onClick={() =>
-								card?.status === 'skipped'
-									? false
-									: cardMutation.mutate({ status: 'skipped' })
-							}
-							className={card?.status === 'skipped' ? 'bg-2-mid-primary' : ''}
+							onClick={() => setCardStatus('skipped')}
+							className={card.status === 'skipped' ? 'bg-2-mid-primary' : ''}
 							data-testid="ignore-card-option"
 						>
 							<StatusSpan choice="skipped" />
@@ -326,7 +289,7 @@ export function CardStatusHeart({
 }) {
 	const requireAuth = useRequireAuth()
 	const { data: card } = useMyCard(phrase.id)
-	const mutation = useCardStatusMutation(phrase, card)
+	const setCardStatus = useCardStatusMutator(phrase, card)
 	const statusToPost = card?.status === 'active' ? 'skipped' : 'active'
 	return (
 		<Button
@@ -334,12 +297,11 @@ export function CardStatusHeart({
 			size="icon"
 			data-name="card-status-heart"
 			data-key={phrase.id}
-			disabled={mutation.isPending}
 			onClick={(e) => {
 				e.preventDefault()
 				e.stopPropagation()
 				requireAuth(
-					() => mutation.mutate({ status: statusToPost }),
+					() => setCardStatus(statusToPost),
 					'Please log in to add phrases to your library'
 				)
 			}}

--- a/src/features/deck/collections.ts
+++ b/src/features/deck/collections.ts
@@ -58,6 +58,28 @@ export const cardsCollection = createCollection(
 		queryClient,
 		startSync: false,
 		schema: CardMetaSchema,
+		onInsert: async ({ transaction }) => {
+			// Only the user_card columns — the rest of CardMetaSchema (last_reviewed_at,
+			// difficulty, stability) lives in user_card_plus via the user_card_review
+			// join, not on the underlying table. { refetch: false } because our
+			// optimistic row already carries the same column values we send.
+			await supabase
+				.from('user_card')
+				.insert(
+					transaction.mutations.map((m) => ({
+						id: m.modified.id,
+						uid: m.modified.uid,
+						phrase_id: m.modified.phrase_id,
+						lang: m.modified.lang,
+						status: m.modified.status,
+						direction: m.modified.direction,
+						created_at: m.modified.created_at,
+						updated_at: m.modified.updated_at,
+					}))
+				)
+				.throwOnError()
+			return { refetch: false }
+		},
 		onUpdate: async ({ transaction }) => {
 			// Throwing rolls the optimistic state back. { refetch: false } keeps
 			// the confirmed value locally instead of reloading user_card_plus —

--- a/src/types/scenetest.d.ts
+++ b/src/types/scenetest.d.ts
@@ -1,0 +1,21 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+// Augment scenetest's ServerContext so `server.supabase` is typed inside
+// serverCheck() callbacks. The matching runtime value is wired up in
+// scenetest/config.ts under `server.supabase`. pnpm hoists checks-react's
+// nested @scenetest/checks separately from the top-level one, so augment
+// both module specifiers.
+
+declare module '@scenetest/checks' {
+	interface ServerContext {
+		supabase: SupabaseClient
+	}
+}
+
+declare module '@scenetest/checks-react' {
+	interface ServerContext {
+		supabase: SupabaseClient
+	}
+}
+
+


### PR DESCRIPTION
Part of transform #625 — migrating one of the two callers of `useCardStatusMutation` (the standalone phrase-status dropdown and its heart-button sibling) off the deprecated `useMutation + writeInsert/writeUpdate` pattern.

## What changed

**`features/deck/collections.ts`** — add `onInsert` handler to `cardsCollection`, parallel to the existing `onUpdate`. Only the `user_card` columns are sent (the rest of `CardMetaSchema` — `last_reviewed_at`, `difficulty`, `stability` — comes from the `user_card_review` join in `user_card_plus`, not on the underlying table). Returns `{ refetch: false }`; the optimistic row already carries the column values we sent.

**`components/card-pieces/card-status-dropdown.tsx`** — replace `useCardStatusMutation` with `useCardStatusMutator`, a plain hook returning a `setCardStatus(status)` function. It either:

- updates both directions of an existing card (via `card.sibling_id` from `useMyCard`), or
- inserts a new pair via `cardsCollection.insert` using `directionsForPhrase`.

Toasts are wired to `tx.isPersisted.promise` so the misleading "saved but local sync failed" path is gone. The per-button no-op-when-already-in-this-status check moves into the mutator.

`updatePhraseCount` (formerly `updatePhraseCounts`) keeps using `phrasesCollection.utils.writeUpdate` — `count_learners` is server-derived (aggregated by the `phrase_full` view), so `phrasesCollection` has no direct mutation handler for it. The function now returns a revert callback that the mutator calls if the cards transaction rolls back, so the optimistic count is consistent with the cards state in both directions.

The `CheckCircle` success-state UI on the trigger and `disabled={mutation.isPending}` blocking come out — with optimistic state, the card status flips immediately on click, so there's no perceived latency to cover.

## Test plan

- [ ] Heart a phrase that's not in your deck (no card) → card pair inserted, count_learners increments, "Added this phrase to your deck" toast
- [ ] Heart a phrase that's already active → status flips to skipped, count_learners decrements
- [ ] Heart a phrase that's skipped/learned → status flips to active, count_learners increments
- [ ] Dropdown: change status between active / learned / skipped → both forward+reverse cards update together, appropriate toast
- [ ] Dropdown: click the row matching current status → no-op (no mutation fires)
- [ ] Force a server error (e.g. throttle / RLS break) → cards roll back to previous status, count_learners reverts, error toast appears

## Notes for review

Transform issue #625 has the wider migration tracked. With this PR landed, **Batch 4 — card-pieces** has one of three boxes ticked. `add-translations.tsx` and `add-tags.tsx` (other Batch 4 files) edit phrase data rather than card status, so they're separate migrations.

https://claude.ai/code/session_01VZKvnRCy1Fec1hmqdb7fxs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZKvnRCy1Fec1hmqdb7fxs)_