### PR TITLE
Update callout icon circle default variant styling

### DIFF
--- a/src/components/ui/callout.tsx
+++ b/src/components/ui/callout.tsx
@@ -16,7 +16,7 @@ const variants = {
 }
 
 const iconCircleVariants = {
-	default: 'bg-0-mlo-primary',
+	default: 'bg-lc-[95] bg-c-[6]',
 	problem: 'border border-lc-[82] border-c-[9] bg-none-lo',
 	ghost: 'bg-1-lo-neutral',
 }

--- a/src/components/ui/callout.tsx
+++ b/src/components/ui/callout.tsx
@@ -10,13 +10,13 @@ type CalloutProps = PropsWithChildren & {
 }
 
 const variants = {
-	default: 'bg-1-mlo-primary border-3-mlo-primary',
+	default: 'bg-0-mlo-primary border-1-mlo-primary',
 	problem: 'hue-danger bg-lc-[97] bg-c-[3] border-lc-[88] border-c-[6]',
 	ghost: 'border text-muted-foreground bg-muted',
 }
 
 const iconCircleVariants = {
-	default: 'bg-lc-[97] bg-c-[2]',
+	default: 'bg-1-mlo-primary',
 	problem: 'border border-lc-[82] border-c-[9] bg-none-lo',
 	ghost: 'bg-1-lo-neutral',
 }

--- a/src/components/ui/callout.tsx
+++ b/src/components/ui/callout.tsx
@@ -10,13 +10,13 @@ type CalloutProps = PropsWithChildren & {
 }
 
 const variants = {
-	default: 'bg-0-mlo-primary border-1-mlo-primary',
+	default: 'bg-1-mlo-primary border-3-mlo-primary',
 	problem: 'hue-danger bg-lc-[97] bg-c-[3] border-lc-[88] border-c-[6]',
 	ghost: 'border text-muted-foreground bg-muted',
 }
 
 const iconCircleVariants = {
-	default: 'bg-1-mlo-primary',
+	default: 'bg-0-mlo-primary',
 	problem: 'border border-lc-[82] border-c-[9] bg-none-lo',
 	ghost: 'bg-1-lo-neutral',
 }


### PR DESCRIPTION
## Summary
Updates the default variant styling for the callout component's icon circle to use a new design token class.

## Changes
- **src/components/ui/callout.tsx**: Changed the `iconCircleVariants.default` class from `'bg-lc-[97] bg-c-[2]'` to `'bg-0-mlo-primary'`

## Details
This change simplifies the icon circle styling by replacing the previous two-part background class combination with a single, more semantic design token class (`bg-0-mlo-primary`). This aligns with the design system's token naming conventions and likely improves maintainability of the styling.

https://claude.ai/code/session_01Ga1KWhS1feF5wefM2k1VF3