### PR TITLE
Fix first-spec failure when dev server cold starts

### DIFF
--- a/scenetest/scenes/_warmup.spec.ts
+++ b/scenetest/scenes/_warmup.spec.ts
@@ -1,0 +1,22 @@
+// Pre-compile the Vite dev server's module graph before the first real spec
+// runs. The alphabetically-first scene was timing out its initial `openTo`
+// because Vite transforms modules on demand on the first request, and the
+// markdown DSL has no per-step timeout escape hatch — every action shares
+// the 5s actionTimeout. Doing the warmup in TS lets us pass a generous
+// timeout directly to page.goto / page.waitForSelector.
+
+import { test } from '@scenetest/scenes'
+
+test('warm up dev server', async ({ actor }) => {
+	const visitor = await actor('visitor')
+
+	await visitor.do(async (page) => {
+		await page.goto('http://localhost:5173/', {
+			timeout: 60_000,
+			waitUntil: 'load',
+		})
+		await page.waitForSelector('[data-testid="landing-page"]', {
+			timeout: 60_000,
+		})
+	})
+})

--- a/scenetest/scenes/admin-phrases.spec.md
+++ b/scenetest/scenes/admin-phrases.spec.md
@@ -9,6 +9,8 @@ cleanup: supabase.from('admin_user').delete().eq('uid', '[learner.key]')
 
 learner:
 
+- openTo /
+- see landing-page
 - login
 - openTo /learn/[team.lang_partial]/phrases/[team.partial_nocard_phrase]
 - up

--- a/scenetest/scenes/admin-phrases.spec.md
+++ b/scenetest/scenes/admin-phrases.spec.md
@@ -9,8 +9,6 @@ cleanup: supabase.from('admin_user').delete().eq('uid', '[learner.key]')
 
 learner:
 
-- openTo /
-- see landing-page
 - login
 - openTo /learn/[team.lang_partial]/phrases/[team.partial_nocard_phrase]
 - up


### PR DESCRIPTION
Put a goto / with a 60s wait time in the beginning of the scene checks, so we know the dev server is warm

https://claude.ai/code/session_011qCUUdzj2X7vigvkCFeWTV