### PR TITLE
Gate dev UI on local network hostname, not just build mode

### DIFF
--- a/src/components/dev-identity-switcher.tsx
+++ b/src/components/dev-identity-switcher.tsx
@@ -10,6 +10,7 @@ import {
 	PopoverContent,
 } from '@/components/ui/popover'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
+import { isDevEnvironment } from '@/lib/dev-mode'
 import { cn } from '@/lib/utils'
 
 type Actor = { role: string; email: string; username?: string }
@@ -69,7 +70,10 @@ const TEAMS: Array<Team> = [
 ]
 
 export function DevIdentitySwitcher() {
-	if (!import.meta.env.DEV) return null
+	// Gate on a real local-dev session, not just the build-time DEV flag: a
+	// production deploy built/served in the wrong Vite mode would otherwise
+	// expose this one-click login switcher and its hardcoded test password.
+	if (!isDevEnvironment()) return null
 	// Hide under Playwright/scenetest so the corner button can't intercept
 	// clicks or overlap toasts. navigator.webdriver is set by Playwright by
 	// default; manual dev sessions get the widget as expected.

--- a/src/components/flagged.tsx
+++ b/src/components/flagged.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { flags } from '@/lib/flags'
+import { isDevEnvironment } from '@/lib/dev-mode'
 import { cn } from '@/lib/utils'
 
 export default function Flagged({
@@ -16,11 +17,12 @@ export default function Flagged({
 		if (flags[name].disabled === true) return null
 		// the enabled flag is the primary control
 		if (flags[name].enabled === true) return children
-	} else if (import.meta.env.DEV) return children
-	// show content in dev/preview mode, with a little yellow border
-	return import.meta.env.PROD ?
-			null
-		:	<div className={cn('border border-dashed border-yellow-500', className)}>
-				{children}
-			</div>
+	} else if (isDevEnvironment()) return children
+	// show content in a local dev session only, with a little yellow border;
+	// never on a deployed domain, even if the build mode is wrong
+	return isDevEnvironment() ? (
+		<div className={cn('border border-dashed border-yellow-500', className)}>
+			{children}
+		</div>
+	) : null
 }

--- a/src/lib/dev-mode.ts
+++ b/src/lib/dev-mode.ts
@@ -1,0 +1,25 @@
+/**
+ * True only during a genuine local development session.
+ *
+ * Dev-only UI must NOT be gated on `import.meta.env.DEV` alone: if a
+ * production deploy is ever built or served in the wrong Vite mode that flag
+ * flips to `true` and leaks dev tooling (the identity switcher, the
+ * work-in-progress buttons behind `<Flagged>`) onto the live site. Requiring
+ * a local-network hostname as well means dev UI can never render on a
+ * deployed domain, even when the build mode is wrong.
+ */
+export function isDevEnvironment(): boolean {
+	if (!import.meta.env.DEV) return false
+	if (typeof window === 'undefined') return false
+	const { hostname } = window.location
+	return (
+		hostname === 'localhost' ||
+		hostname === '127.0.0.1' ||
+		hostname === '::1' ||
+		hostname === '[::1]' ||
+		hostname.endsWith('.local') ||
+		hostname.startsWith('10.') ||
+		hostname.startsWith('192.168.') ||
+		/^172\.(1[6-9]|2\d|3[01])\./.test(hostname)
+	)
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,6 @@
 {
+	"framework": "vite",
+	"buildCommand": "pnpm build",
+	"outputDirectory": "dist",
 	"rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
 }


### PR DESCRIPTION
## Summary

Introduces a new `isDevEnvironment()` function that safely gates development-only UI by checking both the Vite build mode AND the local network hostname. This prevents dev tooling (identity switcher, flagged work-in-progress components) from leaking onto production deployments if the build is ever served in the wrong Vite mode.

## Changes

- **New module** `src/lib/dev-mode.ts`: Exports `isDevEnvironment()` which returns `true` only when both `import.meta.env.DEV` is true AND the hostname is a local/private network address (localhost, 127.0.0.1, ::1, .local, 10.x, 192.168.x, or 172.16-31.x ranges)

- **Updated** `src/components/flagged.tsx`: Replaces `import.meta.env.DEV` and `import.meta.env.PROD` checks with `isDevEnvironment()` calls. Refactors the conditional logic for clarity and ensures flagged content never renders on deployed domains

- **Updated** `src/components/dev-identity-switcher.tsx`: Replaces `import.meta.env.DEV` check with `isDevEnvironment()` to prevent the hardcoded test password switcher from being exposed if a production build is served in dev mode

- **Updated** `vercel.json`: Adds explicit Vite framework configuration and build/output directory settings for Vercel deployments

## Implementation Details

The hostname check covers:
- Loopback addresses: `localhost`, `127.0.0.1`, `::1`, `[::1]`
- mDNS: `.local` suffix
- Private IP ranges: `10.0.0.0/8`, `192.168.0.0/16`, `172.16.0.0/12`

This ensures dev UI is gated by runtime environment, not just build-time configuration, eliminating a security risk where a misconfigured production deploy could expose internal tooling.

https://claude.ai/code/session_018R2qkDyG4ruM5TAJ9VpFwL