### PR TITLE
Refactor comment phrase links to use per-row subscriptions

### DIFF
--- a/src/components/comments/comment-with-replies.tsx
+++ b/src/components/comments/comment-with-replies.tsx
@@ -7,8 +7,9 @@ import { TinySelfAvatar } from '@/components/card-pieces/user-permalink'
 import { Markdown } from '@/components/my-markdown'
 import { CardResultSimple } from '@/components/cards/card-result-simple'
 import { commentsCollection } from '@/features/comments/collections'
-import { usePhrasesFromComment } from '@/features/comments/hooks'
+import { useCommentPhraseLinks } from '@/features/comments/hooks'
 import { publicProfilesCollection } from '@/features/profile/collections'
+import { WithPhrase } from '@/components/with-phrase'
 import { useUserId } from '@/lib/use-auth'
 import { type RequestCommentType } from '@/features/comments/schemas'
 import { buttonVariants } from '@/components/ui/button'
@@ -49,8 +50,8 @@ export function CommentWithReplies({ comment, lang }: CommentThreadProps) {
 		isFocusMode && replies.some(({ reply }) => reply.id === search.focus)
 	const showSubthread = isFocused || hasHighlightedReply
 
-	const { data: phraseFromComment } = usePhrasesFromComment(comment.id)
-	const phrases = phraseFromComment ?? []
+	const { data: phraseLinks } = useCommentPhraseLinks(comment.id)
+	const links = phraseLinks ?? []
 
 	const isOwner = userId === comment.uid
 	const replyCount = replies?.length ?? 0
@@ -113,14 +114,18 @@ export function CommentWithReplies({ comment, lang }: CommentThreadProps) {
 					</div>
 				)}
 
