### PR TITLE
Rename "Initiate Transform" skill to "Become-From"

### DIFF
--- a/.claude/skills/become-from/SKILL.md
+++ b/.claude/skills/become-from/SKILL.md
@@ -1,8 +1,10 @@
-# Initiate Transform
+# Become-From
 
-Formally initiate an architectural transformation — deprecate an old code pattern in favor of a new one. Produces three durable artifacts: a documented standard in `CLAUDE.md`, an initial scan of the codebase, and a tracking issue labeled `transform` that automated tools (and future Claude sessions) can parse.
+Formally initiate an architectural transformation — deprecate an old code pattern in favor of a new one. The skill name flips the grammar of `goto`/`come-from`: instead of "transform from X to Y," the verb is **become** and you say "become Y from X" (e.g. _"become-localfirst from useMutation,"_ _"become pure-PWA from the current mixed mode"_). The tracking issue is still labeled `transform` — that label stays.
 
-Invoke when the developer says something like _"initiate a transform,"_ _"start a transform,"_ or _"/initiate-transform."_
+Produces three durable artifacts: a documented standard in `CLAUDE.md`, an initial scan of the codebase, and a tracking issue labeled `transform` that automated tools (and future Claude sessions) can parse.
+
+Invoke when the developer says something like _"become X from Y,"_ _"set up a become-from,"_ or _"/become-from."_
 
 ## When to use this
 

--- a/.claude/skills/become-from/SKILL.md
+++ b/.claude/skills/become-from/SKILL.md
@@ -1,10 +1,8 @@
 # Become-From
 
-Formally initiate an architectural transformation — deprecate an old code pattern in favor of a new one. The skill name flips the grammar of `goto`/`come-from`: instead of "transform from X to Y," the verb is **become** and you say "become Y from X" (e.g. _"become-localfirst from useMutation,"_ _"become pure-PWA from the current mixed mode"_). The tracking issue is still labeled `transform` — that label stays.
+Formally initiate an architectural transformation — deprecate an old code pattern in favor of a new one. Produces three durable artifacts: a documented standard in `CLAUDE.md`, an initial scan of the codebase, and a tracking issue labeled `transform` that automated tools (and future Claude sessions) can parse.
 
-Produces three durable artifacts: a documented standard in `CLAUDE.md`, an initial scan of the codebase, and a tracking issue labeled `transform` that automated tools (and future Claude sessions) can parse.
-
-Invoke when the developer says something like _"become X from Y,"_ _"set up a become-from,"_ or _"/become-from."_
+Invoke when the developer says something like _"become X from Y,"_ _"set up a become-from,"_ or _"/become-from."_ Read the invocation as the verb **become** taking a target and a source — e.g. _"become localfirst from useMutation,"_ _"become pure-PWA from the current mixed mode."_
 
 ## When to use this
 


### PR DESCRIPTION
## Summary
Renamed the transformation initiation skill from "Initiate Transform" to "Become-From" to better reflect its purpose and provide clearer invocation semantics.

## Key Changes
- Renamed skill directory and documentation file from `initiate-transform` to `become-from`
- Updated skill title from "Initiate Transform" to "Become-From"
- Revised invocation guidance to use the "become X from Y" pattern, which more intuitively expresses the transformation direction (target pattern from source pattern)
- Updated example invocations to demonstrate the new naming convention (e.g., "become localfirst from useMutation")

## Implementation Details
The new naming convention frames transformations as a verb phrase where:
- **become** = the transformation action
- **X** = the target/desired code pattern
- **Y** = the source/deprecated code pattern

This provides clearer semantics for developers initiating architectural transformations and makes the skill's purpose more immediately apparent.

https://claude.ai/code/session_015io6ZH95e6V8bJCwNFe6H8