### PR TITLE
Add BasicIndex to phrases and profile collections

### DIFF
--- a/src/features/phrases/live.ts
+++ b/src/features/phrases/live.ts
@@ -1,4 +1,10 @@
-import { and, createLiveQueryCollection, eq, inArray } from '@tanstack/db'
+import {
+	and,
+	BasicIndex,
+	createLiveQueryCollection,
+	eq,
+	inArray,
+} from '@tanstack/db'
 import { useLiveQuery } from '@tanstack/react-db'
 
 import type { UseLiveQueryResult, uuid } from '@/types/main'
@@ -34,6 +40,8 @@ export const phrasesFull = createLiveQueryCollection({
 				].join(', '),
 			})),
 })
+
+phrasesFull.createIndex((row) => row.id, { indexType: BasicIndex })
 
 export interface PhraseProvenancePlaylist {
 	type: 'playlist'

--- a/src/features/profile/collections.ts
+++ b/src/features/profile/collections.ts
@@ -1,6 +1,7 @@
 import { createCollection } from '@tanstack/react-db'
 import { queryCollectionOptions } from '@tanstack/query-db-collection'
 import { queryOptions } from '@tanstack/react-query'
+import { BasicIndex } from '@tanstack/db'
 import {
 	PublicProfileSchema,
 	type PublicProfileType,
@@ -25,6 +26,8 @@ export const publicProfilesCollection = createCollection(
 		getKey: (item: PublicProfileType) => item.uid,
 		queryClient,
 		schema: PublicProfileSchema,
+		autoIndex: 'eager',
+		defaultIndexType: BasicIndex,
 	})
 )
 


### PR DESCRIPTION
## Summary
Adds explicit indexing configuration to two TanStack DB collections to improve query performance by creating indexes on frequently-accessed fields.

## Changes
- **src/features/phrases/live.ts**: 
  - Import `BasicIndex` from `@tanstack/db`
  - Create an index on the `id` field of the `phrasesFull` collection using `BasicIndex` type

- **src/features/profile/collections.ts**:
  - Import `BasicIndex` from `@tanstack/db`
  - Configure `publicProfilesCollection` with `autoIndex: 'eager'` and `defaultIndexType: BasicIndex` to enable eager indexing on the collection

## Implementation Details
These changes optimize collection queries by explicitly defining index strategies. The `BasicIndex` type provides efficient lookups on the indexed fields, while the `autoIndex: 'eager'` configuration in the profile collection ensures indexes are built proactively rather than on-demand.

https://claude.ai/code/session_017EH8DyL44HA9NAQfA4NNUt