### PR TITLE
Remove placeholder Delete/Edit buttons from the phrase card

### DIFF
--- a/src/components/cards/big-phrase-card.tsx
+++ b/src/components/cards/big-phrase-card.tsx
@@ -6,9 +6,7 @@ import {
 	MessagesSquare,
 	ListMusic,
 	Users,
-	Edit,
 	Settings,
-	Trash2,
 } from 'lucide-react'
 
 import type { uuid } from '@/types/main'
@@ -46,7 +44,6 @@ import {
 } from '@/features/phrases'
 import { PhraseTinyCard } from '@/components/cards/phrase-tiny-card'
 import { PlaylistEmbed } from '@/components/playlists/playlist-embed'
-import Flagged from '@/components/flagged'
 import { ago } from '@/lib/dayjs'
 import { useMyCard } from '@/features/deck/hooks'
 import { useAuth } from '@/lib/use-auth'
@@ -94,21 +91,7 @@ export function BigPhraseCard({ pid }: { pid: uuid }) {
 									</Badge>
 								)}
 							</div>
-							<div className="flex flex-row items-center gap-2">
-								<AdminGearLink phraseId={pid} lang={phrase.lang} />
-								<Flagged>
-									<Button
-										size="icon"
-										variant="ghost"
-										aria-label="Delete phrase"
-									>
-										<Trash2 />
-									</Button>
-									<Button size="icon" variant="ghost" aria-label="Edit phrase">
-										<Edit />
-									</Button>
-								</Flagged>
-							</div>
+							<AdminGearLink phraseId={pid} lang={phrase.lang} />
 						</div>
 						<CardTitle className="space-x-1 text-2xl">
 							<span


### PR DESCRIPTION
## Summary

- The `<Flagged>` Delete and Edit buttons on `BigPhraseCard` were never wired up — no `onClick` handlers, dev-only mockups for a feature that didn't exist yet.
- That feature now exists for real on the admin phrase page (`/admin/$lang/phrases/$id`): editable phrase text, per-translation editing, and archive/unarchive. The card already links there via `AdminGearLink`, so the placeholders are dead UI.
- Removes the `<Flagged>` block and its now-unused imports (`Edit`, `Trash2`, `Flagged`).

Note: the `<Flagged>` wrapper here had no `name`, so there was no entry in `src/lib/flags.ts` to delete — nothing else to clean up.

## Test plan

- [x] `pnpm check` and `pnpm lint` pass (verified locally)
- [ ] Phrase page (`/learn/$lang/phrases/$id`) renders with no Delete/Edit buttons in the card header
- [ ] As an admin, the `AdminGearLink` gear still appears and routes to the admin phrase page where edit/manage works

https://claude.ai/code/session_018R2qkDyG4ruM5TAJ9VpFwL

---
_Generated by [Claude Code](https://claude.ai/code/session_018R2qkDyG4ruM5TAJ9VpFwL)_