### PR TITLE
Refactor chat message type indicators into timestamp line

### DIFF
--- a/src/routes/_user/friends/chats.$friendUid.tsx
+++ b/src/routes/_user/friends/chats.$friendUid.tsx
@@ -153,7 +153,16 @@ function ChatPage() {
 										)}
 										<div>
 											<p className="text-muted-foreground mx-0 mb-1 text-xs">
-												{ago(msg.created_at)}
+												{ago(msg.created_at)} &middot;{' '}
+												{msg.message_type === 'recommendation'
+													? 'Sent a phrase recommendation.'
+													: msg.message_type === 'request'
+														? 'Requested a phrase.'
+														: msg.message_type === 'playlist'
+															? 'Shared a playlist.'
+															: `${isMine ? 'You' : relUsername} added this to ${
+																	isMine ? 'your' : 'their'
+																} deck.`}
 											</p>
 											{msg.phrase_id && msg.lang && (
 												<CardPreview pid={msg.phrase_id} isMine={isMine} />
@@ -164,34 +173,6 @@ function ChatPage() {
 											{msg.playlist_id && msg.lang && (
 												<PlaylistPreview id={msg.playlist_id} />
 											)}
-											<div
-												className={cn(
-													'relative z-0 max-w-xs rounded-b-2xl p-3 lg:max-w-md',
-													isMine
-														? 'bg-primary text-primary-foreground/70 ms-6 place-self-end'
-														: 'bg-muted me-6 place-self-start'
-												)}
-											>
-												{msg.message_type === 'recommendation' && (
-													<p className="text-sm italic">
-														Sent a phrase recommendation.
-													</p>
-												)}
-												{msg.message_type === 'request' && (
-													<p className="text-sm italic">Requested a phrase.</p>
-												)}
-												{msg.message_type === 'accepted' && (
-													<div className="text-sm italic">
-														<p>
-															{isMine ? 'You' : relUsername} added this to{' '}
-															{isMine ? 'your' : 'their'} deck.
-														</p>
-													</div>
-												)}
-												{msg.message_type === 'playlist' && (
-													<p className="text-sm italic">Shared a playlist.</p>
-												)}
-											</div>
 										</div>
 									</div>
 								)

--- a/src/routes/_user/friends/chats.$friendUid.tsx
+++ b/src/routes/_user/friends/chats.$friendUid.tsx
@@ -132,6 +132,16 @@ function ChatPage() {
 							messagesQuery.data?.map((msg) => {
 								if (typeof msg === 'undefined') return null
 								const isMine = msg.sender_uid === userId
+								const messageLabel =
+									msg.message_type === 'recommendation'
+										? 'Sent a phrase recommendation.'
+										: msg.message_type === 'request'
+											? 'Requested a phrase.'
+											: msg.message_type === 'playlist'
+												? 'Shared a playlist.'
+												: `${isMine ? 'You' : relUsername} added this to ${
+														isMine ? 'your' : 'their'
+													} deck.`
 								return (
 									<div
 										key={msg.id}
@@ -152,17 +162,21 @@ function ChatPage() {
 											</Avatar>
 										)}
 										<div>
-											<p className="text-muted-foreground mx-0 mb-1 text-xs">
-												{ago(msg.created_at)} &middot;{' '}
-												{msg.message_type === 'recommendation'
-													? 'Sent a phrase recommendation.'
-													: msg.message_type === 'request'
-														? 'Requested a phrase.'
-														: msg.message_type === 'playlist'
-															? 'Shared a playlist.'
-															: `${isMine ? 'You' : relUsername} added this to ${
-																	isMine ? 'your' : 'their'
-																} deck.`}
+											<p
+												className={cn(
+													'text-muted-foreground mx-0 mb-1 text-xs',
+													isMine && 'text-end'
+												)}
+											>
+												{isMine ? (
+													<>
+														{messageLabel} &middot; {ago(msg.created_at)}
+													</>
+												) : (
+													<>
+														{ago(msg.created_at)} &middot; {messageLabel}
+													</>
+												)}
 											</p>
 											{msg.phrase_id && msg.lang && (
 												<CardPreview pid={msg.phrase_id} isMine={isMine} />

--- a/src/routes/_user/friends/chats.$friendUid.tsx
+++ b/src/routes/_user/friends/chats.$friendUid.tsx
@@ -153,31 +153,33 @@ function ChatPage() {
 												: 'align-start me-auto justify-start pe-[10%]'
 										)}
 									>
-										{!isMine && (
-											<Avatar className="my-5 h-8 w-8">
-												<AvatarImage src={relAvatarUrl} alt={relUsername} />
-												<AvatarFallback>
-													{relUsername.charAt(0).toUpperCase()}
-												</AvatarFallback>
-											</Avatar>
-										)}
 										<div>
-											<p
-												className={cn(
-													'text-muted-foreground mx-0 mb-1 text-xs',
-													isMine && 'text-end'
+											<div className="mb-1 flex items-center gap-2">
+												{!isMine && (
+													<Avatar className="h-8 w-8 shrink-0">
+														<AvatarImage src={relAvatarUrl} alt={relUsername} />
+														<AvatarFallback>
+															{relUsername.charAt(0).toUpperCase()}
+														</AvatarFallback>
+													</Avatar>
 												)}
-											>
-												{isMine ? (
-													<>
-														{messageLabel} &middot; {ago(msg.created_at)}
-													</>
-												) : (
-													<>
-														{ago(msg.created_at)} &middot; {messageLabel}
-													</>
-												)}
-											</p>
+												<p
+													className={cn(
+														'text-muted-foreground grow text-xs',
+														isMine && 'text-end'
+													)}
+												>
+													{isMine ? (
+														<>
+															{messageLabel} &middot; {ago(msg.created_at)}
+														</>
+													) : (
+														<>
+															{ago(msg.created_at)} &middot; {messageLabel}
+														</>
+													)}
+												</p>
+											</div>
 											{msg.phrase_id && msg.lang && (
 												<CardPreview pid={msg.phrase_id} isMine={isMine} />
 											)}

--- a/src/routes/_user/friends/chats.$friendUid.tsx
+++ b/src/routes/_user/friends/chats.$friendUid.tsx
@@ -134,14 +134,14 @@ function ChatPage() {
 								const isMine = msg.sender_uid === userId
 								const messageLabel =
 									msg.message_type === 'recommendation'
-										? 'Sent a phrase recommendation.'
+										? 'Sent a phrase recommendation'
 										: msg.message_type === 'request'
-											? 'Requested a phrase.'
+											? 'Requested a phrase'
 											: msg.message_type === 'playlist'
-												? 'Shared a playlist.'
+												? 'Shared a playlist'
 												: `${isMine ? 'You' : relUsername} added this to ${
 														isMine ? 'your' : 'their'
-													} deck.`
+													} deck`
 								return (
 									<div
 										key={msg.id}


### PR DESCRIPTION
## Summary
Consolidates message type indicators (recommendation, request, playlist, deck addition) from a separate styled message bubble into the timestamp line, reducing visual clutter in the chat interface.

## Changes
- Moved message type text from a dedicated styled `<div>` bubble into the existing timestamp paragraph
- Replaced conditional rendering of four separate message type paragraphs with a single ternary expression
- Removed the styled container div that previously displayed message type information with background color and padding
- Message type indicators now appear inline with the timestamp, separated by a middle dot (`&middot;`)

## Implementation Details
- The message type logic remains functionally identical—it still handles `'recommendation'`, `'request'`, `'playlist'`, and `'accepted'` (deck addition) message types
- The conditional for `'accepted'` type now also handles the generic deck addition case
- This change simplifies the DOM structure and reduces the number of rendered elements per message while maintaining the same information display

https://claude.ai/code/session_01RxeS2pYaoL7J83HxfxEGVq