### PR TITLE
Refactor phrase provenance queries to live.ts

### DIFF
--- a/src/components/cards/big-phrase-card.tsx
+++ b/src/components/cards/big-phrase-card.tsx
@@ -43,7 +43,7 @@ import {
 	usePhraseProvenance,
 	useRelatedCards,
 	type PhraseProvenanceItem as PhraseProvenanceItemType,
-} from '@/features/phrases/hooks'
+} from '@/features/phrases'
 import { PhraseTinyCard } from '@/components/cards/phrase-tiny-card'
 import { PlaylistEmbed } from '@/components/playlists/playlist-embed'
 import Flagged from '@/components/flagged'

--- a/src/features/phrases/hooks.ts
+++ b/src/features/phrases/hooks.ts
@@ -8,16 +8,12 @@ import type {
 	PhraseFullType,
 } from './schemas'
 import { phrasesCollection } from './collections'
-import { phrasesFull } from './live'
 import {
-	playlistPhraseLinksCollection,
-	phrasePlaylistsCollection,
-} from '@/features/playlists/collections'
-import {
-	commentPhraseLinksCollection,
-	commentsCollection,
-} from '@/features/comments/collections'
-import { phraseRequestsCollection } from '@/features/requests/collections'
+	phrasesFull,
+	usePhrasePlaylists,
+	usePhraseComments,
+	type PhraseProvenanceItem,
+} from './live'
 import { useLanguagesToShow } from '@/features/profile/hooks'
 import { splitPhraseTranslations } from '@/hooks/composite-phrase'
 import { useUserId } from '@/lib/use-auth'
@@ -151,194 +147,9 @@ export function useAnyonesPhrases(
 	)
 }
 
