### PR TITLE
Add CI scan to catch dev-only code leaking into prod builds

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -368,6 +368,36 @@ jobs:
               });
             }
 
+  prod-bundle-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Set up dummy env for build
+        run: |
+          echo "VITE_SUPABASE_URL=http://127.0.0.1:54321" >> $GITHUB_ENV
+          echo "VITE_SUPABASE_ANON_KEY=dummy" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build production bundle
+        run: pnpm build
+
+      - name: Scan bundle for leaked dev-only code
+        run: ./scripts/check-prod-bundle.sh dist
+
   unit:
     runs-on: ubuntu-latest
     timeout-minutes: 3

--- a/scripts/check-prod-bundle.sh
+++ b/scripts/check-prod-bundle.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Fails the build if dev-only code leaked into a production bundle.
+#
+# A correct `vite build` runs in production mode, so `import.meta.env.DEV`
+# is statically `false` and the dev-identity-switcher chunk (and its
+# hardcoded test credentials) is tree-shaken out entirely. If any of the
+# fingerprints below show up in dist/, the build ran in the wrong Vite
+# mode and dev tooling is about to ship to real users.
+#
+# Usage: ./scripts/check-prod-bundle.sh [dist-dir]
+
+set -euo pipefail
+
+DIST_DIR="${1:-dist}"
+
+if [ ! -d "$DIST_DIR" ]; then
+	echo "error: build output directory '$DIST_DIR' not found — run 'pnpm build' first" >&2
+	exit 1
+fi
+
+# Literal strings that exist only inside dev-only modules. String literals
+# survive minification, so a clean production build contains none of them.
+patterns=(
+	'dev-identity-switcher'
+	'sunloapp+'
+)
+
+failed=0
+for pattern in "${patterns[@]}"; do
+	matches=$(grep -rlF -- "$pattern" "$DIST_DIR" || true)
+	if [ -n "$matches" ]; then
+		failed=1
+		echo "::error::dev-only fingerprint '$pattern' found in production build:" >&2
+		echo "$matches" | sed 's/^/  /' >&2
+	fi
+done
+
+if [ "$failed" -ne 0 ]; then
+	echo >&2
+	echo "Dev-only code leaked into the production bundle. This usually means the" >&2
+	echo "build ran in the wrong Vite mode (import.meta.env.DEV === true)." >&2
+	exit 1
+fi
+
+echo "OK: no dev-only fingerprints found in $DIST_DIR"


### PR DESCRIPTION
A correct `vite build` tree-shakes the dev-identity-switcher chunk out entirely. The new prod-bundle-scan job builds with `pnpm build` and greps dist/ for fingerprints that only exist in dev-only modules (the dev-identity-switcher testid, the sunloapp+ test emails), failing the build if any survive — the signature of a wrong Vite build mode.

https://claude.ai/code/session_018R2qkDyG4ruM5TAJ9VpFwL