### PR TITLE
Surface password-reset errors instead of a doomed form

### DIFF
--- a/scenetest/TEST_IDS.md
+++ b/scenetest/TEST_IDS.md
@@ -51,6 +51,8 @@ natural wrapper element to label.
 | `login-form`                    | data-testid | Login page             | The login form container                                    |
 | `login-signup-link`             | data-testid | Login page             | "Create account" link to /signup                            |
 | `login-forgot-password-link`    | data-testid | Login page             | "Forgot password?" link to /forgot-password                 |
+| `reset-link-invalid`            | data-testid | Set-new-password page  | Card shown when the recovery link is invalid or expired     |
+| `request-new-link`              | data-testid | Set-new-password page  | Link to /forgot-password from the invalid-link card         |
 | `email-input`                   | data-testid | Form fields            | Email input                                                 |
 | `password-input`                | data-testid | Form fields            | Password input                                              |
 | `submit-button`                 | data-testid | Form submit            | Generic submit button (scope by parent form when ambiguous) |

--- a/src/routes/_auth/set-new-password.tsx
+++ b/src/routes/_auth/set-new-password.tsx
@@ -1,14 +1,85 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { Card, CardHeader, CardTitle } from '@/components/ui/card'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { buttonVariants } from '@/components/ui/button'
+import Callout from '@/components/ui/callout'
 import { PasswordResetForm } from '@/components/password-reset-form'
+import { useAuth } from '@/lib/use-auth'
 
 export const Route = createFileRoute('/_auth/set-new-password')({
 	component: SetNewPasswordPage,
 })
 
+// Supabase appends an error to the URL hash when a recovery link is bad —
+// most often an expired or already-consumed one-time token. supabase-js
+// strips the hash as soon as it processes the link, so capture it once at
+// module load, before that happens.
+const recoveryLinkError = readRecoveryLinkError()
+
+function readRecoveryLinkError(): string | null {
+	const hash = new URLSearchParams(window.location.hash.replace(/^#/, ''))
+	if (!hash.get('error') && !hash.get('error_code')) return null
+	const description = hash.get('error_description')
+	return description
+		? description.replace(/\+/g, ' ')
+		: 'This password reset link is invalid or has expired.'
+}
+
+const cardClass =
+	'mx-auto mt-[10cqh] w-full max-w-md [padding:clamp(0.5rem,2cqw,2rem)]'
+
 function SetNewPasswordPage() {
+	const { isReady, isAuth } = useAuth()
+
+	// A valid recovery link signs the user in (via the URL hash) before this
+	// page settles. Once auth has resolved with no session, the link never
+	// authenticated us — say why, instead of showing a form that can only
+	// fail with a cryptic "Auth session missing" error.
+	if (recoveryLinkError || (isReady && !isAuth)) {
+		return (
+			<Card className={cardClass} data-testid="reset-link-invalid">
+				<CardHeader>
+					<CardTitle>This reset link didn't work</CardTitle>
+				</CardHeader>
+				<CardContent className="space-y-4">
+					<Callout variant="problem" alert>
+						<p>
+							{recoveryLinkError ??
+								'This password reset link is invalid or has expired.'}
+						</p>
+						<p>Reset links can only be used once, and expire after an hour.</p>
+					</Callout>
+					<div className="flex flex-row justify-between">
+						<Link
+							to="/forgot-password"
+							data-testid="request-new-link"
+							className={buttonVariants({ variant: 'default' })}
+						>
+							Request a new link
+						</Link>
+						<Link
+							to="/login"
+							className={buttonVariants({ variant: 'neutral' })}
+						>
+							Back to login
+						</Link>
+					</div>
+				</CardContent>
+			</Card>
+		)
+	}
+
+	if (!isReady) {
+		return (
+			<Card className={cardClass}>
+				<CardHeader>
+					<CardTitle>Verifying your reset link…</CardTitle>
+				</CardHeader>
+			</Card>
+		)
+	}
+
 	return (
-		<Card className="mx-auto mt-[10cqh] w-full max-w-md [padding:clamp(0.5rem,2cqw,2rem)]">
+		<Card className={cardClass}>
 			<CardHeader>
 				<CardTitle>Set your new password</CardTitle>
 			</CardHeader>


### PR DESCRIPTION
## Problem

`set-new-password.tsx` rendered the password form unconditionally. When a
recovery link didn't establish a session — or carried an error in the URL
hash (an expired or already-used link) — the form showed anyway, and
submitting it failed with a cryptic `Auth session missing`.

## Change

- **`set-new-password.tsx`** — read the error Supabase puts in the URL hash
  and confirm a recovery session exists before showing the form. Otherwise
  show an actionable "request a new link" card instead of a form that can
  only fail.
- **`scenetest/TEST_IDS.md`** — register the reset-page test IDs.

## Test coverage

- **`password-reset.spec.md`** — markdown scenes: login → forgot-password
  navigation; `/set-new-password` with no recovery session shows the
  invalid-link card; an expired-link hash surfaces the error instead of a
  doomed form.
- **`password-reset.spec.ts`** — TypeScript scene for the happy path. Mints
  a recovery link via the admin API, follows it, sets a new password. Runs
  on a throwaway user (created/deleted per run) so no shared actor is
  disturbed. `generateLink` returns the link without sending mail, so it
  runs in CI without the Inbucket mail catcher.

Note: the actual `resetPasswordForEmail` → email-delivery step is *not*
covered in CI — that would require enabling Inbucket in the `scenetest`
job. The scenes cover everything else end-to-end.

## Test plan

- [ ] Click a valid reset link; confirm the form shows and a new password works
- [ ] Click an expired/used reset link; confirm the "request a new link"
      card appears instead of a silently-failing form

https://claude.ai/code/session_01KUKsez5tPBXMTpY4swoQPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUKsez5tPBXMTpY4swoQPF)_