-				{phrases && phrases.length > 0 && (
+				{links.length > 0 && (
 					<div
 						className="mt-3 space-y-2"
 						data-testid="comment-phrase-link-badge"
 					>
-						{phrases.map(({ phrase }) => {
-							return <CardResultSimple key={phrase.id} phrase={phrase} />
-						})}
+						{links.map((link) => (
+							<WithPhrase
+								key={link.id}
+								pid={link.phrase_id}
+								Component={CardResultSimple}
+							/>
+						))}
 					</div>
 				)}
 
@@ -208,13 +213,13 @@ export function CommentWithReplies({ comment, lang }: CommentThreadProps) {
 }
 
 function CommentReply({ comment, lang }: CommentThreadProps) {
-	const { data: phraseFromComment } = usePhrasesFromComment(comment.id)
+	const { data: phraseLinks } = useCommentPhraseLinks(comment.id)
 	const isHighlighted = useSearch({
 		strict: false,
 		select: (data) => data.focus === comment.id && !data.mode,
 	})
 	const userId = useUserId()
-	const phrases = phraseFromComment ?? []
+	const links = phraseLinks ?? []
 
 	const isOwner = userId === comment.uid
 
@@ -262,10 +267,14 @@ function CommentReply({ comment, lang }: CommentThreadProps) {
 				</div>
 			)}
 
-			{phrases && phrases.length > 0 && (
+			{links.length > 0 && (
 				<div className="ms-8 mt-2 space-y-1.5">
-					{phrases.map(({ phrase }) => (
-						<CardResultSimple key={phrase.id} phrase={phrase} />
+					{links.map((link) => (
+						<WithPhrase
+							key={link.id}
+							pid={link.phrase_id}
+							Component={CardResultSimple}
+						/>
 					))}
 				</div>
 			)}

--- a/src/features/comments/hooks.ts
+++ b/src/features/comments/hooks.ts
@@ -2,14 +2,12 @@ import { eq, useLiveQuery } from '@tanstack/react-db'
 
 import type { UseLiveQueryResult, uuid } from '@/types/main'
 import type { CommentPhraseLinkType, RequestCommentType } from './schemas'
-import type { PhraseFullFullType } from '@/features/phrases/schemas'
 import type { PhraseRequestType } from '@/features/requests/schemas'
 import {
 	commentPhraseLinksCollection,
 	commentUpvotesCollection,
 	commentsCollection,
 } from './collections'
-import { phrasesFull } from '@/features/phrases/live'
 import { phraseRequestsCollection } from '@/features/requests/collections'
 
 /** Look up a single comment by ID. Returns undefined when no id is given. */
@@ -27,22 +25,20 @@ export const useOneComment = (
 		[commentId]
 	)
 
-/** All phrases attached to a comment, hydrated through phrasesFull. */
-export const usePhrasesFromComment = (
+/**
+ * Comment-phrase-link rows for a single comment. Phrase hydration is the
+ * caller's job — render each link's `phrase_id` through a per-row component
+ * (e.g. `<WithPhrase pid={link.phrase_id} ... />`) so each phrase row owns
+ * its own subscription. Keeps the cross-feature edge inside `phrases`.
+ */
+export const useCommentPhraseLinks = (
 	commentId: uuid
-): UseLiveQueryResult<
-	{ phrase: PhraseFullFullType; link: CommentPhraseLinkType }[]
-> =>
+): UseLiveQueryResult<CommentPhraseLinkType[]> =>
 	useLiveQuery(
 		(q) =>
 			q
 				.from({ link: commentPhraseLinksCollection })
-				.where(({ link }) => eq(link.comment_id, commentId))
-				.join(
-					{ phrase: phrasesFull },
-					({ link, phrase }) => eq(link.phrase_id, phrase.id),
-					'inner'
-				),
+				.where(({ link }) => eq(link.comment_id, commentId)),
 		[commentId]
 	)
 

--- a/src/features/comments/index.ts
+++ b/src/features/comments/index.ts
@@ -21,7 +21,7 @@ export {
 // Hooks
 export {
 	useOneComment,
-	usePhrasesFromComment,
+	useCommentPhraseLinks,
 	useHasCommentUpvote,
 	useAnyonesComments,
 } from './hooks'

--- a/src/routes/_user/learn/-contributions.tsx
+++ b/src/routes/_user/learn/-contributions.tsx
@@ -28,12 +28,13 @@ import {
 import { useAnyonesPhrases } from '@/features/phrases'
 import {
 	useAnyonesComments,
-	usePhrasesFromComment,
+	useCommentPhraseLinks,
 	type RequestCommentType,
 } from '@/features/comments'
 
 import { RequestItem } from '@/components/requests/request-list-item'
 import { CardResultSimple } from '@/components/cards/card-result-simple'
+import { WithPhrase } from '@/components/with-phrase'
 import { useAnyonesPlaylists } from '@/features/playlists/hooks'
 import { PlaylistItem } from '@/components/playlists/playlist-list-item'
 import languages from '@/lib/languages'
@@ -355,7 +356,7 @@ function CommentCardWithPhrases({
 	comment: RequestCommentType
 	request: PhraseRequestType
 }) {
-	const { data: phrases } = usePhrasesFromComment(comment.id)
+	const { data: links } = useCommentPhraseLinks(comment.id)
 
 	return (
 		<div
@@ -376,10 +377,14 @@ function CommentCardWithPhrases({
 					<Markdown>{comment.content}</Markdown>
 				</div>
 			)}
-			{phrases && phrases.length > 0 && (
+			{links && links.length > 0 && (
 				<div className="ms-8 mt-1 space-y-2">
-					{phrases.map(({ phrase }) => (
-						<CardResultSimple key={phrase.id} phrase={phrase} />
+					{links.map((link) => (
+						<WithPhrase
+							key={link.id}
+							pid={link.phrase_id}
+							Component={CardResultSimple}
+						/>
 					))}
 				</div>
 			)}


### PR DESCRIPTION
## Summary
Refactored the comment-phrase link rendering to use per-row subscriptions instead of a single hydrated query. This improves subscription management by keeping each phrase's data subscription isolated within its own component.

## Key Changes
- Renamed `usePhrasesFromComment` hook to `useCommentPhraseLinks` to better reflect its new behavior
- Changed hook return type from hydrated `{ phrase, link }` tuples to simple `CommentPhraseLinkType[]` rows
- Removed the inner join with `phrasesFull` collection from the hook query
- Updated all call sites to use `<WithPhrase>` component wrapper for rendering individual phrase cards
  - `CommentWithReplies` component (main comment and replies)
  - `CommentReply` component
  - `CommentCardWithPhrases` component in contributions page
- Updated exported hook name in `features/comments/index.ts`

## Implementation Details
The refactoring moves phrase hydration responsibility from the hook to the caller. Each phrase link now renders through `<WithPhrase pid={link.phrase_id} Component={CardResultSimple} />`, allowing each phrase row to own its own subscription to the phrases collection. This keeps the cross-feature edge (between comments and phrases) contained within the phrases feature, improving separation of concerns and subscription lifecycle management.

https://claude.ai/code/session_017EH8DyL44HA9NAQfA4NNUt