### PR TITLE
Improve error/lint reporting by detecting shifted issues

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -149,24 +149,61 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const baseErrors = fs.readFileSync('/tmp/base-lint.txt', 'utf8').trim().split('\n').filter(Boolean);
-            const prErrors   = fs.readFileSync('/tmp/pr-lint.txt',   'utf8').trim().split('\n').filter(Boolean);
+            const baseLines = fs.readFileSync('/tmp/base-lint.txt', 'utf8').trim().split('\n').filter(Boolean);
+            const prLines   = fs.readFileSync('/tmp/pr-lint.txt',   'utf8').trim().split('\n').filter(Boolean);
 
-            const baseSet = new Set(baseErrors);
-            const prSet   = new Set(prErrors);
-            const newErrors = prErrors.filter(e => !baseSet.has(e));
-            const resolved  = baseErrors.filter(e => !prSet.has(e));
+            // Parse "file:line:col: message" — file paths in this repo have no colons.
+            const parse = (raw) => {
+              const m = raw.match(/^([^:]+):(\d+):(\d+):\s*(.*)$/);
+              if (!m) return { file: '', line: 0, col: 0, rest: raw, raw };
+              return { file: m[1], line: parseInt(m[2], 10), col: parseInt(m[3], 10), rest: m[4], raw };
+            };
 
+            const baseErrors = baseLines.map(parse);
+            const prErrors   = prLines.map(parse);
+            const baseSet = new Set(baseLines);
+            const prSet   = new Set(prLines);
+
+            // First pass: exact-match set difference.
+            const newCandidates = prErrors.filter(e => !baseSet.has(e.raw));
+            const resolvedCandidates = baseErrors.filter(e => !prSet.has(e.raw));
+
+            // Second pass: pair a "new" with a "resolved" when same file + same message text
+            // and line numbers within 10 of each other. Treat those as the same lint issue
+            // that just shifted (e.g. an unrelated edit pushed it up/down the file).
+            const PROXIMITY = 10;
+            const resolvedPool = [...resolvedCandidates];
+            const newErrors = [];
+            const moved = [];
+            for (const n of newCandidates) {
+              const idx = resolvedPool.findIndex(r =>
+                r.file === n.file &&
+                r.rest === n.rest &&
+                Math.abs(r.line - n.line) <= PROXIMITY
+              );
+              if (idx >= 0) {
+                moved.push({ from: resolvedPool[idx], to: n });
+                resolvedPool.splice(idx, 1);
+              } else {
+                newErrors.push(n);
+              }
+            }
+            const resolved = resolvedPool;
+
+            // Persist the new-error count so the fail step can read it without redoing this work.
+            fs.writeFileSync('/tmp/lint-new-count.txt', String(newErrors.length));
+
+            const movedNote = moved.length ? ` (${moved.length} shifted within ±${PROXIMITY} lines, not counted)` : '';
             const summary = `**Before:** ${baseErrors.length} issue(s) → **After:** ${prErrors.length} issue(s)` +
               (newErrors.length || resolved.length
-                ? ` (+${newErrors.length} new, −${resolved.length} resolved)`
-                : ' (no change)');
+                ? ` (+${newErrors.length} new, −${resolved.length} resolved)${movedNote}`
+                : ` (no change)${movedNote}`);
 
             const lines = ['### Lint (oxlint + eslint)', '', summary];
             if (newErrors.length > 0)
-              lines.push(`\n**New (${newErrors.length}):**\n\`\`\`\n${newErrors.slice(0, 50).join('\n')}\n${newErrors.length > 50 ? `… and ${newErrors.length - 50} more` : ''}\n\`\`\``);
+              lines.push(`\n**New (${newErrors.length}):**\n\`\`\`\n${newErrors.slice(0, 50).map(e => e.raw).join('\n')}\n${newErrors.length > 50 ? `… and ${newErrors.length - 50} more` : ''}\n\`\`\``);
             if (resolved.length > 0)
-              lines.push(`\n**Resolved (${resolved.length}):**\n\`\`\`\n${resolved.slice(0, 50).join('\n')}\n${resolved.length > 50 ? `… and ${resolved.length - 50} more` : ''}\n\`\`\``);
+              lines.push(`\n**Resolved (${resolved.length}):**\n\`\`\`\n${resolved.slice(0, 50).map(e => e.raw).join('\n')}\n${resolved.length > 50 ? `… and ${resolved.length - 50} more` : ''}\n\`\`\``);
             const body = lines.join('\n');
 
             const marker = '### Lint (oxlint + eslint)';
