### PR TITLE
Use tailwind-oklch from GitHub main branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"react-markdown": "^10.1.0",
 		"recharts": "^3.7.0",
 		"sonner": "^1.7.0",
-		"tailwind-oklch": "^0.5.0",
+		"tailwind-oklch": "github:mhsnook/tailwind-oklch#main",
 		"tailwindcss-animate": "^1.0.7",
 		"vaul": "^1.1.2",
 		"zod": "^4.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^1.7.0
         version: 1.7.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwind-oklch:
-        specifier: ^0.5.0
-        version: 0.5.0(tailwindcss@4.3.0)
+        specifier: github:mhsnook/tailwind-oklch#main
+        version: https://codeload.github.com/mhsnook/tailwind-oklch/tar.gz/e1c55ea1e5cea899717f4341d9b30f97f7852f04(tailwindcss@4.3.0)
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.3.0)
@@ -3108,8 +3108,9 @@ packages:
   tailwind-merge@2.6.1:
     resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
 
-  tailwind-oklch@0.5.0:
-    resolution: {integrity: sha512-igRFgzmlT7+NbSxBEUenccu8uMDPqOIiXsXvkVGlaVP7KkWg8FH9RWfHdIeJ69pdKvI6mhoQspNnj1fK9k9YQg==}
+  tailwind-oklch@https://codeload.github.com/mhsnook/tailwind-oklch/tar.gz/e1c55ea1e5cea899717f4341d9b30f97f7852f04:
+    resolution: {tarball: https://codeload.github.com/mhsnook/tailwind-oklch/tar.gz/e1c55ea1e5cea899717f4341d9b30f97f7852f04}
+    version: 0.6.0
     peerDependencies:
       tailwindcss: '>=4.0.0'
 
@@ -6239,7 +6240,7 @@ snapshots:
 
   tailwind-merge@2.6.1: {}
 
-  tailwind-oklch@0.5.0(tailwindcss@4.3.0):
+  tailwind-oklch@https://codeload.github.com/mhsnook/tailwind-oklch/tar.gz/e1c55ea1e5cea899717f4341d9b30f97f7852f04(tailwindcss@4.3.0):
     dependencies:
       tailwindcss: 4.3.0
 


### PR DESCRIPTION
## Summary
Updates the `tailwind-oklch` dependency to use the main branch from the GitHub repository instead of the published npm package version.

## Changes
- Changed `tailwind-oklch` dependency from `^0.5.0` (npm) to `github:mhsnook/tailwind-oklch#main` (GitHub)

## Details
This change allows the project to use the latest development version of `tailwind-oklch` directly from the main branch of the GitHub repository. This is useful for:
- Testing unreleased features or fixes
- Using the most up-to-date version before official releases
- Contributing feedback on in-development changes

The lockfile has been updated accordingly with the new dependency resolution.

https://claude.ai/code/session_01MK5PQPy3HFwzzjqRPcDQ4N