### PR TITLE
Fix icon import: MessagesSquare → MessageSquare

### DIFF
--- a/src/components/requests/request-buttons-row.tsx
+++ b/src/components/requests/request-buttons-row.tsx
@@ -1,4 +1,4 @@
-import { MessagesSquare, Repeat, Send, WalletCards } from 'lucide-react'
+import { MessageSquare, Repeat, Send, WalletCards } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { SendRequestToFriendDialog } from '@/components/card-pieces/send-request-to-friend'
@@ -46,7 +46,7 @@ export function RequestButtonsRow({ request }: { request: PhraseRequestType }) {
 					className="flex flex-row items-center gap-2"
 					data-testid="comments-count"
 				>
-					<MessagesSquare className="size-4" aria-hidden="true" />
+					<MessageSquare className="size-4" aria-hidden="true" />
 					<span>
 						{countComments}
 						<span className="@max-lg:sr-only">


### PR DESCRIPTION
## Summary
Corrects an incorrect icon import from lucide-react in the request buttons row component.

## Changes
- Updated import statement to use `MessageSquare` instead of the non-existent `MessagesSquare` icon from lucide-react
- Updated the icon component usage in the comments count button to match the corrected import

## Details
The `MessagesSquare` icon doesn't exist in lucide-react; the correct icon name is `MessageSquare`. This fix ensures the comments button displays the intended icon without import errors.

https://claude.ai/code/session_01SEFdjuGjB81e1kWbHptCLq