@@ -189,7 +226,7 @@ jobs:
 
       - name: Fail on new issues
         run: |
-          NEW=$(comm -13 /tmp/base-lint.txt /tmp/pr-lint.txt | wc -l | tr -d ' ')
+          NEW=$(cat /tmp/lint-new-count.txt 2>/dev/null || echo 0)
           if [ "$NEW" -gt 0 ]; then
             echo "❌ $NEW new lint issue(s) introduced — see PR comment for details"
             exit 1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,9 +72,10 @@ jobs:
             const newCandidates = prErrors.filter(e => !baseSet.has(e.raw));
             const resolvedCandidates = baseErrors.filter(e => !prSet.has(e.raw));
 
-            // Second pass: pair "new" with "resolved" when same file + same error code/message
-            // and line numbers within 10. Treat as a shifted (unchanged) error rather than a
-            // new one — an unrelated edit just bumped the line number.
+            // Second pass: pair "new" with "resolved" when same file + same column + same
+            // error code/message and line numbers within 10. Treat as a shifted (unchanged)
+            // error rather than a new one — an unrelated edit just bumped the line number.
+            // A changed column means the line itself was edited, so the error is fair game.
             const PROXIMITY = 10;
             const resolvedPool = [...resolvedCandidates];
             const newErrors = [];
