### PR TITLE
Centralize search overlay logic in _user layout

### DIFF
--- a/scenetest/TEST_IDS.md
+++ b/scenetest/TEST_IDS.md
@@ -161,6 +161,10 @@ natural wrapper element to label.
 | `search-page`                            | data-testid | Search route             | Search page container                                                                                              |
 | `search-input`                           | data-testid | Search page              | Search text input                                                                                                  |
 | `search-results`                         | data-testid | Search page              | Search results container                                                                                           |
+| `browse-search-trigger`                  | data-testid | Browse page              | Button that opens the search overlay (also via `?search=true`)                                                     |
+| `browse-search-overlay`                  | data-testid | Search overlay           | Dialog container for the public-library search overlay                                                             |
+| `browse-search-input`                    | data-testid | Search overlay           | Search input inside the overlay                                                                                    |
+| `browse-search-results`                  | data-testid | Search overlay           | Results list inside the overlay                                                                                    |
 
 ## Phrase Requests
 

--- a/scenetest/scenes/browse-search.spec.md
+++ b/scenetest/scenes/browse-search.spec.md
@@ -1,0 +1,32 @@
+# learner opens the search overlay from /browse by clicking the trigger
+
+learner:
+
+- login
+- openTo /browse
+- see browse-page
+- see browse-search-trigger
+- click browse-search-trigger
+- see browse-search-overlay
+- typeInto browse-search-input tea
+- see browse-search-results
+
+# learner opens the search overlay by visiting /browse?search=true directly
+
+// Regression guard: the overlay used to live in the /learn layout, so
+// moving /browse out from under /learn silently broke this deep link.
+
+learner:
+
+- login
+- openTo /browse?search=true
+- see browse-search-overlay
+- see browse-search-input
+
+# visitor can use the search overlay on /browse without logging in
+
+visitor:
+
+- openTo /browse?search=true
+- see browse-search-overlay
+- see browse-search-input

