### PR TITLE
Optimize upvote mutations to avoid full table refetches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,20 @@ See PR #623 (`cardsCollection.onUpdate` + review context-menu) for a worked exam
 - **Realtime sync handlers** writing supabase channel events into a collection (`chatMessagesCollection.utils.writeInsert(...)` inside a `postgres_changes` callback) — that's sync, not a mutation.
 - **Mutations whose server-side transformation can't be predicted client-side** (e.g. FSRS scheduling on review submission) — evaluate case-by-case; may need `createOptimisticAction` with a best-guess optimistic update, or may legitimately keep the React Query pattern.
 
+#### Don't refetch entire tables to sync — return the row and `writeInsert` / `writeUpdate` / `writeDelete`
+
+`collection.utils.refetch()` is **a full table fetch** (`queryCollectionOptions.queryFn` re-runs `.from('…').select()` for the whole table). After a single-row mutation, this is wildly disproportionate: a refetch of `phrase_request` to confirm one new request pulls every request in the system.
+
+The cheap alternative: make supabase or the RPC hand back the affected rows, and write them into the synced state directly.
+
+- For direct supabase writes, append `.select()` (or `.select().single()`) to `insert / update / delete` calls. The post-mutation row(s) come back in the response.
+- For RPCs, prefer ones that already `RETURN json_build_object(...)` with the affected rows (e.g. `create_comment_with_phrases`).
+- Inside a `createOptimisticAction.mutationFn`, call `collection.utils.writeInsert(parsed)` / `writeUpdate(parsed)` / `writeDelete(key)` with the server's returned row(s). The synced state is now correct without a full refetch, and the optimistic state drops cleanly when the action resolves.
+
+Treat `collection.utils.refetch()` like `useEffect`: a code smell that needs a justification. **If you're about to add one, stop and check with the human first.** Usually one of these is the right move instead: pass client-generated IDs to the server so optimistic === synced; use `.select()` to get the row back; or change the RPC to return what you need. Legitimate uses do exist (e.g. picking up cascade-deleted rows on a parent delete) but they're rare and should be commented at the call site.
+
+If you do call `refetch()` against a `startSync: false` user collection that's small (one-column-of-IDs tables like `*_upvote`), note that in a comment — it's much cheaper than refetching a public table, but still worth flagging.
+
 **Deprecated** — do not use for new code, and migrate when touching old code (tracked by the `transform` label):
 
 ```typescript

--- a/src/components/comments/upvote-comment-button.tsx
+++ b/src/components/comments/upvote-comment-button.tsx
@@ -33,16 +33,27 @@ const setCommentUpvote = createOptimisticAction<UpvoteInput>({
 			commentUpvotesCollection.delete(commentId)
 		}
 	},
-	mutationFn: async ({ commentId, action }) => {
+	mutationFn: async ({ commentId, action, currentCount }) => {
 		const { error } = await supabase.rpc('set_comment_upvote', {
 			p_comment_id: commentId,
 			p_action: action,
 		})
 		if (error) throw error
-		await Promise.all([
-			commentsCollection.utils.refetch(),
-			commentUpvotesCollection.utils.refetch(),
-		])
+		// Trust the optimistic ±1 count. Drifts by 1 in the 'no_change' edge
+		// case (e.g. server already had us upvoted from another tab) and
+		// self-corrects on next stale refetch. Avoids a full request_comment
+		// table refetch on every click.
+		const nextCount =
+			action === 'add' ? currentCount + 1 : Math.max(0, currentCount - 1)
+		commentsCollection.utils.writeUpdate({
+			id: commentId,
+			upvote_count: nextCount,
+		})
+		if (action === 'add') {
+			commentUpvotesCollection.utils.writeInsert({ comment_id: commentId })
+		} else {
+			commentUpvotesCollection.utils.writeDelete(commentId)
+		}
 	},
 })
 

--- a/src/components/playlists/upvote-playlist-button.tsx
+++ b/src/components/playlists/upvote-playlist-button.tsx
@@ -33,16 +33,29 @@ const setPlaylistUpvote = createOptimisticAction<UpvoteInput>({
 			phrasePlaylistUpvotesCollection.delete(playlistId)
 		}
 	},
-	mutationFn: async ({ playlistId, action }) => {
+	mutationFn: async ({ playlistId, action, currentCount }) => {
 		const { error } = await supabase.rpc('set_phrase_playlist_upvote', {
 			p_playlist_id: playlistId,
 			p_action: action,
 		})
 		if (error) throw error
-		await Promise.all([
-			phrasePlaylistsCollection.utils.refetch(),
-			phrasePlaylistUpvotesCollection.utils.refetch(),
-		])
+		// Trust the optimistic ±1 count. Drifts by 1 in the 'no_change' edge
+		// case (e.g. server already had us upvoted from another tab) and
+		// self-corrects on next stale refetch. Avoids a full phrase_playlist
+		// table refetch on every click.
+		const nextCount =
+			action === 'add' ? currentCount + 1 : Math.max(0, currentCount - 1)
+		phrasePlaylistsCollection.utils.writeUpdate({
+			id: playlistId,
+			upvote_count: nextCount,
+		})
+		if (action === 'add') {
+			phrasePlaylistUpvotesCollection.utils.writeInsert({
+				playlist_id: playlistId,
+			})
+		} else {
+			phrasePlaylistUpvotesCollection.utils.writeDelete(playlistId)
+		}
 	},
 })
 

--- a/src/components/requests/upvote-request-button.tsx
+++ b/src/components/requests/upvote-request-button.tsx
@@ -33,16 +33,29 @@ const setRequestUpvote = createOptimisticAction<UpvoteInput>({
 			phraseRequestUpvotesCollection.delete(requestId)
 		}
 	},
-	mutationFn: async ({ requestId, action }) => {
+	mutationFn: async ({ requestId, action, currentCount }) => {
 		const { error } = await supabase.rpc('set_phrase_request_upvote', {
 			p_request_id: requestId,
 			p_action: action,
 		})
 		if (error) throw error
-		await Promise.all([
-			phraseRequestsCollection.utils.refetch(),
-			phraseRequestUpvotesCollection.utils.refetch(),
-		])
+		// Trust the optimistic ±1 count. Drifts by 1 in the 'no_change' edge
+		// case (e.g. server already had us upvoted from another tab) and
+		// self-corrects on next stale refetch. Avoids a full phrase_request
+		// table refetch on every click.
+		const nextCount =
+			action === 'add' ? currentCount + 1 : Math.max(0, currentCount - 1)
+		phraseRequestsCollection.utils.writeUpdate({
+			id: requestId,
+			upvote_count: nextCount,
+		})
+		if (action === 'add') {
+			phraseRequestUpvotesCollection.utils.writeInsert({
+				request_id: requestId,
+			})
+		} else {
+			phraseRequestUpvotesCollection.utils.writeDelete(requestId)
+		}
 	},
 })
 


### PR DESCRIPTION
## Summary
Replace full table refetches with targeted cache updates in upvote mutations across comments, requests, and playlists. This reduces unnecessary data fetching and improves performance when users interact with upvote buttons.

## Changes
- **Upvote mutations** (`setCommentUpvote`, `setRequestUpvote`, `setPlaylistUpvote`):
  - Accept `currentCount` parameter to enable client-side count calculation
  - Replace `refetch()` calls with `writeUpdate()` to update the upvote count directly
  - Use `writeInsert()` / `writeDelete()` to sync the upvote collection state
  - Add explanatory comments about trusting optimistic updates and self-correction on stale refetches

- **Documentation** (CLAUDE.md):
  - Add guidance section on avoiding full table refetches for single-row mutations
  - Explain the pattern: return affected rows from server and use `writeInsert/Update/Delete`
  - Recommend treating `refetch()` as a code smell requiring justification
  - Note legitimate edge cases (e.g., cascade deletes) that still warrant refetch

## Implementation Details
The mutations now calculate the next count locally (`currentCount ± 1`) and write it directly to the synced collection state. This avoids fetching entire `phrase_request`, `phrase_playlist`, or `request_comment` tables on every upvote click. The optimistic update already handles the UI; the mutation now just syncs the server state without the overhead of a full table scan. Edge cases (e.g., upvoting from multiple tabs) will self-correct on the next stale refetch, which is acceptable given the performance win.

https://claude.ai/code/session_01EnKyMtHiqCkpJMYHkvLzuQ