### PR TITLE
Restore generated colours for avatar placeholders

### DIFF
--- a/scenetest/scenes/feed.spec.md
+++ b/scenetest/scenes/feed.spec.md
@@ -51,7 +51,7 @@ learner:
 - click friend-chat-link [friend.key]
 - up
 - see chat-messages-container
-- seeText Sent a phrase recommendation.
+- seeText Sent a phrase recommendation
 
 # opening a chat marks messages as read
 

--- a/src/components/card-pieces/user-permalink.tsx
+++ b/src/components/card-pieces/user-permalink.tsx
@@ -58,7 +58,10 @@ export function UidPermalink({
 			>
 				<Avatar className="bg-foreground text-background rounded-2xl">
 					<AvatarImage src={avatarUrl} alt={`${data.username}'s avatar`} />
-					<AvatarFallback className="mx-auto place-self-center font-bold">
+					<AvatarFallback
+						seed={uid}
+						className="mx-auto place-self-center font-bold"
+					>
 						{data.username?.slice(0, 2)}
 					</AvatarFallback>
 				</Avatar>
@@ -133,7 +136,7 @@ export function UidPermalinkInline({
 			>
 				<Avatar className="bg-foreground text-background h-6 w-6 rounded-lg">
 					<AvatarImage src={avatarUrl} alt={`${data.username}'s avatar`} />
-					<AvatarFallback className="text-[10px] font-bold">
+					<AvatarFallback seed={uid} className="text-[10px] font-bold">
 						{data.username?.slice(0, 2)}
 					</AvatarFallback>
 				</Avatar>

--- a/src/components/navs/nav-user.tsx
+++ b/src/components/navs/nav-user.tsx
@@ -71,7 +71,10 @@ export function NavUser() {
 						<Link to="/profile" onClick={setClosedMobile}>
 							<Avatar className="size-6">
 								<AvatarImage src={avatarUrl} alt={profile?.username} />
-								<AvatarFallback className="rounded text-[10px]">
+								<AvatarFallback
+									seed={profile?.uid}
+									className="rounded text-[10px]"
+								>
 									Me
 								</AvatarFallback>
 							</Avatar>

--- a/src/components/select-multiple-friends.tsx
+++ b/src/components/select-multiple-friends.tsx
@@ -1,10 +1,11 @@
-import type { Dispatch, SetStateAction } from 'react'
+import type { CSSProperties, Dispatch, SetStateAction } from 'react'
 import { useRelationFriends } from '@/features/social/hooks'
 import { Loader } from '@/components/ui/loader'
 import { uuid } from '@/types/main'
 import { Checkbox } from '@/components/ui/checkbox'
 import { User } from 'lucide-react'
 import { avatarUrlify } from '@/lib/hooks'
+import { getAvatarHue } from '@/lib/lang-theme'
 
 const EMPTY_UIDS: uuid[] = []
 
@@ -37,17 +38,22 @@ export function SelectMultipleFriends({
 						className={`${uids.includes(f.uid) ? 'bg-1-mlo-primary outline-primary-foresoft/30 outline' : ''} flex items-center justify-between gap-2 rounded-2xl px-3 py-2 transition-all`}
 					>
 						<div className="flex flex-row items-center gap-2">
-							{f.profile.avatar_path ?
+							{f.profile.avatar_path ? (
 								<img
 									src={avatarUrlify(f.profile.avatar_path)}
 									alt={`${f.profile.username}'s avatar`}
 									className="rounded-squircle size-8 rounded-full object-cover"
 								/>
-							:	<User
-									style={{ background: `#${f.profile.uid.slice(-6)}44` }}
-									className="rounded-squircle size-8 rounded-full p-1"
+							) : (
+								<User
+									style={
+										{
+											'--hue-primary': getAvatarHue(f.profile.uid),
+										} as CSSProperties
+									}
+									className="bg-5-mhi-primary text-primary-foreground rounded-squircle size-8 rounded-full p-1"
 								/>
-							}
+							)}
 							<span>{f.profile.username}</span>
 						</div>
 						<Checkbox

--- a/src/components/ui/avatar-icon.tsx
+++ b/src/components/ui/avatar-icon.tsx
@@ -1,8 +1,9 @@
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { Link } from '@tanstack/react-router'
 import { User } from 'lucide-react'
 import { PublicProfileType } from '@/features/profile/schemas'
 import { avatarUrlify } from '@/lib/hooks'
+import { getAvatarHue } from '@/lib/lang-theme'
 
 type AvatarIconRowProps = PublicProfileType & {
 	children?: ReactNode
@@ -22,17 +23,18 @@ export function AvatarIconRow({
 				params={{ uid }}
 				className="hover:bg-1-mlo-primary hover:border-2-mlo-primary flex grow flex-row items-center justify-start gap-4 rounded-2xl border border-transparent p-2"
 			>
-				{avatarUrl ?
+				{avatarUrl ? (
 					<img
 						src={avatarUrl}
 						alt={`${username}'s avatar`}
 						className="rounded-squircle size-8 rounded-full object-cover"
 					/>
-				:	<User
-						style={{ background: `#${uid.slice(-6)}44` }}
-						className="bg-foreground/20 rounded-squircle size-8 rounded-full p-1"
+				) : (
+					<User
+						style={{ '--hue-primary': getAvatarHue(uid) } as CSSProperties}
+						className="bg-5-mhi-primary text-primary-foreground rounded-squircle size-8 rounded-full p-1"
 					/>
-				}
+				)}
 				<span>{username}</span>
 			</Link>
 			{children}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,6 +1,8 @@
+import type { CSSProperties } from 'react'
 import { Avatar as AvatarPrimitive } from '@base-ui/react/avatar'
 
 import { cn } from '@/lib/utils'
+import { getAvatarHue } from '@/lib/lang-theme'
 
 const Avatar = ({ className, ...props }: AvatarPrimitive.Root.Props) => (
 	<AvatarPrimitive.Root
@@ -23,14 +25,25 @@ const AvatarImage = ({ className, ...props }: AvatarPrimitive.Image.Props) => (
 
 const AvatarFallback = ({
 	className,
+	seed,
+	style,
 	...props
-}: AvatarPrimitive.Fallback.Props) => (
+}: AvatarPrimitive.Fallback.Props & { seed?: string }) => (
 	<AvatarPrimitive.Fallback
 		data-slot="avatar-fallback"
 		className={cn(
-			'bg-muted flex h-full w-full items-center justify-center',
+			'flex h-full w-full items-center justify-center',
+			seed ? 'bg-5-mhi-primary text-primary-foreground' : 'bg-muted',
 			className
 		)}
+		style={
+			seed
+				? {
+						...style,
+						...({ '--hue-primary': getAvatarHue(seed) } as CSSProperties),
+					}
+				: style
+		}
 		{...props}
 	/>
 )

--- a/src/lib/lang-theme.ts
+++ b/src/lib/lang-theme.ts
@@ -11,6 +11,28 @@ export const LANG_HUES: ReadonlyArray<number> = [
 	0, 50, 80, 110, 150, 180, 210, 240, 270, 330,
 ] as const
 
+// Avatar placeholder hues: the 10° grid 0–350 with three sets of stops
+// removed. First the LANG_HUES deck stops, so a missing-photo tile
+// never colour-matches a language badge. Then the three dead zones
+// LANG_HUES already hugs — the long Duolingo green dip (120–140),
+// brand purple (290–310), and near-red (10, 350, too close to the
+// danger hue). What's left is 18 saturated, well-separated hues.
+export const AVATAR_HUES: ReadonlyArray<number> = [
+	20, 30, 40, 60, 70, 90, 100, 160, 170, 190, 200, 220, 230, 250, 260, 280, 320,
+	340,
+] as const
+
+// Deterministic placeholder hue for a user, keyed off a stable seed
+// (their uid). A small string hash indexes into AVATAR_HUES.
+export function getAvatarHue(seed: string): number {
+	let hash = 0
+	for (let i = 0; i < seed.length; i++) {
+		hash = (hash * 31 + seed.charCodeAt(i)) | 0
+	}
+	const len = AVATAR_HUES.length
+	return AVATAR_HUES[((hash % len) + len) % len]
+}
+
 // Permutation walked over the popularity-ranked language list. The
 // most popular language (display_order 1) gets stop 6 (sky blue), the
 // next stop 0 (red), and so on. Adjacent ranks always land far apart

--- a/src/routes/_user/friends/-chats-sidebar.tsx
+++ b/src/routes/_user/friends/-chats-sidebar.tsx
@@ -24,18 +24,21 @@ export function ChatsSidebar() {
 				data-testid="friend-chat-list"
 				className="flex flex-1 flex-col gap-2 overflow-y-auto p-2"
 			>
-				{isLoading ?
+				{isLoading ? (
 					<>
 						<ChatSkeleton />
 						<ChatSkeleton />
 						<ChatSkeleton />
 					</>
-				: !entries?.length ?
+				) : !entries?.length ? (
 					<p className="text-muted-foreground p-4 text-sm">
 						You have no friends to chat with yet.
 					</p>
-				:	entries.map((entry) => <ChatEntryItem key={entry.uid} entry={entry} />)
-				}
+				) : (
+					entries.map((entry) => (
+						<ChatEntryItem key={entry.uid} entry={entry} />
+					))
+				)}
 			</CardContent>
 		</Card>
 	)
@@ -70,51 +73,54 @@ function ChatEntryItem({ entry }: { entry: ChatEntry }) {
 					src={avatarUrlify(profile?.avatar_path)}
 					alt={profile?.username}
 				/>
-				<AvatarFallback>
+				<AvatarFallback seed={uid}>
 					{profile?.username?.charAt(0).toUpperCase()}
 				</AvatarFallback>
 			</Avatar>
 			<div className="flex-1 overflow-hidden">
 				<div className="flex items-center gap-2 font-semibold">
 					<span>{profile?.username}</span>
-					{unreadCount ?
+					{unreadCount ? (
 						<Badge data-testid="unread-badge" size="sm">
 							{unreadCount}
 						</Badge>
-					: hasPendingRequest ?
+					) : hasPendingRequest ? (
 						<div className="bg-primary h-2.5 w-2.5 rounded-full" />
-					:	null}
+					) : null}
 				</div>
-				{hasPendingRequest ?
+				{hasPendingRequest ? (
 					<p className="text-muted-foreground line-clamp-1 text-xs">
 						<UserPlus className="me-1 inline size-3" />
 						Wants to connect • {ago(mostRecentActivity)}
 					</p>
-				:	<p
+				) : (
+					<p
 						className={cn(
 							'line-clamp-2 text-xs',
-							isUnreadPreview ?
-								'text-foreground font-medium'
-							:	'text-muted-foreground'
+							isUnreadPreview
+								? 'text-foreground font-medium'
+								: 'text-muted-foreground'
 						)}
 					>
-						{previewMessage ?
+						{previewMessage ? (
 							<>
 								{ago(previewMessage.created_at)} •{' '}
-								{'isByMe' in previewMessage && previewMessage.isByMe ?
-									'you '
-								:	'they '}
-								{previewMessage.message_type === 'recommendation' ?
-									'sent a recommendation'
-								: previewMessage.message_type === 'request' ?
-									'requested a card'
-								: previewMessage.message_type === 'playlist' ?
-									'shared a playlist'
-								:	'accepted your recommendation'}
+								{'isByMe' in previewMessage && previewMessage.isByMe
+									? 'you '
+									: 'they '}
+								{previewMessage.message_type === 'recommendation'
+									? 'sent a recommendation'
+									: previewMessage.message_type === 'request'
+										? 'requested a card'
+										: previewMessage.message_type === 'playlist'
+											? 'shared a playlist'
+											: 'accepted your recommendation'}
 							</>
-						:	'No messages yet'}
+						) : (
+							'No messages yet'
+						)}
 					</p>
-				}
+				)}
 			</div>
 		</Link>
 	)

--- a/src/routes/_user/friends/-friends-feed.tsx
+++ b/src/routes/_user/friends/-friends-feed.tsx
@@ -115,7 +115,7 @@ function FriendGroup({ group }: { group: FriendGroupType }) {
 				>
 					<Avatar className="bg-foreground text-background mt-0.5 size-8 rounded-lg">
 						<AvatarImage src={avatarUrl} alt={`${username}'s avatar`} />
-						<AvatarFallback className="text-[10px] font-bold">
+						<AvatarFallback seed={group.uid} className="text-[10px] font-bold">
 							{username.slice(0, 2)}
 						</AvatarFallback>
 					</Avatar>

--- a/src/routes/_user/friends/chats.$friendUid.tsx
+++ b/src/routes/_user/friends/chats.$friendUid.tsx
@@ -97,7 +97,7 @@ function ChatPage() {
 				<Link to="/friends/$uid" params={{ uid: friendUid }}>
 					<Avatar>
 						<AvatarImage src={relAvatarUrl} alt={relUsername} />
-						<AvatarFallback>
+						<AvatarFallback seed={friendUid}>
 							{relUsername.charAt(0).toUpperCase()}
 						</AvatarFallback>
 					</Avatar>
@@ -158,7 +158,7 @@ function ChatPage() {
 												{!isMine && (
 													<Avatar className="h-8 w-8 shrink-0">
 														<AvatarImage src={relAvatarUrl} alt={relUsername} />
-														<AvatarFallback>
+														<AvatarFallback seed={friendUid}>
 															{relUsername.charAt(0).toUpperCase()}
 														</AvatarFallback>
 													</Avatar>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -108,7 +108,9 @@ function UserLogin() {
 						src={avatarUrlify(profile.avatar_path)}
 						alt="Your profile pic"
 					/>
-					<AvatarFallback>{profile.username?.slice(0, 2)}</AvatarFallback>
+					<AvatarFallback seed={profile.uid}>
+						{profile.username?.slice(0, 2)}
+					</AvatarFallback>
 				</Avatar>
 			) : (
 				<LogIn className="h-5 w-5 text-slate-800 dark:text-slate-200" />

--- a/src/routes/themes.index.lazy.tsx
+++ b/src/routes/themes.index.lazy.tsx
@@ -104,7 +104,7 @@ function Byline({
 		return (
 			<div className="inline-flex flex-row items-center gap-2">
 				<Avatar className="bg-foreground text-background h-6 w-6 rounded-lg">
-					<AvatarFallback className="text-[10px] font-bold">
+					<AvatarFallback seed={name} className="text-[10px] font-bold">
 						{initials}
 					</AvatarFallback>
 				</Avatar>
@@ -119,7 +119,9 @@ function Byline({
 	return (
 		<div className="flex flex-row items-center gap-3">
 			<Avatar className="bg-foreground text-background rounded-2xl">
-				<AvatarFallback className="font-bold">{initials}</AvatarFallback>
+				<AvatarFallback seed={name} className="font-bold">
+					{initials}
+				</AvatarFallback>
 			</Avatar>
 			<div className="text-sm">
 				<span className="font-medium">{name}</span>
@@ -267,7 +269,10 @@ function ShowcaseRequestThread() {
 				<CardFooter className="flex flex-col gap-4 border-t py-4">
 					<div className="flex w-full flex-row items-center gap-2">
 						<Avatar className="bg-foreground text-background h-8 w-8 shrink-0 rounded-lg">
-							<AvatarFallback className="text-[10px] font-bold">
+							<AvatarFallback
+								seed="showcase-self"
+								className="text-[10px] font-bold"
+							>
 								You
 							</AvatarFallback>
 						</Avatar>


### PR DESCRIPTION
When a user has no avatar image, the fallback now derives a
deterministic, saturated hue from their uid instead of rendering a
flat grey tile (or the muddy last-6-hex-of-uid hash the icon rows
used). Hues are drawn from AVATAR_HUES — the 10° grid minus the
deck-theme LANG_HUES and the red/green/purple dead zones — so a
placeholder never colour-matches a language badge.

https://claude.ai/code/session_016DYyJXVNStixhiobiLTxBf