--- a/src/components/navs/navbar.tsx
+++ b/src/components/navs/navbar.tsx
@@ -11,7 +11,7 @@ import { useTitleBar } from '@/hooks/use-title-bar'
 export default function Navbar() {
 	const matches = useMatches()
 	const focusMode = matches.some((m) => m.staticData.focusMode)
-	const hasSearchAction = matches.some((m) => m.staticData.searchAction)
+	const hasSearchAction = matches.some((m) => !!m.staticData.search)
 
 	return (
 		<nav

--- a/src/routes/_user.tsx
+++ b/src/routes/_user.tsx
@@ -1,14 +1,21 @@
-import { lazy, Suspense, useEffect, useRef } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useRef } from 'react'
 import {
 	createFileRoute,
 	Outlet,
 	redirect,
 	useMatches,
+	useParams,
+	useRouter,
 } from '@tanstack/react-router'
+import * as z from 'zod'
 import { cn } from '@/lib/utils'
 import { SidebarInset, useSidebar } from '@/components/ui/sidebar'
 import { Loader } from '@/components/ui/loader'
 import Navbar from '@/components/navs/navbar'
+import BrowseSearchOverlay from '@/components/browse-search-overlay'
+import FriendSearchOverlay from '@/components/friend-search-overlay'
+import languages from '@/lib/languages'
+import type { SearchScope } from '@/types/route-static-data'
 
 const AppSidebar = lazy(() =>
 	import('@/components/navs/app-sidebar').then((m) => ({
@@ -32,6 +39,10 @@ import { useNotificationsRealtime } from '@/features/notifications/hooks'
 import { useFontPreference } from '@/hooks/use-font-preference'
 import { queryClient } from '@/lib/query-client'
 
+const UserSearchParams = z.object({
+	search: z.boolean().optional(),
+})
+
 export const Route = createFileRoute('/_user')({
 	// Auth is optional at this layout — RLS handles data security and
 	// individual routes can require auth if needed.
@@ -41,6 +52,7 @@ export const Route = createFileRoute('/_user')({
 			subtitle: 'Which deck are we studying today?',
 		},
 	},
+	validateSearch: UserSearchParams,
 	loader: async ({ context, location }) => {
 		// If not authenticated, skip user-specific loading
 		if (!context.auth.isAuth) return
@@ -110,6 +122,13 @@ export const Route = createFileRoute('/_user')({
 	pendingComponent: Loader,
 })
 
+function setSearchParam(key: string, value: string | null) {
+	const url = new URL(window.location.href)
+	if (value === null) url.searchParams.delete(key)
+	else url.searchParams.set(key, value)
+	return url.pathname + url.search
+}
+
 function UserLayout() {
 	const { auth } = Route.useRouteContext()
 	const matches = useMatches()
@@ -123,6 +142,38 @@ function UserLayout() {
 	// Skip the AppNav chunk entirely when no route declares an appnav
 	const appnav = matches.findLast((m) => m.staticData.appnav)?.staticData.appnav
 	const hasAppNav = !!resolveNavList(appnav, auth.isAuth).length
+
+	// Resolve the search overlay the same way titleBar / appnav are resolved:
+	// the deepest match that declares `search` wins.
+	const searchScope: SearchScope | undefined = matches.findLast(
+		(m) => m.staticData.search
+	)?.staticData.search
+	const { search: isSearchOpen } = Route.useSearch()
+	const router = useRouter()
+	const { lang } = useParams({ strict: false })
+	const initialLangs = lang && lang in languages ? [lang] : undefined
+
+	const closeSearch = useCallback(() => {
+		void router.navigate({ to: setSearchParam('search', null), replace: true })
+	}, [router])
+
+	// Ctrl+K / Cmd+K toggles the overlay on any route that opts into a search
+	// scope. Disabled on routes that don't, so /search itself, the legacy /chat,
+	// etc. keep their own keybindings free.
+	useEffect(() => {
+		if (!searchScope) return
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+				e.preventDefault()
+				void router.navigate({
+					to: setSearchParam('search', isSearchOpen ? null : 'true'),
+					replace: true,
+				})
+			}
+		}
+		window.addEventListener('keydown', handler)
+		return () => window.removeEventListener('keydown', handler)
+	}, [searchScope, isSearchOpen, router])
 
 	// Auto-collapse sidebar when entering focus mode, restore when leaving
 	const { setOpen, open } = useSidebar()
@@ -197,6 +248,15 @@ function UserLayout() {
 					<RightSidebar />
 				</div>
 			</SidebarInset>
+			{isSearchOpen && searchScope === 'content' && (
+				<BrowseSearchOverlay
+					onClose={closeSearch}
+					initialLangs={initialLangs}
+				/>
+			)}
+			{isSearchOpen && searchScope === 'profiles' && (
+				<FriendSearchOverlay onClose={closeSearch} />
+			)}
 		</div>
 	)
 }

--- a/src/routes/_user/admin/routes.lazy.tsx
+++ b/src/routes/_user/admin/routes.lazy.tsx
@@ -2,7 +2,11 @@ import { type CSSProperties, type ReactNode, useMemo, useState } from 'react'
 import { createLazyFileRoute, useRouter } from '@tanstack/react-router'
 import { cn } from '@/lib/utils'
 import { Input } from '@/components/ui/input'
-import type { NavList, TitleBarStatic } from '@/types/route-static-data'
+import type {
+	NavList,
+	SearchScope,
+	TitleBarStatic,
+} from '@/types/route-static-data'
 import type { StaticDataRouteOption } from '@tanstack/react-router'
 
 export const Route = createLazyFileRoute('/_user/admin/routes')({
@@ -18,7 +22,7 @@ type Row = {
 	appnav?: NavList
 	contextMenu?: NavList
 	titleBar?: TitleBarStatic
-	searchAction: boolean
+	search: SearchScope | undefined
 	focusMode: boolean
 	wideContent: boolean
 	fixedHeight: boolean
@@ -44,7 +48,7 @@ function readRows(routesById: Record<string, RouteLike>): Row[] {
 			appnav: sd.appnav,
 			contextMenu: sd.contextMenu,
 			titleBar: sd.titleBar,
-			searchAction: sd.searchAction === true,
+			search: sd.search,
 			focusMode: sd.focusMode === true,
 			wideContent: sd.wideContent === true,
 			fixedHeight: sd.fixedHeight === true,
@@ -77,7 +81,7 @@ function RoutesIntrospection() {
 			titleBar: rows.filter((r) => r.titleBar !== undefined).length,
 			appnav: rows.filter((r) => r.appnav !== undefined).length,
 			ctxmenu: rows.filter((r) => r.contextMenu !== undefined).length,
-			search: rows.filter((r) => r.searchAction).length,
+			search: rows.filter((r) => r.search !== undefined).length,
 			focus: rows.filter((r) => r.focusMode).length,
 			wide: rows.filter((r) => r.wideContent).length,
 			fixed: rows.filter((r) => r.fixedHeight).length,
@@ -137,7 +141,7 @@ function RoutesIntrospection() {
 								<TitleBarCell tb={r.titleBar} />
 								<NavCell list={r.appnav} />
 								<NavCell list={r.contextMenu} />
-								<BoolCell on={r.searchAction} />
+								<SearchCell scope={r.search} />
 								<BoolCell on={r.focusMode} />
 								<BoolCell on={r.wideContent} />
 								<BoolCell on={r.fixedHeight} />
@@ -184,6 +188,16 @@ function BoolCell({ on }: { on: boolean }) {
 			)}
 		>
 			{on ? '✓' : '·'}
+		</td>
+	)
+}
+
+function SearchCell({ scope }: { scope: SearchScope | undefined }) {
+	if (scope === undefined)
+		return <td className="text-muted-foreground px-2 py-1.5 text-center">·</td>
+	return (
+		<td className="text-7-hi-success px-2 py-1.5 text-center font-mono text-xs">
+			{scope}
 		</td>
 	)
 }

--- a/src/routes/_user/browse.tsx
+++ b/src/routes/_user/browse.tsx
@@ -1,8 +1,5 @@
-import { useCallback, useEffect } from 'react'
-import { createFileRoute, Outlet, useRouter } from '@tanstack/react-router'
-import * as z from 'zod'
+import { createFileRoute } from '@tanstack/react-router'
 
-import BrowseSearchOverlay from '@/components/browse-search-overlay'
 import {
 	languagesCollection,
 	langTagsCollection,
@@ -14,13 +11,9 @@ import {
 	playlistPhraseLinksCollection,
 } from '@/features/playlists/collections'
 
-const BrowseSearchParams = z.object({
-	search: z.boolean().optional(),
-})
-
 export const Route = createFileRoute('/_user/browse')({
 	staticData: {
-		searchAction: true,
+		search: 'content',
 		appnav: ['/browse', '/browse/charts'],
 		contextMenu: [
 			['/learn/add-deck', '/learn/contributions'],
@@ -31,7 +24,6 @@ export const Route = createFileRoute('/_user/browse')({
 			subtitle: 'Browse the public library',
 		},
 	},
-	validateSearch: BrowseSearchParams,
 	loader: async () => {
 		await Promise.all([
 			languagesCollection.preload(),
@@ -42,50 +34,4 @@ export const Route = createFileRoute('/_user/browse')({
 			playlistPhraseLinksCollection.preload(),
 		])
 	},
-	component: BrowseLayout,
 })
-
-function setSearchParam(key: string, value: string | null) {
-	const url = new URL(window.location.href)
-	if (value === null) url.searchParams.delete(key)
-	else url.searchParams.set(key, value)
-	return url.pathname + url.search
-}
-
-function BrowseLayout() {
-	const router = useRouter()
-	const { search: isSearchOpen } = Route.useSearch()
-
-	const openSearch = useCallback(() => {
-		void router.navigate({
-			to: setSearchParam('search', 'true'),
-			replace: true,
-		})
-	}, [router])
-
-	const closeSearch = useCallback(() => {
-		void router.navigate({ to: setSearchParam('search', null), replace: true })
-	}, [router])
-
-	useEffect(() => {
-		const handler = (e: KeyboardEvent) => {
-			if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
-				e.preventDefault()
-				if (isSearchOpen) {
-					closeSearch()
-				} else {
-					openSearch()
-				}
-			}
-		}
-		window.addEventListener('keydown', handler)
-		return () => window.removeEventListener('keydown', handler)
-	}, [isSearchOpen, closeSearch, openSearch])
-
-	return (
-		<>
-			<Outlet />
-			{isSearchOpen && <BrowseSearchOverlay onClose={closeSearch} />}
-		</>
-	)
-}

--- a/src/routes/_user/browse.tsx
+++ b/src/routes/_user/browse.tsx
@@ -1,5 +1,8 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { useCallback, useEffect } from 'react'
+import { createFileRoute, Outlet, useRouter } from '@tanstack/react-router'
+import * as z from 'zod'
 
+import BrowseSearchOverlay from '@/components/browse-search-overlay'
 import {
 	languagesCollection,
 	langTagsCollection,
@@ -11,8 +14,13 @@ import {
 	playlistPhraseLinksCollection,
 } from '@/features/playlists/collections'
 
+const BrowseSearchParams = z.object({
+	search: z.boolean().optional(),
+})
+
 export const Route = createFileRoute('/_user/browse')({
 	staticData: {
+		searchAction: true,
 		appnav: ['/browse', '/browse/charts'],
 		contextMenu: [
 			['/learn/add-deck', '/learn/contributions'],
@@ -23,6 +31,7 @@ export const Route = createFileRoute('/_user/browse')({
 			subtitle: 'Browse the public library',
 		},
 	},
+	validateSearch: BrowseSearchParams,
 	loader: async () => {
 		await Promise.all([
 			languagesCollection.preload(),
@@ -33,4 +42,50 @@ export const Route = createFileRoute('/_user/browse')({
 			playlistPhraseLinksCollection.preload(),
 		])
 	},
+	component: BrowseLayout,
 })
+
+function setSearchParam(key: string, value: string | null) {
+	const url = new URL(window.location.href)
+	if (value === null) url.searchParams.delete(key)
+	else url.searchParams.set(key, value)
+	return url.pathname + url.search
+}
+
+function BrowseLayout() {
+	const router = useRouter()
+	const { search: isSearchOpen } = Route.useSearch()
+
+	const openSearch = useCallback(() => {
+		void router.navigate({
+			to: setSearchParam('search', 'true'),
+			replace: true,
+		})
+	}, [router])
+
+	const closeSearch = useCallback(() => {
+		void router.navigate({ to: setSearchParam('search', null), replace: true })
+	}, [router])
+
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+				e.preventDefault()
+				if (isSearchOpen) {
+					closeSearch()
+				} else {
+					openSearch()
+				}
+			}
+		}
+		window.addEventListener('keydown', handler)
+		return () => window.removeEventListener('keydown', handler)
+	}, [isSearchOpen, closeSearch, openSearch])
+
+	return (
+		<>
+			<Outlet />
+			{isSearchOpen && <BrowseSearchOverlay onClose={closeSearch} />}
+		</>
+	)
+}

--- a/src/routes/_user/friends.tsx
+++ b/src/routes/_user/friends.tsx
@@ -1,22 +1,14 @@
-import { useCallback, useEffect } from 'react'
-import { createFileRoute, Outlet, useRouter } from '@tanstack/react-router'
-import * as z from 'zod'
+import { createFileRoute, Outlet } from '@tanstack/react-router'
 import { publicProfilesCollection } from '@/features/profile/collections'
 import { friendSummariesCollection } from '@/features/social/collections'
 import { RequireAuth } from '@/components/require-auth'
-import FriendSearchOverlay from '@/components/friend-search-overlay'
-
-const FriendsSearchParams = z.object({
-	search: z.boolean().optional(),
-})
 
 export const Route = createFileRoute('/_user/friends')({
 	staticData: {
-		searchAction: true,
+		search: 'profiles',
 		contextMenu: ['/friends/chats', '/friends/invite'],
 		titleBar: { title: 'Friends and Contacts' },
 	},
-	validateSearch: FriendsSearchParams,
 	loader: async ({ context }) => {
 		// Only preload if authenticated
 		if (!context.auth.isAuth) return
@@ -28,51 +20,10 @@ export const Route = createFileRoute('/_user/friends')({
 	component: FriendsLayout,
 })
 
-function setSearchParam(key: string, value: string | null) {
-	const url = new URL(window.location.href)
-	if (value === null) url.searchParams.delete(key)
-	else url.searchParams.set(key, value)
-	return url.pathname + url.search
-}
-
 function FriendsLayout() {
-	const router = useRouter()
-	const { search: isSearchOpen } = Route.useSearch()
-
-	const openSearch = useCallback(() => {
-		void router.navigate({
-			to: setSearchParam('search', 'true'),
-			replace: true,
-		})
-	}, [router])
-
-	const closeSearch = useCallback(() => {
-		void router.navigate({
-			to: setSearchParam('search', null),
-			replace: true,
-		})
-	}, [router])
-
-	// Ctrl+K / Cmd+K to toggle search overlay
-	useEffect(() => {
-		const handler = (e: KeyboardEvent) => {
-			if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
-				e.preventDefault()
-				if (isSearchOpen) {
-					closeSearch()
-				} else {
-					openSearch()
-				}
-			}
-		}
-		window.addEventListener('keydown', handler)
-		return () => window.removeEventListener('keydown', handler)
-	}, [isSearchOpen, closeSearch, openSearch])
-
 	return (
 		<RequireAuth message="Log in to connect with friends, share phrases, and chat.">
 			<Outlet />
-			{isSearchOpen && <FriendSearchOverlay onClose={closeSearch} />}
 		</RequireAuth>
 	)
 }

--- a/src/routes/_user/learn.tsx
+++ b/src/routes/_user/learn.tsx
@@ -1,24 +1,9 @@
-import { useCallback, useEffect } from 'react'
-import {
-	createFileRoute,
-	Outlet,
-	useParams,
-	useRouter,
-} from '@tanstack/react-router'
-import * as z from 'zod'
-
-import BrowseSearchOverlay from '@/components/browse-search-overlay'
-import languages from '@/lib/languages'
-
-const LearnSearchParams = z.object({
-	search: z.boolean().optional(),
-})
+import { createFileRoute, Outlet } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/_user/learn')({
-	component: LearnLayout,
-	validateSearch: LearnSearchParams,
+	component: Outlet,
 	staticData: {
-		searchAction: true,
+		search: 'content',
 		contextMenu: [['/learn/add-deck', '/learn/contributions']],
 		titleBar: ({ isAuth }) => ({
 			title: 'Learning Home',
@@ -28,58 +13,3 @@ export const Route = createFileRoute('/_user/learn')({
 		}),
 	},
 })
-
-function setSearchParam(key: string, value: string | null) {
-	const url = new URL(window.location.href)
-	if (value === null) url.searchParams.delete(key)
-	else url.searchParams.set(key, value)
-	return url.pathname + url.search
-}
-
-function LearnLayout() {
-	const router = useRouter()
-	const { search: isSearchOpen } = Route.useSearch()
-	const { lang } = useParams({ strict: false })
-
-	// Pre-filter by the current deck language if we're inside a $lang route
-	const initialLangs = lang && lang in languages ? [lang] : undefined
-
-	const openSearch = useCallback(() => {
-		void router.navigate({
-			to: setSearchParam('search', 'true'),
-			replace: true,
-		})
-	}, [router])
-
-	const closeSearch = useCallback(() => {
-		void router.navigate({ to: setSearchParam('search', null), replace: true })
-	}, [router])
-
-	// Ctrl+K / Cmd+K to toggle search overlay
-	useEffect(() => {
-		const handler = (e: KeyboardEvent) => {
-			if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
-				e.preventDefault()
-				if (isSearchOpen) {
-					closeSearch()
-				} else {
-					openSearch()
-				}
-			}
-		}
-		window.addEventListener('keydown', handler)
-		return () => window.removeEventListener('keydown', handler)
-	}, [isSearchOpen, closeSearch, openSearch])
-
-	return (
-		<div className="h-full space-y-4">
-			<Outlet />
-			{isSearchOpen && (
-				<BrowseSearchOverlay
-					onClose={closeSearch}
-					initialLangs={initialLangs}
-				/>
-			)}
-		</div>
-	)
-}

--- a/src/routes/_user/learn/$lang.tsx
+++ b/src/routes/_user/learn/$lang.tsx
@@ -26,7 +26,7 @@ import { ReviewStoreProvider } from '@/components/review/review-context-provider
 export const Route = createFileRoute('/_user/learn/$lang')({
 	component: LanguageLayout,
 	staticData: {
-		searchAction: true,
+		search: 'content',
 		appnav: [
 			[
 				'/learn/$lang/feed',

--- a/src/types/route-static-data.ts
+++ b/src/types/route-static-data.ts
@@ -29,11 +29,20 @@ export type TitleBarFn = (args: {
 
 export type TitleBarStatic = TitleBar | TitleBarFn
 
+/**
+ * Which search overlay a route opts into. Resolved by walking `matches` in
+ * the `_user` layout (the same way `titleBar` is resolved) so the overlay,
+ * Ctrl+K handler, and `?search=true` validateSearch live in exactly one place.
+ *   - 'content'  → public-library search (phrases / playlists / requests)
+ *   - 'profiles' → people search (friends, public profiles)
+ */
+export type SearchScope = 'content' | 'profiles'
+
 declare module '@tanstack/react-router' {
 	interface StaticDataRouteOption {
 		appnav?: NavList
 		contextMenu?: NavList
-		searchAction?: boolean
+		search?: SearchScope
 		focusMode?: boolean
 		wideContent?: boolean
 		fixedHeight?: boolean


### PR DESCRIPTION
## Summary
Refactored search overlay handling by moving the Ctrl+K keyboard shortcut, search state management, and overlay rendering from individual route layouts (`/learn` and `/friends`) to the parent `_user` layout. This eliminates code duplication and establishes a single source of truth for search functionality across the app.

## Key Changes
- **Moved search logic to `_user` layout**: The `_user` layout now handles:
  - Search parameter validation via `UserSearchParams` schema
  - Ctrl+K/Cmd+K keyboard shortcut for toggling search overlays
  - Conditional rendering of `BrowseSearchOverlay` and `FriendSearchOverlay` based on route context
  
- **Introduced `SearchScope` type**: New type in `route-static-data.ts` that defines which search overlay a route opts into:
  - `'content'` → public library search (phrases/playlists/requests)
  - `'profiles'` → people search (friends/public profiles)
  
- **Simplified route configurations**:
  - `/learn` route now uses `component: Outlet` directly instead of custom `LearnLayout`
  - `/friends` route simplified to remove search handling logic
  - Both routes declare `search: 'content'` or `search: 'profiles'` in `staticData`
  - `/browse` route now declares `search: 'content'` to enable search functionality
  
- **Updated route introspection**: Admin routes page now displays `SearchScope` values instead of boolean `searchAction` flag

## Implementation Details
- Search overlay resolution uses the same pattern as `titleBar` and `appnav`: the deepest matching route that declares a `search` scope wins
- The `setSearchParam` utility function was moved to `_user` layout to be shared across all search-enabled routes
- Keyboard handler is disabled on routes that don't opt into a search scope, preserving keybindings for routes like `/search` and legacy `/chat`
- Added test scenarios in `browse-search.spec.md` to guard against regressions when `/browse` was moved out from under `/learn`

https://claude.ai/code/session_01A3Arfwhshr57KLXXC9q385