@@ -82,6 +83,7 @@ jobs:
             for (const n of newCandidates) {
               const idx = resolvedPool.findIndex(r =>
                 r.file === n.file &&
+                r.col === n.col &&
                 r.rest === n.rest &&
                 Math.abs(r.line - n.line) <= PROXIMITY
               );
@@ -204,9 +206,10 @@ jobs:
             const newCandidates = prErrors.filter(e => !baseSet.has(e.raw));
             const resolvedCandidates = baseErrors.filter(e => !prSet.has(e.raw));
 
-            // Second pass: pair a "new" with a "resolved" when same file + same message text
-            // and line numbers within 10 of each other. Treat those as the same lint issue
-            // that just shifted (e.g. an unrelated edit pushed it up/down the file).
+            // Second pass: pair a "new" with a "resolved" when same file + same column +
+            // same message text and line numbers within 10. Treat those as the same lint
+            // issue that just shifted (e.g. an unrelated edit pushed it up/down the file).
+            // A changed column means the line itself was edited, so the issue is fair game.
             const PROXIMITY = 10;
             const resolvedPool = [...resolvedCandidates];
             const newErrors = [];
@@ -214,6 +217,7 @@ jobs:
             for (const n of newCandidates) {
               const idx = resolvedPool.findIndex(r =>
                 r.file === n.file &&
+                r.col === n.col &&
                 r.rest === n.rest &&
                 Math.abs(r.line - n.line) <= PROXIMITY
               );

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,24 +53,60 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const baseErrors = fs.readFileSync('/tmp/base-errors.txt', 'utf8').trim().split('\n').filter(Boolean);
-            const prErrors   = fs.readFileSync('/tmp/pr-errors.txt',   'utf8').trim().split('\n').filter(Boolean);
+            const baseLines = fs.readFileSync('/tmp/base-errors.txt', 'utf8').trim().split('\n').filter(Boolean);
+            const prLines   = fs.readFileSync('/tmp/pr-errors.txt',   'utf8').trim().split('\n').filter(Boolean);
 
-            const baseSet = new Set(baseErrors);
-            const prSet   = new Set(prErrors);
-            const newErrors = prErrors.filter(e => !baseSet.has(e));
-            const resolved  = baseErrors.filter(e => !prSet.has(e));
+            // Parse "file(line,col): error TS####: message" — tsc's default (non-pretty) format.
+            const parse = (raw) => {
+              const m = raw.match(/^(.+?)\((\d+),(\d+)\):\s*(error\s+TS\d+:\s*.*)$/);
+              if (!m) return { file: '', line: 0, col: 0, rest: raw, raw };
+              return { file: m[1], line: parseInt(m[2], 10), col: parseInt(m[3], 10), rest: m[4], raw };
+            };
 
+            const baseErrors = baseLines.map(parse);
+            const prErrors   = prLines.map(parse);
+            const baseSet = new Set(baseLines);
+            const prSet   = new Set(prLines);
+
+            // First pass: exact-match set difference.
+            const newCandidates = prErrors.filter(e => !baseSet.has(e.raw));
+            const resolvedCandidates = baseErrors.filter(e => !prSet.has(e.raw));
+
+            // Second pass: pair "new" with "resolved" when same file + same error code/message
+            // and line numbers within 10. Treat as a shifted (unchanged) error rather than a
+            // new one — an unrelated edit just bumped the line number.
+            const PROXIMITY = 10;
+            const resolvedPool = [...resolvedCandidates];
+            const newErrors = [];
+            const moved = [];
+            for (const n of newCandidates) {
+              const idx = resolvedPool.findIndex(r =>
+                r.file === n.file &&
+                r.rest === n.rest &&
+                Math.abs(r.line - n.line) <= PROXIMITY
+              );
+              if (idx >= 0) {
+                moved.push({ from: resolvedPool[idx], to: n });
+                resolvedPool.splice(idx, 1);
+              } else {
+                newErrors.push(n);
+              }
+            }
+            const resolved = resolvedPool;
+
+            fs.writeFileSync('/tmp/tsc-new-count.txt', String(newErrors.length));
+
+            const movedNote = moved.length ? ` (${moved.length} shifted within ±${PROXIMITY} lines, not counted)` : '';
             const summary = `**Before:** ${baseErrors.length} error(s) → **After:** ${prErrors.length} error(s)` +
               (newErrors.length || resolved.length
-                ? ` (+${newErrors.length} new, −${resolved.length} resolved)`
-                : ' (no change)');
+                ? ` (+${newErrors.length} new, −${resolved.length} resolved)${movedNote}`
+                : ` (no change)${movedNote}`);
 
             const lines = ['### TypeScript type check', '', summary];
             if (newErrors.length > 0)
-              lines.push(`\n**New (${newErrors.length}):**\n\`\`\`\n${newErrors.join('\n')}\n\`\`\``);
+              lines.push(`\n**New (${newErrors.length}):**\n\`\`\`\n${newErrors.map(e => e.raw).join('\n')}\n\`\`\``);
             if (resolved.length > 0)
-              lines.push(`\n**Resolved (${resolved.length}):**\n\`\`\`\n${resolved.join('\n')}\n\`\`\``);
+              lines.push(`\n**Resolved (${resolved.length}):**\n\`\`\`\n${resolved.map(e => e.raw).join('\n')}\n\`\`\``);
             const body = lines.join('\n');
 
             const marker = '### TypeScript type check';
@@ -93,7 +129,7 @@ jobs:
 
       - name: Fail on new errors
         run: |
-          NEW=$(comm -13 /tmp/base-errors.txt /tmp/pr-errors.txt | wc -l | tr -d ' ')
+          NEW=$(cat /tmp/tsc-new-count.txt 2>/dev/null || echo 0)
           if [ "$NEW" -gt 0 ]; then
             echo "❌ $NEW new type error(s) introduced — see PR comment for details"
             exit 1


### PR DESCRIPTION
## Summary
Enhanced the TypeScript type check and lint reporting workflows to intelligently distinguish between genuinely new issues and existing issues that have simply shifted line numbers due to unrelated edits.

## Key Changes
- **Parse error/lint output**: Added structured parsing of TypeScript compiler output (`file(line,col): error TS####: message`) and linter output (`file:line:col: message`) to extract file, line, column, and message components
- **Two-pass matching algorithm**: 
  - First pass performs exact-match set difference to identify candidates for new/resolved issues
  - Second pass pairs "new" issues with "resolved" issues when they match on file, column, and message text with line numbers within ±10 lines, treating these as shifted (not new) issues
- **Improved reporting**: Updated PR comments to note how many issues were shifted rather than newly introduced, providing clearer context
- **Persist counts**: Write new error/issue counts to temporary files so the fail step can reuse them without recalculating
- **Simplified fail logic**: Replace `comm` command with direct file read for cleaner and more maintainable code

## Implementation Details
- The proximity threshold is set to 10 lines—issues within this range are considered the same issue that moved, not a new one
- Column changes indicate the line itself was edited, so those are treated as genuinely new issues
- Both TypeScript and lint workflows use the same two-pass algorithm with format-specific parsers
- Moved issues are excluded from the "new" count but still tracked for transparency in the PR comment

https://claude.ai/code/session_01SMSZJNh57bYGygJ3soc8nT