### PR TITLE
Migrate from React Query to Tanstack DB for request mutations

### DIFF
--- a/src/components/requests/delete-request-dialog.tsx
+++ b/src/components/requests/delete-request-dialog.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
 import { Trash2 } from 'lucide-react'
 import {
@@ -14,7 +13,6 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import { PhraseRequestType } from '@/features/requests/schemas'
-import supabase from '@/lib/supabase-client'
 import { phraseRequestsCollection } from '@/features/requests/collections'
 import { useNavigate } from '@tanstack/react-router'
 
@@ -26,29 +24,26 @@ export function DeleteRequestDialog({
 	const [open, setOpen] = useState(false)
 	const navigate = useNavigate()
 
-	// Delete request mutation
-	const mutation = useMutation({
-		mutationFn: async () => {
-			const { error } = await supabase
-				.from('phrase_request')
-				.update({ deleted: true })
-				.eq('id', request.id)
+	const deleteRequest = () => {
+		setOpen(false)
+		const tx = phraseRequestsCollection.update(request.id, (draft) => {
+			draft.deleted = true
+		})
+		tx.isPersisted.promise.then(
+			() => {
+				toastSuccess('Request deleted')
+				void navigate({
+					to: '/learn/$lang',
+					params: { lang: request.lang },
+				})
+			},
+			(err: unknown) => {
+				const message = err instanceof Error ? err.message : 'unknown error'
+				toastError(`Failed to delete request: ${message}`)
+			}
+		)
+	}
 
-			if (error) throw error
-		},
-		onSuccess: () => {
-			phraseRequestsCollection.utils.writeDelete(request.id)
-			toastSuccess('Request deleted')
-			// Navigate away from the deleted request page
-			void navigate({
-				to: '/learn/$lang',
-				params: { lang: request.lang },
-			})
-		},
-		onError: (error: Error) => {
-			toastError(`Failed to delete request: ${error.message}`)
-		},
-	})
 	return (
 		<AlertDialog open={open} onOpenChange={setOpen}>
 			<Button
@@ -71,8 +66,7 @@ export function DeleteRequestDialog({
 				<AlertDialogFooter>
 					<AlertDialogCancel>Cancel</AlertDialogCancel>
 					<AlertDialogAction
-						disabled={mutation.isPending}
-						onClick={() => mutation.mutate()}
+						onClick={deleteRequest}
 						data-testid="confirm-delete-button"
 						className="bg-destructive text-destructive-foreground"
 					>

--- a/src/components/requests/request-form.tsx
+++ b/src/components/requests/request-form.tsx
@@ -1,5 +1,5 @@
-import { useMutation } from '@tanstack/react-query'
-import { PostgrestError } from '@supabase/supabase-js'
+import { useState } from 'react'
+import { createOptimisticAction } from '@tanstack/db'
 
 import supabase from '@/lib/supabase-client'
 import { MarkdownHint } from '@/components/comments/comment-dialog'
@@ -10,10 +10,8 @@ import {
 	phraseRequestUpvotesCollection,
 } from '@/features/requests/collections'
 import {
-	PhraseRequestSchema,
 	PhraseRequestType,
 	RequestPhraseFormSchema,
-	type RequestPhraseFormInputs,
 	requestPromptPlaceholders,
 } from '@/features/requests/schemas'
 import { useRequest } from '@/features/requests/hooks'
@@ -22,6 +20,40 @@ import { Button } from '@/components/ui/button'
 import { useAppForm } from '@/components/form'
 import { toastSuccess, toastError } from '@/components/ui/sonner'
 import type { uuid } from '@/types/main'
+
+type CreateInput = {
+	id: uuid
+	prompt: string
+	lang: string
+	userId: uuid
+}
+
+const createRequest = createOptimisticAction<CreateInput>({
+	onMutate: ({ id, prompt, lang, userId }) => {
+		phraseRequestsCollection.insert({
+			id,
+			prompt,
+			lang,
+			requester_uid: userId,
+			// DB trigger auto-upvotes the requester, so the count starts at 1.
+			upvote_count: 1,
+			deleted: false,
+			created_at: new Date().toISOString(),
+			updated_at: null,
+		})
+		phraseRequestUpvotesCollection.insert({ request_id: id })
+	},
+	mutationFn: async ({ id, prompt, lang, userId }) => {
+		await supabase
+			.from('phrase_request')
+			.insert({ id, prompt, lang, requester_uid: userId })
+			.throwOnError()
+		await Promise.all([
+			phraseRequestsCollection.utils.refetch(),
+			phraseRequestUpvotesCollection.utils.refetch(),
+		])
+	},
+})
 
 export function RequestForm({
 	lang,
@@ -43,67 +75,51 @@ export function RequestForm({
 	const invalidateFeed = useInvalidateFeed()
 	const { data: request } = useRequest(requestId ?? '')
 	const isEditing = !!requestId
-
-	const mutation = useMutation<
-		PhraseRequestType,
-		PostgrestError,
-		RequestPhraseFormInputs
-	>({
-		mutationFn: async ({ prompt }) => {
-			if (isEditing) {
-				const { data } = await supabase
-					.from('phrase_request')
-					.update({ prompt })
-					.eq('id', requestId)
-					.throwOnError()
-					.select()
-					.single()
-				return data!
-			}
-			const { data } = await supabase
-				.from('phrase_request')
-				.insert({ prompt, lang, requester_uid: userId! })
-				.throwOnError()
-				.select()
-				.single()
-			return data!
-		},
-		onSuccess: (data) => {
-			const parsed = PhraseRequestSchema.parse(data)
-			if (isEditing) {
-				phraseRequestsCollection.utils.writeUpdate(parsed)
-				toastSuccess('Request updated!')
-			} else {
-				// The DB trigger auto-upvotes, but RETURNING gets the pre-trigger value.
-				// Override upvote_count to reflect the auto-upvote.
-				phraseRequestsCollection.utils.writeInsert({
-					...parsed,
-					upvote_count: 1,
-				})
-				phraseRequestUpvotesCollection.utils.writeInsert({
-					request_id: data.id,
-				})
-				invalidateFeed(lang)
-				toastSuccess('Your request has been posted!')
-			}
-			onSuccess?.(data)
-		},
-		onError: (error) => {
-			console.error(error)
-			toastError(
-				isEditing
-					? 'There was an error updating your request.'
-					: 'There was an error posting your request.'
-			)
-		},
-	})
+	const [submitError, setSubmitError] = useState<Error | null>(null)
 
 	const form = useAppForm({
 		defaultValues: { prompt: request?.prompt ?? '' },
 		validators: { onChange: RequestPhraseFormSchema },
 		onSubmit: async ({ value, formApi }) => {
-			await mutation.mutateAsync(value)
-			formApi.reset()
+			setSubmitError(null)
+			try {
+				if (isEditing) {
+					const tx = phraseRequestsCollection.update(requestId, (draft) => {
+						draft.prompt = value.prompt
+					})
+					await tx.isPersisted.promise
+					const updated = phraseRequestsCollection.get(requestId)
+					toastSuccess('Request updated!')
+					if (updated) onSuccess?.(updated)
+				} else {
+					await Promise.all([
+						phraseRequestsCollection.preload(),
+						phraseRequestUpvotesCollection.preload(),
+					])
+					const id = crypto.randomUUID()
+					const tx = createRequest({
+						id,
+						prompt: value.prompt,
+						lang,
+						userId: userId!,
+					})
+					await tx.isPersisted.promise
+					const created = phraseRequestsCollection.get(id)
+					invalidateFeed(lang)
+					toastSuccess('Your request has been posted!')
+					if (created) onSuccess?.(created)
+				}
+				formApi.reset()
+			} catch (err) {
+				const error = err instanceof Error ? err : new Error('unknown error')
+				setSubmitError(error)
+				toastError(
+					isEditing
+						? 'There was an error updating your request.'
+						: 'There was an error posting your request.'
+				)
+				console.error(error)
+			}
 		},
 	})
 
@@ -147,7 +163,7 @@ export function RequestForm({
 
 			<form.AppForm>
 				<form.FormAlert
-					error={mutation.error}
+					error={submitError}
 					text={
 						isEditing
 							? 'There was an error updating your request.'

--- a/src/features/requests/collections.ts
+++ b/src/features/requests/collections.ts
@@ -28,6 +28,18 @@ export const phraseRequestsCollection = createCollection(
 		queryClient,
 		autoIndex: 'eager',
 		defaultIndexType: BasicIndex,
+		onUpdate: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map((m) =>
+					supabase
+						.from('phrase_request')
+						.update(m.changes)
+						.eq('id', m.original.id)
+						.throwOnError()
+				)
+			)
+			return { refetch: false }
+		},
 	})
 )
 


### PR DESCRIPTION
## Summary
Refactored request creation, updating, and deletion operations to use Tanstack DB's optimistic updates instead of React Query mutations. This provides better offline support and more granular control over local state management.

## Key Changes
- **Request Form**: Replaced `useMutation` with direct collection operations and `createOptimisticAction` for new requests
  - Removed React Query and Zod schema parsing dependencies
  - Implemented optimistic updates that immediately reflect changes in the UI
  - Added manual error handling with `useState` instead of mutation error state
  - Split create and update logic to use collection methods directly

- **Delete Request Dialog**: Removed `useMutation` and replaced with direct collection update
  - Simplified to a single `deleteRequest` function using `phraseRequestsCollection.update()`
  - Removed loading state management (no longer needed with optimistic updates)
  - Maintained same user feedback via toasts and navigation

- **Collections**: Added `onUpdate` hook to `phraseRequestsCollection`
  - Syncs local collection mutations back to Supabase database
  - Handles batch updates from transactions
  - Returns `{ refetch: false }` to prevent unnecessary refetches

## Implementation Details
- Uses `crypto.randomUUID()` for generating request IDs client-side
- Leverages `tx.isPersisted.promise` to wait for database persistence
- Maintains optimistic UI updates via collection insert/update methods before database confirmation
- Error handling now uses try-catch with manual error state instead of mutation error callbacks

https://claude.ai/code/session_01EnKyMtHiqCkpJMYHkvLzuQ