### PR TITLE
Refactor sidebar layout: move user nav to content, add footer actions

### DIFF
--- a/src/components/navs/app-sidebar.tsx
+++ b/src/components/navs/app-sidebar.tsx
@@ -1,6 +1,7 @@
 import type { ComponentProps } from 'react'
 import { NavMain } from '@/components/navs/nav-main'
 import { NavUser } from '@/components/navs/nav-user'
+import { NavFooterActions } from '@/components/navs/nav-footer-actions'
 import { DeckSwitcher } from '@/components/navs/deck-switcher'
 import { ActiveReviewCallout } from '@/components/navs/active-review-callout'
 import {
@@ -9,6 +10,7 @@ import {
 	SidebarFooter,
 	SidebarHeader,
 	SidebarRail,
+	SidebarSeparator,
 } from '@/components/ui/sidebar'
 import { useParams } from '@tanstack/react-router'
 
@@ -29,9 +31,11 @@ export function AppSidebar({
 			<SidebarContent>
 				<ActiveReviewCallout currentLang={lang} />
 				<NavMain />
+				<SidebarSeparator />
+				<NavUser />
 			</SidebarContent>
 			<SidebarFooter>
-				<NavUser />
+				<NavFooterActions />
 			</SidebarFooter>
 			<SidebarRail />
 		</Sidebar>

--- a/src/components/navs/nav-footer-actions.tsx
+++ b/src/components/navs/nav-footer-actions.tsx
@@ -1,0 +1,33 @@
+import { Github, Moon, Sun } from 'lucide-react'
+import { useTheme } from '@/components/theme-provider'
+import { Button } from '@/components/ui/button'
+
+export function NavFooterActions() {
+	const { theme, setTheme } = useTheme()
+	const isDark = theme === 'dark'
+	const toggleTheme = () => setTheme(isDark ? 'light' : 'dark')
+
+	return (
+		<div className="flex items-center justify-between gap-2 px-2 py-1 group-data-[collapsible=icon]:hidden">
+			<a
+				href="https://github.com/mhsnook/sunlo"
+				target="_blank"
+				rel="noreferrer"
+				className="text-c-lo text-lc-5 hover:text-lc-7 flex items-center gap-2 text-xs"
+				data-testid="sidebar-open-source-link"
+			>
+				<Github className="size-4" />
+				<span>Free forever &middot; Open source</span>
+			</a>
+			<Button
+				variant="ghost"
+				size="icon"
+				onClick={toggleTheme}
+				aria-label="Toggle theme"
+				data-testid="sidebar-theme-toggle"
+			>
+				{isDark ? <Sun className="size-4" /> : <Moon className="size-4" />}
+			</Button>
+		</div>
+	)
+}

--- a/src/components/navs/nav-footer-actions.tsx
+++ b/src/components/navs/nav-footer-actions.tsx
@@ -17,7 +17,7 @@ export function NavFooterActions() {
 				data-testid="sidebar-open-source-link"
 			>
 				<Github className="size-4" />
-				<span>Free forever &middot; Open source</span>
+				<span>Free &amp; open source</span>
 			</a>
 			<Button
 				variant="ghost"

--- a/src/components/navs/nav-user.tsx
+++ b/src/components/navs/nav-user.tsx
@@ -1,4 +1,5 @@
 import { LogIn, Settings, UserPlus } from 'lucide-react'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import {
 	SidebarGroup,
 	SidebarMenu,
@@ -7,11 +8,14 @@ import {
 	useSidebar,
 } from '@/components/ui/sidebar'
 import { useAuth } from '@/lib/use-auth'
+import { useProfile } from '@/features/profile/hooks'
 import { Link } from '@tanstack/react-router'
+import { avatarUrlify } from '@/lib/hooks'
 
 export function NavUser() {
 	const { setClosedMobile } = useSidebar()
 	const { isAuth } = useAuth()
+	const { data: profile } = useProfile()
 
 	if (!isAuth) {
 		return (
@@ -54,6 +58,8 @@ export function NavUser() {
 		)
 	}
 
+	const avatarUrl = avatarUrlify(profile?.avatar_path)
+
 	return (
 		<SidebarGroup>
 			<SidebarMenu>
@@ -63,7 +69,12 @@ export function NavUser() {
 						data-testid="sidebar-profile-settings-link"
 					>
 						<Link to="/profile" onClick={setClosedMobile}>
-							<Settings className="size-4" />
+							<Avatar className="size-6">
+								<AvatarImage src={avatarUrl} alt={profile?.username} />
+								<AvatarFallback className="rounded text-[10px]">
+									Me
+								</AvatarFallback>
+							</Avatar>
 							<span>Profile &amp; settings</span>
 						</Link>
 					</SidebarMenuButton>

--- a/src/components/navs/nav-user.tsx
+++ b/src/components/navs/nav-user.tsx
@@ -1,77 +1,74 @@
 import { LogIn, Settings, UserPlus } from 'lucide-react'
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import {
+	SidebarGroup,
 	SidebarMenu,
 	SidebarMenuButton,
 	SidebarMenuItem,
 	useSidebar,
 } from '@/components/ui/sidebar'
 import { useAuth } from '@/lib/use-auth'
-import { useProfile } from '@/features/profile/hooks'
 import { Link } from '@tanstack/react-router'
-import { avatarUrlify } from '@/lib/hooks'
 
 export function NavUser() {
 	const { setClosedMobile } = useSidebar()
 	const { isAuth } = useAuth()
-	const { data: profile } = useProfile()
 
 	if (!isAuth) {
 		return (
+			<SidebarGroup>
+				<SidebarMenu>
+					<SidebarMenuItem>
+						<SidebarMenuButton asChild>
+							<Link
+								to="/login"
+								data-testid="login-link"
+								onClick={setClosedMobile}
+							>
+								<LogIn className="size-4" />
+								<span>Log in</span>
+							</Link>
+						</SidebarMenuButton>
+					</SidebarMenuItem>
+					<SidebarMenuItem>
+						<SidebarMenuButton asChild>
+							<Link to="/signup" onClick={setClosedMobile}>
+								<UserPlus className="size-4" />
+								<span>Sign up</span>
+							</Link>
+						</SidebarMenuButton>
+					</SidebarMenuItem>
+					<SidebarMenuItem>
+						<SidebarMenuButton asChild>
+							<Link
+								to="/profile"
+								data-testid="sidebar-display-settings-link"
+								onClick={setClosedMobile}
+							>
+								<Settings className="size-4" />
+								<span>Display settings</span>
+							</Link>
+						</SidebarMenuButton>
+					</SidebarMenuItem>
+				</SidebarMenu>
+			</SidebarGroup>
+		)
+	}
+
+	return (
+		<SidebarGroup>
 			<SidebarMenu>
 				<SidebarMenuItem>
-					<SidebarMenuButton asChild>
-						<Link
-							to="/login"
-							data-testid="login-link"
-							onClick={setClosedMobile}
-						>
-							<LogIn className="size-4" />
-							<span>Log in</span>
-						</Link>
-					</SidebarMenuButton>
-				</SidebarMenuItem>
-				<SidebarMenuItem>
-					<SidebarMenuButton asChild>
-						<Link to="/signup" onClick={setClosedMobile}>
-							<UserPlus className="size-4" />
-							<span>Sign up</span>
-						</Link>
-					</SidebarMenuButton>
-				</SidebarMenuItem>
-				<SidebarMenuItem>
-					<SidebarMenuButton asChild>
-						<Link
-							to="/profile"
-							data-testid="sidebar-display-settings-link"
-							onClick={setClosedMobile}
-						>
+					<SidebarMenuButton
+						asChild
+						data-testid="sidebar-profile-settings-link"
+					>
+						<Link to="/profile" onClick={setClosedMobile}>
 							<Settings className="size-4" />
-							<span>Display settings</span>
+							<span>Profile &amp; settings</span>
 						</Link>
 					</SidebarMenuButton>
 				</SidebarMenuItem>
 			</SidebarMenu>
-		)
-	}
-
-	const avatarUrl = avatarUrlify(profile?.avatar_path)
-
-	return (
-		<SidebarMenu>
-			<SidebarMenuItem>
-				<SidebarMenuButton asChild data-testid="sidebar-profile-settings-link">
-					<Link to="/profile" onClick={setClosedMobile}>
-						<Avatar className="size-6">
-							<AvatarImage src={avatarUrl} alt={profile?.username} />
-							<AvatarFallback className="rounded text-[10px]">
-								Me
-							</AvatarFallback>
-						</Avatar>
-						<span>Profile &amp; settings</span>
-					</Link>
-				</SidebarMenuButton>
-			</SidebarMenuItem>
-		</SidebarMenu>
+		</SidebarGroup>
 	)
 }


### PR DESCRIPTION
## Summary
Restructures the app sidebar to improve layout organization by moving the user navigation menu from the footer to the main content area, and introducing a new footer component for theme toggle and open-source link.

## Changes
- **NavUser component**: Simplified to remove avatar display and profile data dependency. Now wraps menu items in `SidebarGroup` for both authenticated and unauthenticated states. Removed unused imports (`Avatar`, `useProfile`, `avatarUrlify`).
- **New NavFooterActions component**: Created footer component featuring theme toggle button and GitHub/open-source link with responsive hiding on collapsed sidebar.
- **AppSidebar layout**: Reorganized sidebar structure:
  - Moved `NavUser` from `SidebarFooter` to `SidebarContent` (after `NavMain`)
  - Added `SidebarSeparator` between main nav and user nav
  - Replaced footer content with new `NavFooterActions` component
  - Added `SidebarSeparator` import

## Implementation Details
- User navigation now uses `SidebarGroup` wrapper for consistent styling with other sidebar sections
- Footer actions use `group-data-[collapsible=icon]:hidden` to hide text labels when sidebar is in icon-only mode
- Removed profile avatar display, simplifying the authenticated user menu to a single "Profile & settings" link
- Theme toggle uses existing `useTheme` hook from theme provider

https://claude.ai/code/session_01PCmGArZR3EAU2d24tgrkTF