### PR TITLE
Switch from preview to dev server for testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -527,14 +527,11 @@ jobs:
           echo "VITE_SUPABASE_ANON_KEY=$(supabase status -o json | jq -r '.ANON_KEY')" >> $GITHUB_ENV
           echo "SUPABASE_SERVICE_ROLE_KEY=$(supabase status -o json | jq -r '.SERVICE_ROLE_KEY')" >> $GITHUB_ENV
 
-      - name: Build app
-        run: pnpm build:test
+      - name: Start dev server
+        run: pnpm dev:local &
 
-      - name: Start preview server
-        run: pnpm preview &
-
-      - name: Wait for preview server
-        run: npx wait-on http://localhost:4173 --timeout 20000
+      - name: Wait for dev server
+        run: npx wait-on http://localhost:5173 --timeout 60000
 
       - name: Run scenetest specs
         id: scene

--- a/scenetest/config.ts
+++ b/scenetest/config.ts
@@ -36,7 +36,7 @@ const supabaseUrl = process.env.VITE_SUPABASE_URL ?? 'http://127.0.0.1:54321'
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
 
 export default defineConfig({
-	baseUrl: 'http://localhost:4173',
+	baseUrl: 'http://localhost:5173',
 	scenes: './scenetest/scenes',
 	noKeyboardActor: true,
 	// Fail fast when an error toast appears, instead of timing out on a


### PR DESCRIPTION
## Summary
Updated the CI/CD test workflow and scenetest configuration to use the development server instead of the preview server for running integration tests.

## Key Changes
- **CI Workflow**: Replaced the build and preview server steps with a direct dev server startup
  - Removed `pnpm build:test` step
  - Changed from `pnpm preview` to `pnpm dev:local`
  - Updated server health check port from 4173 (preview) to 5173 (dev)
  - Increased wait timeout from 20s to 60s to accommodate dev server startup time
- **Scenetest Configuration**: Updated baseUrl from `http://localhost:4173` to `http://localhost:5173` to match the dev server port

## Benefits
- Faster test execution by eliminating the build step
- More direct testing against development code
- Allows for faster iteration during test development

https://claude.ai/code/session_018EABMLmkGd98thDeqYnngK