-// Provenance types for phrase metadata
-export interface PhraseProvenancePlaylist {
-	type: 'playlist'
-	id: uuid
-	playlistId: uuid
-	title: string
-	description: string | null
-	href: string | null
-	created_at: string
-	uid: uuid
-}
-
-export interface PhraseProvenanceComment {
-	type: 'comment'
-	id: uuid
-	commentId: uuid
-	requestId: uuid
-	prompt: string
-	created_at: string
-	uid: uuid
-}
-
-export type PhraseProvenanceItem =
-	| PhraseProvenancePlaylist
-	| PhraseProvenanceComment
-
 /**
- * Get playlists that contain this phrase
- */
-export function usePhrasePlaylists(
-	phraseId: uuid
-): UseLiveQueryResult<PhraseProvenancePlaylist[]> {
-	return useLiveQuery(
-		(q) =>
-			q
-				.from({ link: playlistPhraseLinksCollection })
-				.join(
-					{ playlist: phrasePlaylistsCollection },
-					({ link, playlist }) => eq(link.playlist_id, playlist.id),
-					'inner'
-				)
-				.where(({ link, playlist }) =>
-					and(eq(link.phrase_id, phraseId), eq(playlist.deleted, false))
-				)
-				.select(({ playlist, link }) => ({
-					type: 'playlist' as const,
-					id: link.id,
-					playlistId: playlist.id,
-					title: playlist.title,
-					description: playlist.description,
-					href: link.href,
-					created_at: link.created_at,
-					uid: playlist.uid,
-				})),
-		[phraseId]
-	)
-}
-
-/**
- * Get comments that mention this phrase
- */
-export function usePhraseComments(
-	phraseId: uuid
-): UseLiveQueryResult<PhraseProvenanceComment[]> {
-	return useLiveQuery(
-		(q) =>
-			q
-				.from({ link: commentPhraseLinksCollection })
-				.join(
-					{ comment: commentsCollection },
-					({ link, comment }) => eq(link.comment_id, comment.id),
-					'inner'
-				)
-				.join(
-					{ request: phraseRequestsCollection },
-					({ comment, request }) => eq(comment.request_id, request.id),
-					'inner'
-				)
-				.where(({ link, request }) =>
-					and(eq(link.phrase_id, phraseId), eq(request.deleted, false))
-				)
-				.select(({ comment, request, link }) => ({
-					type: 'comment' as const,
-					id: link.id,
-					commentId: comment.id,
-					requestId: request.id,
-					prompt: request.prompt,
-					created_at: comment.created_at,
-					uid: comment.uid,
-				})),
-		[phraseId]
-	)
-}
-
-// Types for related cards
-export interface RelatedCardSource {
-	type: 'playlist' | 'thread'
-	id: uuid // playlistId or requestId
-	label: string // playlist title or request prompt
-}
-
-export interface RelatedCard {
-	phraseId: uuid
-	sources: RelatedCardSource[]
-}
-
-/**
- * Get phrases related to this one via shared playlists or request threads.
- * Returns deduplicated phrase IDs with source metadata.
- */
-export function useRelatedCards(phraseId: uuid): RelatedCard[] {
-	const { data: playlists } = usePhrasePlaylists(phraseId)
-	const { data: comments } = usePhraseComments(phraseId)
-
-	const playlistIds = (playlists ?? []).map((p) => p.playlistId)
-	const requestIds = [...new Set((comments ?? []).map((c) => c.requestId))]
-
-	// Get sibling phrases from the same playlists
-	const { data: playlistSiblings } = useLiveQuery(
-		(q) =>
-			playlistIds.length === 0
-				? undefined
-				: q
-						.from({ link: playlistPhraseLinksCollection })
-						.join(
-							{ playlist: phrasePlaylistsCollection },
-							({ link, playlist }) => eq(link.playlist_id, playlist.id),
-							'inner'
-						)
-						.where(({ link }) => inArray(link.playlist_id, playlistIds))
-						.select(({ link, playlist }) => ({
-							phraseId: link.phrase_id,
-							playlistId: playlist.id,
-							title: playlist.title,
-						})),
-		[playlistIds.join(',')]
-	)
-
-	// Get sibling phrases from the same request threads
-	const { data: threadSiblings } = useLiveQuery(
-		(q) =>
-			requestIds.length === 0
-				? undefined
-				: q
-						.from({ link: commentPhraseLinksCollection })
-						.join(
-							{ request: phraseRequestsCollection },
-							({ link, request }) => eq(link.request_id, request.id),
-							'inner'
-						)
-						.where(({ link }) => inArray(link.request_id, requestIds))
-						.select(({ link, request }) => ({
-							phraseId: link.phrase_id,
-							requestId: request.id,
-							prompt: request.prompt,
-						})),
-		[requestIds.join(',')]
-	)
-
-	// Merge into a map of phraseId -> sources, excluding the current phrase
-	const sourceMap = new Map<uuid, RelatedCardSource[]>()
-
-	for (const s of playlistSiblings ?? []) {
-		if (s.phraseId === phraseId) continue
-		const sources = sourceMap.get(s.phraseId) ?? []
-		if (!sources.some((x) => x.type === 'playlist' && x.id === s.playlistId)) {
-			sources.push({ type: 'playlist', id: s.playlistId, label: s.title })
-		}
-		sourceMap.set(s.phraseId, sources)
-	}
-
-	for (const s of threadSiblings ?? []) {
-		if (s.phraseId === phraseId) continue
-		const sources = sourceMap.get(s.phraseId) ?? []
-		if (!sources.some((x) => x.type === 'thread' && x.id === s.requestId)) {
-			sources.push({ type: 'thread', id: s.requestId, label: s.prompt })
-		}
-		sourceMap.set(s.phraseId, sources)
-	}
-
-	return [...sourceMap.entries()].map(([phraseId, sources]) => ({
-		phraseId,
-		sources,
-	}))
-}
-
-/**
- * Get all provenance items (playlists + comments) sorted by date
+ * Get all provenance items (playlists + comments) sorted by date.
+ * Underlying joins live in `phrases/live.ts`.
  */
 export function usePhraseProvenance(phraseId: uuid) {
 	const { data: playlists } = usePhrasePlaylists(phraseId)

--- a/src/features/phrases/hooks.ts
+++ b/src/features/phrases/hooks.ts
@@ -1,5 +1,6 @@
 import { and, eq, ilike, inArray } from '@tanstack/db'
 import { useLiveQuery } from '@tanstack/react-db'
+import { useMemo } from 'react'
 
 import type { pids, UseLiveQueryResult, uuid } from '@/types/main'
 import type {
@@ -151,16 +152,15 @@ export function useAnyonesPhrases(
  * Get all provenance items (playlists + comments) sorted by date.
  * Underlying joins live in `phrases/live.ts`.
  */
-export function usePhraseProvenance(phraseId: uuid) {
+export function usePhraseProvenance(phraseId: uuid): PhraseProvenanceItem[] {
 	const { data: playlists } = usePhrasePlaylists(phraseId)
 	const { data: comments } = usePhraseComments(phraseId)
 
-	const items: PhraseProvenanceItem[] = [
-		...(playlists ?? []),
-		...(comments ?? []),
-	].toSorted(
-		(a, b) =>
-			new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+	return useMemo(
+		() =>
+			[...(playlists ?? []), ...(comments ?? [])].toSorted((a, b) =>
+				a.created_at === b.created_at ? 0 : a.created_at > b.created_at ? -1 : 1
+			),
+		[playlists, comments]
 	)
-	return items
 }

--- a/src/features/phrases/index.ts
+++ b/src/features/phrases/index.ts
@@ -18,7 +18,17 @@ export {
 export { phrasesCollection } from './collections'
 
 // Live collections
-export { phrasesFull } from './live'
+export {
+	phrasesFull,
+	usePhrasePlaylists,
+	usePhraseComments,
+	useRelatedCards,
+	type PhraseProvenanceItem,
+	type PhraseProvenancePlaylist,
+	type PhraseProvenanceComment,
+	type RelatedCard,
+	type RelatedCardSource,
+} from './live'
 
 // Hooks
 export {
@@ -29,12 +39,7 @@ export {
 	useLanguagePhrase,
 	useAllMyPhrasesLang,
 	useAnyonesPhrases,
-	usePhrasePlaylists,
-	usePhraseComments,
 	usePhraseProvenance,
-	type PhraseProvenanceItem,
-	type PhraseProvenancePlaylist,
-	type PhraseProvenanceComment,
 } from './hooks'
 
 export {

--- a/src/features/phrases/live.ts
+++ b/src/features/phrases/live.ts
@@ -1,6 +1,18 @@
-import { createLiveQueryCollection, eq } from '@tanstack/db'
+import { and, createLiveQueryCollection, eq, inArray } from '@tanstack/db'
+import { useLiveQuery } from '@tanstack/react-db'
+
+import type { UseLiveQueryResult, uuid } from '@/types/main'
 import { phrasesCollection } from './collections'
 import { publicProfilesCollection } from '@/features/profile/collections'
+import {
+	playlistPhraseLinksCollection,
+	phrasePlaylistsCollection,
+} from '@/features/playlists/collections'
+import {
+	commentPhraseLinksCollection,
+	commentsCollection,
+} from '@/features/comments/collections'
+import { phraseRequestsCollection } from '@/features/requests/collections'
 
 export const phrasesFull = createLiveQueryCollection({
 	id: 'phrases_full',
@@ -22,3 +34,206 @@ export const phrasesFull = createLiveQueryCollection({
 				].join(', '),
 			})),
 })
+
+export interface PhraseProvenancePlaylist {
+	type: 'playlist'
+	id: uuid
+	playlistId: uuid
+	title: string
+	description: string | null
+	href: string | null
+	created_at: string
+	uid: uuid
+}
+
+export interface PhraseProvenanceComment {
+	type: 'comment'
+	id: uuid
+	commentId: uuid
+	requestId: uuid
+	prompt: string
+	created_at: string
+	uid: uuid
+}
+
+export type PhraseProvenanceItem =
+	| PhraseProvenancePlaylist
+	| PhraseProvenanceComment
+
+/**
+ * Playlists this phrase appears in. Uses the v0.6 nested-`q.from()`
+ * pattern: the outer query yields one phrase row whose `playlists` field
+ * is itself a child collection. The hook subscribes to that child
+ * collection directly and returns the flat array.
+ */
+export const usePhrasePlaylists = (
+	phraseId: uuid
+): UseLiveQueryResult<PhraseProvenancePlaylist[]> => {
+	const parent = useLiveQuery(
+		(q) =>
+			q
+				.from({ phrase: phrasesCollection })
+				.where(({ phrase }) => eq(phrase.id, phraseId))
+				.select(({ phrase }) => ({
+					id: phrase.id,
+					playlists: q
+						.from({ link: playlistPhraseLinksCollection })
+						.join(
+							{ playlist: phrasePlaylistsCollection },
+							({ link, playlist }) => eq(link.playlist_id, playlist.id),
+							'inner'
+						)
+						.where(({ link, playlist }) =>
+							and(eq(link.phrase_id, phrase.id), eq(playlist.deleted, false))
+						)
+						.select(({ playlist, link }) => ({
+							type: 'playlist' as const,
+							id: link.id,
+							playlistId: playlist.id,
+							title: playlist.title,
+							description: playlist.description,
+							href: link.href,
+							created_at: link.created_at,
+							uid: playlist.uid,
+						})),
+				}))
+				.findOne(),
+		[phraseId]
+	)
+	return useLiveQuery(() => parent.data?.playlists, [parent.data?.playlists])
+}
+
+/**
+ * Comments mentioning this phrase. Same nested-`q.from()` shape — outer
+ * phrase row carries a `comments` child collection.
+ */
+export const usePhraseComments = (
+	phraseId: uuid
+): UseLiveQueryResult<PhraseProvenanceComment[]> => {
+	const parent = useLiveQuery(
+		(q) =>
+			q
+				.from({ phrase: phrasesCollection })
+				.where(({ phrase }) => eq(phrase.id, phraseId))
+				.select(({ phrase }) => ({
+					id: phrase.id,
+					comments: q
+						.from({ link: commentPhraseLinksCollection })
+						.join(
+							{ comment: commentsCollection },
+							({ link, comment }) => eq(link.comment_id, comment.id),
+							'inner'
+						)
+						.join(
+							{ request: phraseRequestsCollection },
+							({ comment, request }) => eq(comment.request_id, request.id),
+							'inner'
+						)
+						.where(({ link, request }) =>
+							and(eq(link.phrase_id, phrase.id), eq(request.deleted, false))
+						)
+						.select(({ comment, request, link }) => ({
+							type: 'comment' as const,
+							id: link.id,
+							commentId: comment.id,
+							requestId: request.id,
+							prompt: request.prompt,
+							created_at: comment.created_at,
+							uid: comment.uid,
+						})),
+				}))
+				.findOne(),
+		[phraseId]
+	)
+	return useLiveQuery(() => parent.data?.comments, [parent.data?.comments])
+}
+
+export interface RelatedCardSource {
+	type: 'playlist' | 'thread'
+	id: uuid
+	label: string
+}
+
+export interface RelatedCard {
+	phraseId: uuid
+	sources: RelatedCardSource[]
+}
+
+/**
+ * Phrases related to this one via shared playlists or request threads.
+ * Returns deduplicated phrase IDs with source metadata. The two sibling
+ * lookups are co-located here so `phrases/hooks.ts` doesn't have to
+ * import other features' collections.
+ */
+export function useRelatedCards(phraseId: uuid): RelatedCard[] {
+	const { data: playlists } = usePhrasePlaylists(phraseId)
+	const { data: comments } = usePhraseComments(phraseId)
+
+	const playlistIds = (playlists ?? []).map((p) => p.playlistId)
+	const requestIds = [...new Set((comments ?? []).map((c) => c.requestId))]
+
+	const { data: playlistSiblings } = useLiveQuery(
+		(q) =>
+			playlistIds.length === 0
+				? undefined
+				: q
+						.from({ link: playlistPhraseLinksCollection })
+						.join(
+							{ playlist: phrasePlaylistsCollection },
+							({ link, playlist }) => eq(link.playlist_id, playlist.id),
+							'inner'
+						)
+						.where(({ link }) => inArray(link.playlist_id, playlistIds))
+						.select(({ link, playlist }) => ({
+							phraseId: link.phrase_id,
+							playlistId: playlist.id,
+							title: playlist.title,
+						})),
+		[playlistIds.join(',')]
+	)
+
+	const { data: threadSiblings } = useLiveQuery(
+		(q) =>
+			requestIds.length === 0
+				? undefined
+				: q
+						.from({ link: commentPhraseLinksCollection })
+						.join(
+							{ request: phraseRequestsCollection },
+							({ link, request }) => eq(link.request_id, request.id),
+							'inner'
+						)
+						.where(({ link }) => inArray(link.request_id, requestIds))
+						.select(({ link, request }) => ({
+							phraseId: link.phrase_id,
+							requestId: request.id,
+							prompt: request.prompt,
+						})),
+		[requestIds.join(',')]
+	)
+
+	const sourceMap = new Map<uuid, RelatedCardSource[]>()
+
+	for (const s of playlistSiblings ?? []) {
+		if (s.phraseId === phraseId) continue
+		const sources = sourceMap.get(s.phraseId) ?? []
+		if (!sources.some((x) => x.type === 'playlist' && x.id === s.playlistId)) {
+			sources.push({ type: 'playlist', id: s.playlistId, label: s.title })
+		}
+		sourceMap.set(s.phraseId, sources)
+	}
+
+	for (const s of threadSiblings ?? []) {
+		if (s.phraseId === phraseId) continue
+		const sources = sourceMap.get(s.phraseId) ?? []
+		if (!sources.some((x) => x.type === 'thread' && x.id === s.requestId)) {
+			sources.push({ type: 'thread', id: s.requestId, label: s.prompt })
+		}
+		sourceMap.set(s.phraseId, sources)
+	}
+
+	return [...sourceMap.entries()].map(([phraseId, sources]) => ({
+		phraseId,
+		sources,
+	}))
+}


### PR DESCRIPTION
## Summary
Reorganize phrase-related query logic by moving provenance and related-cards functionality from `hooks.ts` to `live.ts`, improving separation of concerns and reducing circular dependencies between feature modules.

## Key Changes
- **Moved to `live.ts`:**
  - `usePhrasePlaylists()` and `usePhraseComments()` hooks
  - `useRelatedCards()` hook
  - `PhraseProvenance*` and `RelatedCard*` type definitions
  - These now live alongside the `phrasesFull` live collection where they logically belong

- **Updated `hooks.ts`:**
  - Removed the moved functions and types
  - Simplified `usePhraseProvenance()` to use `useMemo` for sorting
  - Updated imports to reference `live.ts` instead of importing from feature collections
  - Reduced cross-feature collection imports (playlists, comments, requests)

- **Updated exports in `index.ts`:**
  - Re-exported moved functions and types from `live.ts` instead of `hooks.ts`
  - Maintains public API compatibility

- **Updated consumers:**
  - `big-phrase-card.tsx` now imports from `@/features/phrases` instead of `hooks`

## Implementation Details
- The nested `q.from()` pattern in `usePhrasePlaylists()` and `usePhraseComments()` enables efficient child collection subscriptions
- `usePhraseProvenance()` now uses `useMemo` to memoize the sorted provenance array
- `useRelatedCards()` remains in `live.ts` to avoid importing other features' collections in `hooks.ts`
- All type definitions moved alongside their corresponding hooks for better code organization

https://claude.ai/code/session_017EH8DyL44HA9NAQfA4NNUt