### PR TITLE
Add react-to-solid-feasibility skill

### DIFF
--- a/.claude/skills/react-to-solid-feasibility/SKILL.md
+++ b/.claude/skills/react-to-solid-feasibility/SKILL.md
@@ -86,9 +86,24 @@ This is the core measurement — do not skip or estimate it away.
 build`). If the build cannot run in this environment, say so explicitly in
   the report and fall back to per-package sizes from bundlephobia, clearly
   labelled as estimates.
+- **Build a _representative_ bundle — env vars matter.** Apps routinely gate
+  code on build-time env (`import.meta.env.VITE_*`, `process.env.*`). A common
+  pattern: `if (!import.meta.env.VITE_X) throw …` guarding a client
+  constructor. Build with that var **unset** and the guard constant-folds to
+  `if (true) throw`, the constructor below it becomes dead code, and the
+  bundler tree-shakes out the _entire SDK behind it_ — silently. The measured
+  bundle is then hundreds of KB too light and the whole report is wrong.
+  Before trusting the numbers: check for a `.env` / `.env.example`, set any
+  required `VITE_*` vars to dummy-but-truthy values (the build does not
+  connect to anything), and confirm large expected dependencies actually
+  appear in the output (`grep` the dist for a known SDK symbol). If your build
+  and a clean CI build disagree on size, the build environment is the suspect
+  — not the code.
 - Record **total JS** (sum of all emitted chunks) and the **entry/main chunk**
   (the always-loaded one), both **raw and gzipped**. Vite prints gzip sizes
-  per chunk.
+  per chunk. Note that a bundle visualizer's treemap reports _pre-minification_
+  sizes — use it for proportional attribution, and the real `dist/` files for
+  absolute totals.
 - Attribute kilobytes to packages. Run a bundle visualizer that emits machine-
   readable output — e.g. `npx vite-bundle-visualizer --template raw-data -o
 /tmp/bundle.json` (or `rollup-plugin-visualizer`, or `source-map-explorer`

--- a/.claude/skills/react-to-solid-feasibility/SKILL.md
+++ b/.claude/skills/react-to-solid-feasibility/SKILL.md
@@ -2,19 +2,23 @@
 name: react-to-solid-feasibility
 description: >-
   Produce a speculative feasibility report for migrating a React single-page
-  application to SolidJS 2.0. Use when someone asks what a React-to-Solid port
-  would take or gain, wants a migration assessment, or wants to scope a Solid
-  rewrite of an SPA. Report-only: it assesses dependencies and architecture,
-  it does not perform the migration or write Solid code.
+  application to SolidJS 2.0. The headline is a measured bundle projection:
+  build the app, account for where every kilobyte lands, and project what it
+  would weigh in SolidJS. Use when someone asks what a React-to-Solid port
+  would take or gain, wants a migration assessment, wants to know the bundle
+  savings, or wants to scope a Solid rewrite of an SPA. Report-only: it
+  assesses, it does not perform the migration or write Solid code.
 ---
 
 # React to SolidJS Feasibility
 
 Produce an **information report** for a team weighing a React-to-SolidJS
-migration of a single-page app. The report describes what the migration would
-touch, which dependencies have a clean landing zone in the Solid ecosystem and
-which don't, and which architectural systems need careful examination before
-anyone commits.
+migration of a single-page app. **The point of the report is the bundle
+math.** Build the app as it stands, measure its chunks, account for where
+every kilobyte lands, and project what the bundle would weigh in SolidJS if
+every dependency took its default replacement. That projected delta is the
+headline. The rest of the report — dependency landing zones, architectural
+seams — explains the shape of the work behind that number.
 
 ## What this skill is — and is not
 
@@ -26,94 +30,137 @@ anyone commits.
   removal of `<Index>`. For an SPA doing package-level analysis, the async
   model can be treated as a forward consideration rather than modelled in
   depth — flag it, don't dwell on it.
-- **Report-only.** This skill assesses. It never writes Solid code, never
-  edits the target repo, never runs a codemod. Its single deliverable is the
-  report.
-- **Information, not a recommendation.** Do **not** open with a verdict, a
-  score, a go/no-go, or a "favorable / unfavorable" headline. You do not know
-  the reader's appetite for large changes, their timeline, or their reasons
-  for considering the move. Lay out the facts and the shape of the work; let
-  the reader draw the conclusion.
-- **Do not quantify effort.** No hour / day / week estimates, no story points,
-  no t-shirt sizes. Counting things that exist (components, collections,
-  dependencies) is fine as inventory. Converting those counts into an effort
-  number is not. Characterize work qualitatively instead: "contained",
-  "sprawling but shallow", "needs careful examination", "a spike would surface
-  the rough edges early".
+- **Report-only.** This skill assesses. It never writes Solid code, never edits
+  the target repo's source, never runs a codemod. It _does_ build the app to
+  measure it. Its single written deliverable is the report.
+- **Lead with the bundle number — that is information, not a verdict.** The
+  report opens, in the first paragraph, with the measured current bundle and
+  the projected SolidJS bundle: "ships ~X KB today; ~Y KB projected in Solid;
+  ~Z KB saved, ~W KB of it from the main chunk." That is a fact. What you must
+  _not_ do is open with a go/no-go, a score, or a "favorable / unfavorable"
+  judgment — you do not know the reader's appetite for change. Give the number
+  and the shape of the work; let the reader conclude.
+- **Do not quantify effort.** Bundle size is measured and projected — that is
+  the job. _Effort_ is different: no hour / day / week estimates, no story
+  points, no t-shirt sizes. Counting things (components, collections) is fine
+  as inventory; converting counts into an effort number is not. Characterize
+  work qualitatively: "contained", "sprawling but shallow", "a spike would
+  surface the rough edges early".
 
 ## Mental model
 
-Two lenses produce the whole report:
+Three lenses, in priority order:
 
-1. **Dependency landing zones.** Every dependency lands somewhere on a
-   spectrum: keep untouched (framework-agnostic) → swap to a clear Solid leader
-   → swap into a contested/wonky space where you must pick a winner → no direct
-   equivalent, rebuild on a different paradigm. The interesting content is
-   _the quality of the landing zone_, not merely "this changes."
-2. **Architectural seams.** A React SPA is a handful of systems — auth, the
+1. **Bundle accounting — the headline.** Build the app. Measure total JS and
+   the always-loaded main/entry chunk, raw and gzipped. Attribute kilobytes to
+   npm packages. Then project: swap each package for its registry default and
+   re-sum. The delta, split into total vs main-chunk, is the report's lead.
+2. **Dependency landing zones.** Every dependency lands somewhere: keep
+   untouched → swap to a clear Solid leader → swap into a contested space → no
+   direct equivalent, rebuild. The interesting content is _the quality of the
+   landing zone_. This lens also supplies the replacement choices the bundle
+   projection needs.
+3. **Architectural seams.** A React SPA is a handful of systems — auth, the
    data/sync layer, global state, forms, the UI primitive layer, charting,
-   realtime. Each ports with its own character: some carry over almost
-   verbatim, some need careful examination, and for some Solid's idioms are
-   genuinely _cleaner_ than the React originals. Narrate each seam.
+   realtime. Each ports with its own character. Narrate each seam.
 
 ## Process
 
 ### 1. Inventory (facts only)
 
-- Read `package.json`: framework versions, every runtime and build dependency.
+- Read `package.json`: framework versions, every runtime and build dependency,
+  the build command.
 - Read the build config (`vite.config.*`, etc.): confirm it is an SPA; note
   the React plugin and whether the **React Compiler** is enabled.
 - Count, roughly: component files, custom hooks, feature/module directories,
   data collections or stores.
 - Grep for React-specific escape hatches: `forwardRef`, `useImperativeHandle`,
   `createPortal`, `useSyncExternalStore`, `useReducer`, HOCs, `React.*`
-  namespace use. These are the seam hot spots.
+  namespace use.
 
-### 2. Classify dependencies
+### 2. Build and measure the bundle
+
+This is the core measurement — do not skip or estimate it away.
+
+- Install dependencies and run the production build (`pnpm build` / `npm run
+build`). If the build cannot run in this environment, say so explicitly in
+  the report and fall back to per-package sizes from bundlephobia, clearly
+  labelled as estimates.
+- Record **total JS** (sum of all emitted chunks) and the **entry/main chunk**
+  (the always-loaded one), both **raw and gzipped**. Vite prints gzip sizes
+  per chunk.
+- Attribute kilobytes to packages. Run a bundle visualizer that emits machine-
+  readable output — e.g. `npx vite-bundle-visualizer --template raw-data -o
+/tmp/bundle.json` (or `rollup-plugin-visualizer`, or `source-map-explorer`
+  on a sourcemap build). Parse it for per-package size.
+- Note which packages land in the **main chunk** (loaded on every visit) vs
+  **lazy route chunks** (loaded on demand). This split decides how the savings
+  are reported.
+
+### 3. Classify dependencies
 
 Place every dependency into a landing-zone bucket using
 [reference/dependency-registry.md](reference/dependency-registry.md). For a
-dependency not in the registry, apply the registry's classification heuristics
-and **verify maturity live** (npm last-publish date, GitHub activity, version)
-— the Solid ecosystem moves, and the registry is a dated snapshot.
+dependency not in the registry, apply the registry heuristics and **verify
+maturity live** (npm last-publish date, GitHub activity, version). Record the
+_default replacement_ for each — the projection needs it.
 
-### 3. Identify the architectural seams
+### 4. Project the SolidJS bundle
 
-Walk the codebase and identify which of the archetypal systems in
-[reference/system-archetypes.md](reference/system-archetypes.md) are present.
-Use the Agent tool with `subagent_type=Explore` for breadth. For each seam,
-gather the concrete facts: which files, how coupled, how contained.
+For each measured package, take its default replacement and its size:
 
-### 4. Map the primitive-level rewrite
+- **Framework** (`react` + `react-dom` → `solid-js`): the largest, most
+  defensible delta. Get real sizes (bundlephobia or measure). Note that Solid
+  compiles some machinery into component output, so the framework _chunk_
+  shrinks dramatically but it is not a pure package-size subtraction.
+- **No-equivalent removals** (e.g. `recharts`): subtract the package, add the
+  replacement charting library's weight.
+- **Contested swaps** (Base UI → Kobalte, etc.): estimate from the
+  replacement's published size.
+- **Clear-leader swaps within a shared-core family** (TanStack `react-*` →
+  `solid-*`): treat as roughly neutral.
+- **Kept** dependencies and **app source**: zero delta. Do not claim app-code
+  savings — be conservative; the headline must survive scrutiny.
+
+Sum the deltas. Split into a **total** saving and a **main-chunk** saving
+(deltas for packages in the always-loaded chunk). Present as a projection with
+its uncertainty stated: the framework delta is near-certain; replacement-
+library deltas are estimates.
+
+### 5. Identify the architectural seams
+
+Walk the codebase for the archetypal systems in
+[reference/system-archetypes.md](reference/system-archetypes.md). Use the Agent
+tool with `subagent_type=Explore` for breadth. For each seam, gather concrete
+facts: which files, how coupled, how contained.
+
+### 6. Map the primitive-level rewrite
 
 Use [reference/solid-2-semantic-map.md](reference/solid-2-semantic-map.md) to
-characterize the per-component rewrite — hooks to primitives, JSX control
-flow, the props rules. This informs the seam narratives (a seam thick with
-`forwardRef` or stale-closure patterns is harder) and supports a short
-"per-component rewrite" section. Tag patterns mechanical vs judgment; do not
-turn the tags into an effort total.
+characterize the per-component rewrite. Tag patterns mechanical vs judgment; do
+not turn the tags into an effort total.
 
-### 5. Write the report
+### 7. Write the report
 
-Use this structure exactly. No headline verdict.
+Open with a first paragraph that states the headline bundle delta. Then use
+this structure:
 
-1. **Scope & inventory** — neutral facts: it is/isn't an SPA, framework
+1. **Bundle projection** — the headline. The measured current bundle (total +
+   main, raw + gzip), the projected SolidJS bundle, the delta, and the
+   per-package breakdown of where the savings come from. State the method and
+   the uncertainty.
+2. **Scope & inventory** — neutral facts: it is/isn't an SPA, framework
    versions, counts, build setup, React Compiler status.
-2. **Dependency landscape** — the four buckets. For _keep_ and _clear leader_,
-   a list suffices. For _contested/wonky_ and _no equivalent_, name the
-   contenders and describe the space honestly: is there a de-facto standard,
-   or is it fragmented and unsettled?
-3. **System-by-system reconnaissance** — the core. One narrative per seam:
-   what carries over cleanly, what needs careful examination, where Solid's
-   pattern may be cleaner, and whether the seam is contained (a good early
-   spike) or sprawling.
-4. **The per-component rewrite** — brief: the broad, shallow body of work of
-   rewriting every component's hooks and JSX. Mechanical vs judgment, no total.
-5. **Gains, as information** — framework bundle delta, the performance profile
-   (and where it does _not_ help), React Compiler becoming moot. State as
-   facts with sources; attach no argument.
-6. **Suggested spikes** — the contained seams worth probing first to surface
-   rough edges before any broad commitment.
+3. **Dependency landscape** — the four buckets. List _keep_ and _clear leader_;
+   for _contested_ and _no equivalent_, name the contenders and describe the
+   space honestly.
+4. **System-by-system reconnaissance** — one narrative per seam: what carries
+   over, what needs examination, where Solid is cleaner, contained vs sprawling.
+5. **The per-component rewrite** — brief: the broad, shallow body of work.
+   Mechanical vs judgment, no total.
+6. **Performance profile** — the non-bundle perf picture and where it does
+   _not_ help; React Compiler becoming moot. Facts with sources, no argument.
+7. **Suggested spikes** — contained seams worth probing first.
 
 ## Reference files
 
@@ -121,16 +168,16 @@ Use this structure exactly. No headline verdict.
   verified React-to-Solid dependency equivalence, grouped by landing zone.
 - [reference/solid-2-semantic-map.md](reference/solid-2-semantic-map.md) —
   React-to-Solid-2.0 primitive mapping; mechanical vs judgment.
-- [reference/system-archetypes.md](reference/system-archetypes.md) — catalog
-  of common React-SPA seams and how each tends to port.
+- [reference/system-archetypes.md](reference/system-archetypes.md) — catalog of
+  common React-SPA seams and how each tends to port.
 - [examples/sunlo-report.md](examples/sunlo-report.md) — a worked report for a
   real React 19 + TanStack SPA, showing tone and depth.
 
 ## Honesty rules
 
-- If a Solid equivalent is young, pre-1.0, or thinly maintained, say so — do
-  not paper over ecosystem risk.
-- If no production React-to-Solid migration case study exists to cite, say so;
-  do not imply field-tested certainty.
-- Distinguish what you verified from what you projected. Solid 2.0 is recent;
-  some guidance is forward projection. Mark it.
+- The bundle projection is a _projection_. State which parts are measured
+  (current bundle) and which are estimated (replacement-library sizes). The
+  framework delta is near-certain; do not present the rest as equally firm.
+- If a Solid equivalent is young, pre-1.0, or thinly maintained, say so.
+- If no production React-to-Solid migration case study exists to cite, say so.
+- Distinguish what you verified from what you projected. Solid 2.0 is recent.

--- a/.claude/skills/react-to-solid-feasibility/SKILL.md
+++ b/.claude/skills/react-to-solid-feasibility/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: react-to-solid-feasibility
+description: >-
+  Produce a speculative feasibility report for migrating a React single-page
+  application to SolidJS 2.0. Use when someone asks what a React-to-Solid port
+  would take or gain, wants a migration assessment, or wants to scope a Solid
+  rewrite of an SPA. Report-only: it assesses dependencies and architecture,
+  it does not perform the migration or write Solid code.
+---
+
+# React to SolidJS Feasibility
+
+Produce an **information report** for a team weighing a React-to-SolidJS
+migration of a single-page app. The report describes what the migration would
+touch, which dependencies have a clean landing zone in the Solid ecosystem and
+which don't, and which architectural systems need careful examination before
+anyone commits.
+
+## What this skill is — and is not
+
+- **Scope: SPAs only.** No SSR, no React Server Components, no Next.js / Remix
+  server code. If the target repo is a server-rendered app, say so plainly and
+  stop — this skill does not cover that migration.
+- **Target: SolidJS 2.0.** Solid 2.0 is the assessment baseline. It introduces
+  first-class async, a reworked Suspense, a split `createEffect`, and the
+  removal of `<Index>`. For an SPA doing package-level analysis, the async
+  model can be treated as a forward consideration rather than modelled in
+  depth — flag it, don't dwell on it.
+- **Report-only.** This skill assesses. It never writes Solid code, never
+  edits the target repo, never runs a codemod. Its single deliverable is the
+  report.
+- **Information, not a recommendation.** Do **not** open with a verdict, a
+  score, a go/no-go, or a "favorable / unfavorable" headline. You do not know
+  the reader's appetite for large changes, their timeline, or their reasons
+  for considering the move. Lay out the facts and the shape of the work; let
+  the reader draw the conclusion.
+- **Do not quantify effort.** No hour / day / week estimates, no story points,
+  no t-shirt sizes. Counting things that exist (components, collections,
+  dependencies) is fine as inventory. Converting those counts into an effort
+  number is not. Characterize work qualitatively instead: "contained",
+  "sprawling but shallow", "needs careful examination", "a spike would surface
+  the rough edges early".
+
+## Mental model
+
+Two lenses produce the whole report:
+
+1. **Dependency landing zones.** Every dependency lands somewhere on a
+   spectrum: keep untouched (framework-agnostic) → swap to a clear Solid leader
+   → swap into a contested/wonky space where you must pick a winner → no direct
+   equivalent, rebuild on a different paradigm. The interesting content is
+   _the quality of the landing zone_, not merely "this changes."
+2. **Architectural seams.** A React SPA is a handful of systems — auth, the
+   data/sync layer, global state, forms, the UI primitive layer, charting,
+   realtime. Each ports with its own character: some carry over almost
+   verbatim, some need careful examination, and for some Solid's idioms are
+   genuinely _cleaner_ than the React originals. Narrate each seam.
+
+## Process
+
+### 1. Inventory (facts only)
+
+- Read `package.json`: framework versions, every runtime and build dependency.
+- Read the build config (`vite.config.*`, etc.): confirm it is an SPA; note
+  the React plugin and whether the **React Compiler** is enabled.
+- Count, roughly: component files, custom hooks, feature/module directories,
+  data collections or stores.
+- Grep for React-specific escape hatches: `forwardRef`, `useImperativeHandle`,
+  `createPortal`, `useSyncExternalStore`, `useReducer`, HOCs, `React.*`
+  namespace use. These are the seam hot spots.
+
+### 2. Classify dependencies
+
+Place every dependency into a landing-zone bucket using
+[reference/dependency-registry.md](reference/dependency-registry.md). For a
+dependency not in the registry, apply the registry's classification heuristics
+and **verify maturity live** (npm last-publish date, GitHub activity, version)
+— the Solid ecosystem moves, and the registry is a dated snapshot.
+
+### 3. Identify the architectural seams
+
+Walk the codebase and identify which of the archetypal systems in
+[reference/system-archetypes.md](reference/system-archetypes.md) are present.
+Use the Agent tool with `subagent_type=Explore` for breadth. For each seam,
+gather the concrete facts: which files, how coupled, how contained.
+
+### 4. Map the primitive-level rewrite
+
+Use [reference/solid-2-semantic-map.md](reference/solid-2-semantic-map.md) to
+characterize the per-component rewrite — hooks to primitives, JSX control
+flow, the props rules. This informs the seam narratives (a seam thick with
+`forwardRef` or stale-closure patterns is harder) and supports a short
+"per-component rewrite" section. Tag patterns mechanical vs judgment; do not
+turn the tags into an effort total.
+
+### 5. Write the report
+
+Use this structure exactly. No headline verdict.
+
+1. **Scope & inventory** — neutral facts: it is/isn't an SPA, framework
+   versions, counts, build setup, React Compiler status.
+2. **Dependency landscape** — the four buckets. For _keep_ and _clear leader_,
+   a list suffices. For _contested/wonky_ and _no equivalent_, name the
+   contenders and describe the space honestly: is there a de-facto standard,
+   or is it fragmented and unsettled?
+3. **System-by-system reconnaissance** — the core. One narrative per seam:
+   what carries over cleanly, what needs careful examination, where Solid's
+   pattern may be cleaner, and whether the seam is contained (a good early
+   spike) or sprawling.
+4. **The per-component rewrite** — brief: the broad, shallow body of work of
+   rewriting every component's hooks and JSX. Mechanical vs judgment, no total.
+5. **Gains, as information** — framework bundle delta, the performance profile
+   (and where it does _not_ help), React Compiler becoming moot. State as
+   facts with sources; attach no argument.
+6. **Suggested spikes** — the contained seams worth probing first to surface
+   rough edges before any broad commitment.
+
+## Reference files
+
+- [reference/dependency-registry.md](reference/dependency-registry.md) —
+  verified React-to-Solid dependency equivalence, grouped by landing zone.
+- [reference/solid-2-semantic-map.md](reference/solid-2-semantic-map.md) —
+  React-to-Solid-2.0 primitive mapping; mechanical vs judgment.
+- [reference/system-archetypes.md](reference/system-archetypes.md) — catalog
+  of common React-SPA seams and how each tends to port.
+- [examples/sunlo-report.md](examples/sunlo-report.md) — a worked report for a
+  real React 19 + TanStack SPA, showing tone and depth.
+
+## Honesty rules
+
+- If a Solid equivalent is young, pre-1.0, or thinly maintained, say so — do
+  not paper over ecosystem risk.
+- If no production React-to-Solid migration case study exists to cite, say so;
+  do not imply field-tested certainty.
+- Distinguish what you verified from what you projected. Solid 2.0 is recent;
+  some guidance is forward projection. Mark it.

--- a/.claude/skills/react-to-solid-feasibility/examples/sunlo-report.md
+++ b/.claude/skills/react-to-solid-feasibility/examples/sunlo-report.md
@@ -1,91 +1,103 @@
 # React to SolidJS feasibility: Sunlo
 
-Built as it stands, Sunlo ships about **2.26 MB of JavaScript (777 KB
-gzipped)**, of which **448 KB (141 KB gzipped) is the always-loaded main
+Built as it stands, Sunlo ships about **2.93 MB of JavaScript (959 KB
+gzipped)**, of which **1,090 KB (320 KB gzipped) is the always-loaded main
 chunk**. Rebuilt in SolidJS 2.0 — taking the default replacement for every
-dependency — the projection is roughly **1.97 MB / ~685 KB gzipped** total and
-**~325 KB / ~100 KB gzipped** for the main chunk. That is about **290 KB raw /
-95 KB gzipped off the total bundle, and 125 KB raw / 40 KB gzipped off the main
-chunk**. Almost the entire main-chunk saving is one item: React's ~135 KB DOM
-runtime collapsing to ~20 KB of `solid-js`. The rest of this report shows where
-that number comes from and the shape of the work behind it.
+dependency — the projection is roughly **2.64 MB / ~865 KB gzipped** total and
+**~970 KB / ~282 KB gzipped** for the main chunk. That is about **290 KB raw /
+95 KB gzipped off the total bundle, and 120 KB raw / 38 KB gzipped off the main
+chunk**. Almost the entire main-chunk saving is one swap: React's ~135 KB DOM
+runtime collapsing to ~20 KB of `solid-js`.
+
+Note the proportion before reading on: the React runtime is only about **13% of
+that 1,090 KB main chunk**. The rest is the TanStack DB stack, the Supabase
+SDK, Base UI, `zod`, and app code — all of which is either kept untouched or
+swapped like-for-like. The migration's bundle effect is real but modest against
+a foundation this heavy.
 
 This is information for a migration decision, not a recommendation. It does not
 argue for or against the move and it does not estimate effort in time.
 
 _Assessment baseline: SolidJS 2.0. Built and measured 2026-05-21 on branch
-`claude/react-solidjs-migration-tool` (`pnpm build`, Vite 8)._
+`claude/react-solidjs-migration-tool` (`pnpm build`, Vite 8, Supabase
+credentials present — see Method note in §1)._
 
 ## 1. Bundle projection
 
 ### Measured today
 
-|                                     | Raw     | Gzip   |
-| ----------------------------------- | ------- | ------ |
-| Total JS (247 chunks)               | 2.26 MB | 777 KB |
-| Main / entry chunk (`index-*.js`)   | 448 KB  | 141 KB |
-| CSS (unaffected by the migration)   | 182 KB  | 26 KB  |
-| `chart-*.js` (recharts, lazy)       | 323 KB  | 96 KB  |
-| `my-markdown-*.js` (markdown, lazy) | 116 KB  | 35 KB  |
-| `form-*.js` (TanStack Form, lazy)   | 50 KB   | 14 KB  |
+|                                     | Raw      | Gzip   |
+| ----------------------------------- | -------- | ------ |
+| Total JS (248 chunks)               | 2.93 MB  | 959 KB |
+| Main / entry chunk (`index-*.js`)   | 1,090 KB | 320 KB |
+| CSS (unaffected by the migration)   | 182 KB   | 26 KB  |
+| `chart-*.js` (recharts, lazy)       | 323 KB   | 97 KB  |
+| `my-markdown-*.js` (markdown, lazy) | 116 KB   | 35 KB  |
 
 ### Where the JavaScript goes today
 
-Attributed from the build's module treemap (gzipped, approximate — the
-treemap measures pre-minification, so these are scaled to the real totals):
+Attributed from the build's module treemap (gzipped, approximate — the treemap
+measures pre-minification, scaled here to the real totals):
 
-| Slice                                                             | ≈ Gzip  | Migration fate                                     |
-| ----------------------------------------------------------------- | ------- | -------------------------------------------------- |
-| App source (~275 components)                                      | ~263 KB | rewritten; size roughly held (see §5)              |
-| `@tanstack/*` — router, query, db, form                           | ~102 KB | **mostly kept** — the cores are framework-agnostic |
-| `recharts` + `d3`                                                 | ~117 KB | **rebuilt** on a different charting engine         |
-| Base UI (`@base-ui/react`, `@floating-ui`)                        | ~99 KB  | swapped to Kobalte — size roughly neutral          |
-| React runtime (`react-dom`, `react`, `scheduler`)                 | ~48 KB  | **collapses** to `solid-js`                        |
-| Markdown ecosystem (`react-markdown` + remark/micromark)          | ~35 KB  | **kept** — only the thin renderer swaps            |
-| Everything else (`zod`, `sonner`, `lucide`, `vaul`, `zustand`, …) | ~113 KB | mostly kept; a few small swaps                     |
+| Slice                                                                         | ≈ Gzip  | Migration fate                                     |
+| ----------------------------------------------------------------------------- | ------- | -------------------------------------------------- |
+| App source (~275 components)                                                  | ~305 KB | rewritten; size roughly held (see §5)              |
+| `recharts` + `d3`                                                             | ~115 KB | **rebuilt** on a different charting engine         |
+| Other deps (`sonner`, `lucide`, `vaul`, `immer`, `qrcode`, `tailwind-merge`…) | ~130 KB | mostly kept; a few small swaps                     |
+| `@tanstack/*` — router, query, db, form                                       | ~117 KB | **mostly kept** — the cores are framework-agnostic |
+| Base UI (`@base-ui/react`, `@floating-ui`)                                    | ~120 KB | swapped to Kobalte — size roughly neutral          |
+| React runtime (`react-dom`, `react`, `scheduler`)                             | ~48 KB  | **collapses** to `solid-js`                        |
+| `@supabase/*` SDK                                                             | ~43 KB  | **kept** — framework-agnostic                      |
+| Markdown ecosystem (`react-markdown` + remark/micromark)                      | ~32 KB  | **kept** — only the thin renderer swaps            |
 
 The single most useful observation: a large share of the bundle — the
-`@tanstack` cores, the markdown ecosystem, `zod`, styling — is
-framework-agnostic and **does not move at all**. The migration's bundle effect
-is concentrated in two places.
+`@tanstack` cores, the `@supabase` SDK, the markdown ecosystem, `zod`, styling
+— is framework-agnostic and **does not move at all**. The migration's bundle
+effect is concentrated in two places: the React runtime and the chart engine.
 
 ### The projection — what actually moves
 
-| Change                                           | ≈ Gzip delta | Lands in                      |
-| ------------------------------------------------ | ------------ | ----------------------------- |
-| `react` + `react-dom` + `scheduler` → `solid-js` | **−40 KB**   | main chunk                    |
-| `zustand` → Solid's built-in `createStore`       | −2 KB        | main chunk                    |
-| `recharts` → `solid-chartjs` (or ECharts)        | **≈ −50 KB** | lazy (stats / charts routes)  |
-| `vaul`, `qrcode.react`, misc small swaps         | ≈ −5 KB      | mixed                         |
-| `@base-ui/react` → Kobalte                       | **≈ 0 (±)**  | mixed — see uncertainty below |
-| `@tanstack` React adapters → Solid adapters      | ≈ 0          | mixed — shared cores          |
-| Markdown ecosystem, all kept dependencies        | 0            | —                             |
+| Change                                             | ≈ Gzip delta | Lands in                      |
+| -------------------------------------------------- | ------------ | ----------------------------- |
+| `react` + `react-dom` + `scheduler` → `solid-js`   | **−36 KB**   | main chunk                    |
+| `zustand` → Solid's built-in `createStore`         | −2 KB        | main chunk                    |
+| `recharts` → `solid-chartjs` (or ECharts)          | **≈ −53 KB** | lazy (stats / charts routes)  |
+| `vaul`, `qrcode.react`, misc small swaps           | ≈ −5 KB      | mixed                         |
+| `@base-ui/react` → Kobalte                         | **≈ 0 (±)**  | mixed — see uncertainty below |
+| `@tanstack` React adapters → Solid adapters        | ≈ 0          | mixed — shared cores          |
+| `@supabase` SDK, markdown ecosystem, all kept deps | 0            | —                             |
 
-**Projected result:** total JS ≈ 1.97 MB raw / ~685 KB gzip; main chunk
-≈ 325 KB raw / ~100 KB gzip.
+**Projected result:** total JS ≈ 2.64 MB raw / ~865 KB gzip; main chunk
+≈ 970 KB raw / ~282 KB gzip.
 
 ### Method and uncertainty
 
-- **Measured** (firm): the current bundle, from an actual `pnpm build`.
+- **Measured** (firm): the current bundle, from an actual `pnpm build` with
+  Supabase credentials present in the environment.
+- **Build-environment note:** `src/lib/supabase-client.ts` throws if
+  `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` are unset. A build _without_
+  those vars constant-folds that guard to `if (true) throw`, makes the
+  `createClient()` call dead code, and lets the bundler tree-shake out the
+  entire `@supabase/*` SDK — ~640 KB, vanished. The baseline above is the
+  credentialed build (the one your CI and deploy produce). Measure a
+  representative build or this number is wrong by a third.
 - **Firm projection:** the React-runtime collapse. `react-dom` + `react` +
   `scheduler` is ~135 KB raw / ~44 KB gzip of well-characterized code;
-  `solid-js` is ~20 KB raw / ~7.5 KB gzip. This delta is near-certain and it
-  is the bulk of the main-chunk win.
-- **Soft projection:** the charting delta depends on which Solid charting
-  library is chosen — `solid-chartjs` (Chart.js) lands around ~190 KB raw;
-  a lighter library would save more, ECharts less. The −50 KB gzip figure
-  assumes `solid-chartjs`.
-- **The one real unknown:** Base UI → Kobalte. Base UI is ~250 KB raw /
-  ~99 KB gzip of this bundle. Kobalte is a comparable accessible-primitives
-  library; whether it lands smaller, similar, or larger was not measured.
-  This could swing the total saving by roughly ±40 KB.
-- **Not counted — upside:** the ~800 KB raw of app code is held flat in the
-  projection. In practice Solid compiles components to compact DOM operations
-  rather than `React.createElement` trees, and the React Compiler's injected
-  memoization — currently woven through all ~275 components — disappears
-  entirely. App code would very likely shrink, possibly materially. It is not
-  banked here because it cannot be measured without doing the port. Treat it
-  as headroom on top of the headline.
+  `solid-js` is ~20 KB raw / ~7.5 KB gzip. This delta is near-certain and is
+  the bulk of the main-chunk win.
+- **Soft projection:** the charting delta depends on the Solid charting library
+  chosen — `solid-chartjs` (Chart.js) lands around ~190 KB raw; a lighter
+  library saves more, ECharts less.
+- **The one real unknown:** Base UI → Kobalte. Base UI is ~120 KB gzip of this
+  bundle. Kobalte is a comparable accessible-primitives library; whether it
+  lands smaller, similar, or larger was not measured. This could swing the
+  total by roughly ±40 KB.
+- **Not counted — upside:** the ~960 KB raw of app code is held flat in the
+  projection. Solid compiles components to compact DOM operations rather than
+  `React.createElement` trees, and the React Compiler's injected memoization —
+  woven through all ~275 components — disappears. App code would likely shrink,
+  possibly materially. Not banked, because it cannot be measured without doing
+  the port.
 
 ## 2. Scope & inventory
 
@@ -119,10 +131,15 @@ internals.
 
 `zod`, `dayjs`, `class-variance-authority`, `clsx`, `tailwind-merge`,
 `tailwindcss` and every Tailwind plugin, `tailwind-oklch`, `tailwindcss-animate`,
-`@supabase/supabase-js`, `ts-fsrs`, the Fontsource fonts — and, importantly,
-the `@tanstack` cores and the entire `remark`/`micromark` markdown ecosystem,
-which together are a large slice of the bundle (§1). The `tailwind-oklch` color
-system and the `cn()` helper carry over untouched.
+`ts-fsrs`, the Fontsource fonts — the `@tanstack` cores, the entire
+`remark`/`micromark` markdown ecosystem, and, notably, **the whole
+`@supabase/*` SDK** (`supabase-js`, `auth-js`, `realtime-js`, `postgrest-js`,
+`storage-js`, `phoenix` — together ~330 KB of the bundle, one of its largest
+single blocks). All of this carries over untouched. The `tailwind-oklch` color
+system and the `cn()` helper carry over too. Vite itself stays.
+
+This is a large fraction of the dependency list, and a large fraction of the
+bundle — a meaningful point in the migration's favor.
 
 ### Swap — clear leader, one obvious target
 
@@ -140,16 +157,14 @@ system and the `cn()` helper carry over untouched.
 
 ### Swap — contested, a real decision with no dominant winner
 
-- **`@base-ui/react` (38 component wrappers, ~99 KB gzipped of the bundle).**
+- **`@base-ui/react` (38 component wrappers, ~120 KB gzipped of the bundle).**
   Base UI has **no SolidJS port** — it is React-only. The Solid space offers
   three credible options and no default: **Kobalte** (closest to Radix, the
-  de-facto community pick), **Corvu** (complementary primitives, often used
-  alongside Kobalte), and **Ark UI** (Chakra team, on Zag.js — exposes the
-  _same component API for React and Solid_). This is the most consequential
-  single choice in the migration, and per §1 it is also the projection's
-  largest unknown.
-- **`vaul` (drawer, ~12 KB gzipped).** No direct port; re-implement on Corvu's
-  drawer or Kobalte.
+  de-facto community pick), **Corvu** (complementary primitives), and **Ark
+  UI** (Chakra team, on Zag.js — exposes the _same component API for React and
+  Solid_). The most consequential single choice in the migration, and per §1
+  the projection's largest unknown.
+- **`vaul` (drawer).** No direct port; re-implement on Corvu's drawer or Kobalte.
 - **`cmdk` (command menu).** Solid ports exist but are small and thinly
   maintained — a wonky corner.
 - **`qrcode.react`.** Minor; a Solid QR component exists, verify maintenance.
@@ -157,9 +172,9 @@ system and the `cn()` helper carry over untouched.
 
 ### No direct equivalent — rebuild on a different paradigm
 
-- **`recharts` 3.7.0 (~117 KB gzipped with its d3 dependencies).** Solid has no
+- **`recharts` 3.7.0 (~115 KB gzipped with its d3 dependencies).** Solid has no
   declarative-SVG charting library equivalent to Recharts. The realistic path
-  is `solid-chartjs` (Chart.js, canvas) or an ECharts wrapper — a _different_
+  is `solid-chartjs` (Chart.js, canvas) or an ECharts wrapper — a different
   rendering model and API. It is **contained**: three files
   (`components/activity-chart.tsx`, `components/library-charts.tsx`,
   `components/ui/chart.tsx`) feeding two lazy route chunks. A scoped soft wall,
@@ -252,11 +267,12 @@ also bundle saving number two (§1).
 ### Seam 9 — code-splitting and odds-and-ends
 
 `_user.tsx` uses `React.lazy` + `<Suspense>` for `AppSidebar` / `AppNav`, and
-the router plugin does `autoCodeSplitting`. `lazy()` and `<Suspense>` exist in
-Solid; Suspense is reworked in Solid 2.0, but here it does code-split loading,
-not data orchestration, so the concern is low. The two `useSyncExternalStore`
-uses in `lib/lang-theme.ts` become a native Solid signal/store — a small, clean
-rewrite.
+the router plugin does `autoCodeSplitting`. The code-splitting is in good
+shape: `recharts`, the markdown ecosystem, every route, forms, and per-icon
+chunks are all already lazy. `lazy()` and `<Suspense>` exist in Solid; Suspense
+is reworked in Solid 2.0, but here it does code-split loading, not data
+orchestration, so the concern is low. The two `useSyncExternalStore` uses in
+`lib/lang-theme.ts` become a native Solid signal/store — a small, clean rewrite.
 
 ## 5. The per-component rewrite
 
@@ -283,6 +299,10 @@ upside is the uncounted headroom from §1.
   migration win: the Compiler's entire job is unnecessary in Solid, so its
   config is deleted rather than ported, and its injected memoization leaves the
   bundle (§1, uncounted upside).
+- **Proportion check.** The React runtime is ~13% of the 1,090 KB main chunk
+  and ~5% of the 2.93 MB total. A migration trims that slice; the data layer,
+  Supabase SDK, and UI primitives — the other ~87% of the main chunk — stay.
+  The bundle case for migrating is real but should not be oversold.
 - **Honesty caveat.** There is no published production React-to-Solid migration
   case study with before/after numbers to cite. The bundle figures here are
   measured and projected from this repo's own build; performance figures in the
@@ -295,8 +315,8 @@ Sources: [react-dom — Bundlephobia](https://bundlephobia.com/package/react-dom
 
 ## 7. Suggested spikes
 
-Three contained seams worth probing first, to surface rough edges before any
-broad commitment:
+Three contained seams are worth probing first, to surface rough edges before
+any broad commitment:
 
 1. **`@tanstack/solid-db`** — the highest-risk dependency. Stand up one
    collection and one `useLiveQuery` equivalent in isolation and confirm the

--- a/.claude/skills/react-to-solid-feasibility/examples/sunlo-report.md
+++ b/.claude/skills/react-to-solid-feasibility/examples/sunlo-report.md
@@ -1,0 +1,255 @@
+# React to SolidJS feasibility: Sunlo
+
+A speculative feasibility report for migrating Sunlo from React 19 to SolidJS
+2.0. This is information for a migration decision — it describes what the
+migration would touch and the character of the work. It does not recommend for
+or against, and it does not estimate effort in time.
+
+_Assessment baseline: SolidJS 2.0. Generated 2026-05-21 against branch
+`claude/react-solidjs-migration-tool`._
+
+## 1. Scope & inventory
+
+Sunlo is a **single-page app** — Vite 8 + React 19, client-rendered, no SSR or
+RSC. It is in scope for this skill. A root `middleware.ts` exists; it is
+deployment-edge logic, not part of the React tree, and sits outside the
+migration surface (worth confirming it does no server rendering, but it does
+not change the SPA classification).
+
+| Fact                      | Value                                                                |
+| ------------------------- | -------------------------------------------------------------------- |
+| Framework                 | React 19.2.3 / react-dom 19.2.3                                      |
+| Build                     | Vite 8, `@vitejs/plugin-react` 6                                     |
+| React Compiler            | **Enabled** — `babel-plugin-react-compiler` 1.0.0 via a Babel preset |
+| Component files (`.tsx`)  | ~275                                                                 |
+| Other `.ts` files         | ~119                                                                 |
+| Custom hooks              | ~12                                                                  |
+| Feature modules           | 9 (`src/features/*`)                                                 |
+| Data collections          | ~14, across 9 `collections.ts` files                                 |
+| `useLiveQuery` call sites | ~110                                                                 |
+| UI primitive wrappers     | 38 (`src/components/ui/`)                                            |
+| Forms                     | ~15, on TanStack Form                                                |
+| Realtime subscriptions    | 2 hooks                                                              |
+
+React-specific escape hatches are **rare**, which matters for the migration:
+`forwardRef` appears once (`components/ui/chart.tsx`), `useImperativeHandle`
+zero times, `createPortal` zero, `useReducer` zero. `useSyncExternalStore`
+appears twice, both in `src/lib/lang-theme.ts`. The app is built on hooks and
+modern patterns, not on imperative React internals.
+
+## 2. Dependency landscape
+
+### Keep — framework-agnostic, zero change
+
+`zod`, `dayjs`, `class-variance-authority`, `clsx`, `tailwind-merge`,
+`tailwindcss` and every Tailwind plugin (`@tailwindcss/vite`,
+container-queries, line-clamp, typography), `tailwind-oklch`,
+`tailwindcss-animate`, `@supabase/supabase-js`, `ts-fsrs`, the Fontsource
+fonts. The `tailwind-oklch` color system and the `cn()` helper carry over
+untouched. Vite itself stays.
+
+This is a large fraction of the dependency list and includes the entire
+styling system — a meaningful point in the app's favor.
+
+### Swap — clear leader, one obvious target
+
+| Current                                                                         | Target                   | Note                                                                   |
+| ------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------- |
+| `react` + `react-dom`                                                           | `solid-js`               | The runtime swap.                                                      |
+| `@vitejs/plugin-react`, `@rolldown/plugin-babel`, `babel-plugin-react-compiler` | `vite-plugin-solid`      | The Babel + React-Compiler wiring is **deleted**, not ported (see §5). |
+| `@tanstack/react-query` (+ devtools)                                            | `@tanstack/solid-query`  | Same monorepo; near drop-in.                                           |
+| `@tanstack/react-router` (+ router-plugin, devtools)                            | `@tanstack/solid-router` | Same loader / beforeLoad / context concepts.                           |
+| `@tanstack/react-form`                                                          | `@tanstack/solid-form`   | **Same family** — the form library is not a contested swap.            |
+| `@tanstack/react-db`, `@tanstack/db`, `@tanstack/query-db-collection`           | `@tanstack/solid-db`     | Exists and official — **but pre-1.0 and young.** See §3, seam 2.       |
+| `lucide-react`                                                                  | `lucide-solid`           | Same icon monorepo; drop-in.                                           |
+| `sonner`                                                                        | `solid-sonner`           | API mirrors `sonner`; pre-1.0.                                         |
+| `react-markdown`                                                                | `solid-markdown`         | Community port that tracks `react-markdown`.                           |
+
+One unknown: **`@tanstack/intent` (0.0.29)** is a very new TanStack package; a
+Solid story for it should be verified directly before relying on this row.
+
+### Swap — contested, a real decision with no dominant winner
+
+- **`@base-ui/react` (38 component wrappers).** Base UI has **no SolidJS
+  port** — it is a React-only library from the MUI team. The Solid space
+  offers three credible, non-overlapping options and no default: **Kobalte**
+  (closest to Radix, the de-facto community pick), **Corvu** (complementary
+  primitives, often used alongside Kobalte), and **Ark UI** (Chakra team, on
+  Zag.js — notably exposes the _same component API for React and Solid_).
+  Choosing among these is an architectural decision, not a swap. It is the
+  single most consequential dependency call in the migration.
+- **`vaul` (drawer).** No direct port; re-implement on Corvu's drawer or
+  Kobalte.
+- **`cmdk` (command menu).** Solid ports (`cmdk-solid`) exist but are small
+  and thinly maintained — a wonky corner.
+- **`qrcode.react`.** Minor; a Solid QR component exists but verify maintenance.
+- **The ~12 custom hooks.** Port individually onto `@solid-primitives/*`, a
+  broad and officially-curated catalog, or hand-write.
+
+### No direct equivalent — rebuild on a different paradigm
+
+- **`recharts` 3.7.0.** Solid has no declarative-SVG charting library
+  equivalent to Recharts. The realistic path is `solid-chartjs` (Chart.js,
+  canvas) or an ECharts wrapper — a different rendering model and API. The
+  chart layer is rebuilt, not ported. It is **contained**: three files
+  (`components/activity-chart.tsx`, `components/library-charts.tsx`,
+  `components/ui/chart.tsx`). Treat it as a scoped soft wall, not a blocker.
+
+## 3. System-by-system reconnaissance
+
+### Seam 1 — auth, router, mounting, context, data-loader
+
+`src/main.tsx` builds the router with a context object (`auth`, `queryClient`);
+`components/auth-context.tsx` runs `AuthProvider` off Supabase
+`onAuthStateChange` inside a `useLayoutEffect`; `routes/_user.tsx` is the
+protected layout whose `loader` ensures the profile collection is loaded — and
+notably uses a `fetchQuery` with a 1-second `staleTime` to dodge a post-login
+race; `routes/_user/learn/$lang.tsx` validates the language in `beforeLoad` and
+parallel-preloads ~10 collections in its `loader`.
+
+The **router** half of this seam carries over recognizably:
+`@tanstack/solid-router` keeps `loader`, `beforeLoad`, and route context, so
+the route files are a rewrite of the same shapes, not a redesign. The **auth
+and mount-ordering** half needs careful examination — the `useLayoutEffect`
+timing and that 1-second-`staleTime` race-dodge are a tell that the React mount
+sequence here is delicate. That said, there is real cause for optimism: Solid's
+`createResource` + context + `onMount` tends to express "resolve auth, then
+gate, then preload" more directly than React's effect-timing dance, and the
+race-dodge may simply dissolve. The seam is **contained** — a handful of files
+— which makes it an ideal early spike that surfaces both the router-binding and
+the mount-timing rough edges before any broad commitment.
+
+### Seam 2 — the TanStack DB collections + live-query layer
+
+This is the reactive spine of the app: ~14 collections and ~110 `useLiveQuery`
+call sites. Two things pull in opposite directions. In its favor: the
+collection/live-query model maps **naturally onto Solid's fine-grained
+signals** — arguably more naturally than onto React, since Solid is built for
+exactly this kind of granular subscription. Against it: `@tanstack/solid-db` is
+**pre-1.0 and young** next to the battle-tested `@tanstack/react-db`. The risk
+here is not "missing," it is "new." And because every one of the ~110 call
+sites changes shape, this is the **most sprawling** seam in the app. The
+sensible move is to de-risk it in isolation early (see §6) rather than discover
+binding limitations halfway through 110 rewrites.
+
+### Seam 3 — optimistic mutations
+
+The `onInsert` / `onUpdate` / `onDelete` collection handlers and the
+`collection.utils.writeInsert` / `writeUpdate` sync writes are TanStack DB
+_configuration_, not React. They ride along with whatever seam 2 concludes
+about `@tanstack/solid-db`; they carry no independent React coupling.
+
+### Seam 4 — the review feature (Zustand + Context + FSRS)
+
+`features/review/store.ts` builds a per-session Zustand store
+(`createReviewStore(lang, dayString)`), persisted to `localStorage`, wrapped in
+a React Context and exposed through custom hooks. The FSRS algorithm is
+`ts-fsrs` — framework-agnostic, carries over untouched. The Zustand store maps
+to a Solid `createStore`, and the React-Context-for-injection wrapper likely
+**simplifies away** — Solid stores live outside the component tree without
+provider ceremony. This seam is **contained** (the review routes only) and is
+where the "Solid may be cleaner" hypothesis is most testable, so it is a strong
+spike candidate.
+
+### Seam 5 — forms
+
+Forms run on TanStack Form behind a shared `useAppForm` / `withForm` wrapper
+(`src/components/form/`), with field components and form-parts. Because the
+underlying library has a same-family Solid binding (`@tanstack/solid-form`),
+this seam is a swap rather than a rewrite-into-a-foreign-API. The shared
+abstraction is ported once; the ~15 forms then follow a repeatable pattern. The
+`withForm` HOC is the one part that wants rethinking — HOCs are not idiomatic
+in Solid and would become composition.
+
+### Seam 6 — the UI primitive layer
+
+38 wrappers in `src/components/ui/` over Base UI. With no Base UI Solid port,
+this seam depends on the §2 decision among Kobalte / Corvu / Ark UI, plus
+re-homing `vaul` and `cmdk`. Its character is **sprawling but shallow**: many
+small, self-contained wrapper files, low conceptual risk, high file count. It
+is not a spike candidate — there is no single rough edge to probe — it is a
+steady body of work. The one `forwardRef` in the app lives here
+(`ui/chart.tsx`) and is hand-rewritten as a callable `ref` prop. If the team is
+willing to leave Base UI anyway, Ark UI's shared React/Solid API can make this
+seam closer to mechanical.
+
+### Seam 7 — realtime
+
+Two hooks — `useSocialRealtime` and `useNotificationsRealtime` — subscribe to
+Supabase `postgres_changes` channels and write into collections. `supabase-js`
+is framework-agnostic; the only React-specific part is the `useEffect`
+subscribe/unsubscribe, which becomes `onMount` / `onCleanup`. This is the
+easiest seam in the app.
+
+### Seam 8 — charting
+
+`recharts` across three files (§2, bucket D). Rebuilt on a Solid charting
+library with a different rendering model. Contained to those files.
+
+### Seam 9 — code-splitting and odds-and-ends
+
+`_user.tsx` uses `React.lazy` + `<Suspense>` for `AppSidebar` / `AppNav`, and
+the router plugin does `autoCodeSplitting`. `lazy()` and `<Suspense>` both
+exist in Solid; Suspense is reworked in Solid 2.0, but here it is doing
+code-split loading, not data orchestration, so the concern is low. Separately,
+the two `useSyncExternalStore` uses in `lib/lang-theme.ts` become a native
+Solid signal/store — a small, clean rewrite.
+
+## 4. The per-component rewrite
+
+Beneath the named seams sits the broad, shallow body of work: rewriting each of
+~275 components' hooks and JSX. Much of it is mechanical — `className` to
+`class`, `useMemo` to `createMemo`, deleting `useCallback`, fragment and
+control-flow renames. The judgment-bearing parts are consistent and learnable:
+the signal getter-call rewrite (`value` becomes `value()` at every read site),
+never destructuring props, effect dependency auto-tracking, and `&&` / `.map()`
+becoming `<Show>` / `<For>`. Because escape hatches are rare here (§1), this
+work is voluminous but low-surprise. It is not estimated in time by design.
+
+## 5. Gains, as information
+
+- **Framework bundle.** `react` + `react-dom` is roughly 44 KB min+gzip;
+  `solid-js` is roughly 7 KB — a framework-layer reduction of about
+  **37–40 KB**. Against an app of ~275 components plus its own non-framework
+  dependencies, this is real but modest; the app's own code dominates the
+  bundle.
+- **Performance profile.** Solid's fine-grained reactivity removes VDOM
+  diffing and lowers memory. The benchmarked gains concentrate in
+  **update-heavy and large-list UIs** — in Sunlo, the card-by-card review flow
+  and large phrase lists are where a difference could be felt; forms and mostly
+  static pages would see little.
+- **React Compiler interaction.** Sunlo runs the React Compiler today, which
+  already auto-memoizes away unnecessary re-renders. That narrows the
+  _performance_ delta a migration would deliver — much of what Solid gives
+  natively, the Compiler is already approximating. It is, separately, a clean
+  migration win: the Compiler's entire job is unnecessary in Solid, so its
+  config is deleted rather than ported.
+- **Honesty caveat.** There is no published production React-to-Solid
+  migration case study with before/after numbers to cite. The bundle figure is
+  verifiable; the performance figures are benchmark-derived and
+  workload-dependent.
+
+Sources: [react-dom — Bundlephobia](https://bundlephobia.com/package/react-dom),
+[solid-js — Bundlephobia](https://bundlephobia.com/package/solid-js),
+[js-framework-benchmark](https://krausest.github.io/js-framework-benchmark/),
+[I tried React Compiler — Developer Way](https://www.developerway.com/posts/i-tried-react-compiler).
+
+## 6. Suggested spikes
+
+Three contained seams are worth probing first, to surface rough edges before
+any broad commitment:
+
+1. **`@tanstack/solid-db`** — the highest-risk dependency. Stand up one
+   collection and one `useLiveQuery` equivalent in isolation and confirm the
+   pre-1.0 binding does what the app needs. Everything in seam 2 (and ~110 call
+   sites) rests on the answer.
+2. **Auth + router + mount** (seam 1) — port `auth-context.tsx`, `_user.tsx`,
+   and one `$lang` loader. Contained, and it surfaces both the
+   `solid-router` binding and the mount-timing question (does the 1-second
+   race-dodge survive, or dissolve?).
+3. **The review feature** (seam 4) — Zustand to Solid `createStore`. Contained
+   to the review routes, and the clearest test of whether Solid's idioms come
+   out cleaner than the React originals.
+
+Each is small, self-contained, and load-bearing — together they convert the
+biggest unknowns in this report into observed facts.

--- a/.claude/skills/react-to-solid-feasibility/examples/sunlo-report.md
+++ b/.claude/skills/react-to-solid-feasibility/examples/sunlo-report.md
@@ -1,20 +1,97 @@
 # React to SolidJS feasibility: Sunlo
 
-A speculative feasibility report for migrating Sunlo from React 19 to SolidJS
-2.0. This is information for a migration decision — it describes what the
-migration would touch and the character of the work. It does not recommend for
-or against, and it does not estimate effort in time.
+Built as it stands, Sunlo ships about **2.26 MB of JavaScript (777 KB
+gzipped)**, of which **448 KB (141 KB gzipped) is the always-loaded main
+chunk**. Rebuilt in SolidJS 2.0 — taking the default replacement for every
+dependency — the projection is roughly **1.97 MB / ~685 KB gzipped** total and
+**~325 KB / ~100 KB gzipped** for the main chunk. That is about **290 KB raw /
+95 KB gzipped off the total bundle, and 125 KB raw / 40 KB gzipped off the main
+chunk**. Almost the entire main-chunk saving is one item: React's ~135 KB DOM
+runtime collapsing to ~20 KB of `solid-js`. The rest of this report shows where
+that number comes from and the shape of the work behind it.
 
-_Assessment baseline: SolidJS 2.0. Generated 2026-05-21 against branch
-`claude/react-solidjs-migration-tool`._
+This is information for a migration decision, not a recommendation. It does not
+argue for or against the move and it does not estimate effort in time.
 
-## 1. Scope & inventory
+_Assessment baseline: SolidJS 2.0. Built and measured 2026-05-21 on branch
+`claude/react-solidjs-migration-tool` (`pnpm build`, Vite 8)._
+
+## 1. Bundle projection
+
+### Measured today
+
+|                                     | Raw     | Gzip   |
+| ----------------------------------- | ------- | ------ |
+| Total JS (247 chunks)               | 2.26 MB | 777 KB |
+| Main / entry chunk (`index-*.js`)   | 448 KB  | 141 KB |
+| CSS (unaffected by the migration)   | 182 KB  | 26 KB  |
+| `chart-*.js` (recharts, lazy)       | 323 KB  | 96 KB  |
+| `my-markdown-*.js` (markdown, lazy) | 116 KB  | 35 KB  |
+| `form-*.js` (TanStack Form, lazy)   | 50 KB   | 14 KB  |
+
+### Where the JavaScript goes today
+
+Attributed from the build's module treemap (gzipped, approximate — the
+treemap measures pre-minification, so these are scaled to the real totals):
+
+| Slice                                                             | ≈ Gzip  | Migration fate                                     |
+| ----------------------------------------------------------------- | ------- | -------------------------------------------------- |
+| App source (~275 components)                                      | ~263 KB | rewritten; size roughly held (see §5)              |
+| `@tanstack/*` — router, query, db, form                           | ~102 KB | **mostly kept** — the cores are framework-agnostic |
+| `recharts` + `d3`                                                 | ~117 KB | **rebuilt** on a different charting engine         |
+| Base UI (`@base-ui/react`, `@floating-ui`)                        | ~99 KB  | swapped to Kobalte — size roughly neutral          |
+| React runtime (`react-dom`, `react`, `scheduler`)                 | ~48 KB  | **collapses** to `solid-js`                        |
+| Markdown ecosystem (`react-markdown` + remark/micromark)          | ~35 KB  | **kept** — only the thin renderer swaps            |
+| Everything else (`zod`, `sonner`, `lucide`, `vaul`, `zustand`, …) | ~113 KB | mostly kept; a few small swaps                     |
+
+The single most useful observation: a large share of the bundle — the
+`@tanstack` cores, the markdown ecosystem, `zod`, styling — is
+framework-agnostic and **does not move at all**. The migration's bundle effect
+is concentrated in two places.
+
+### The projection — what actually moves
+
+| Change                                           | ≈ Gzip delta | Lands in                      |
+| ------------------------------------------------ | ------------ | ----------------------------- |
+| `react` + `react-dom` + `scheduler` → `solid-js` | **−40 KB**   | main chunk                    |
+| `zustand` → Solid's built-in `createStore`       | −2 KB        | main chunk                    |
+| `recharts` → `solid-chartjs` (or ECharts)        | **≈ −50 KB** | lazy (stats / charts routes)  |
+| `vaul`, `qrcode.react`, misc small swaps         | ≈ −5 KB      | mixed                         |
+| `@base-ui/react` → Kobalte                       | **≈ 0 (±)**  | mixed — see uncertainty below |
+| `@tanstack` React adapters → Solid adapters      | ≈ 0          | mixed — shared cores          |
+| Markdown ecosystem, all kept dependencies        | 0            | —                             |
+
+**Projected result:** total JS ≈ 1.97 MB raw / ~685 KB gzip; main chunk
+≈ 325 KB raw / ~100 KB gzip.
+
+### Method and uncertainty
+
+- **Measured** (firm): the current bundle, from an actual `pnpm build`.
+- **Firm projection:** the React-runtime collapse. `react-dom` + `react` +
+  `scheduler` is ~135 KB raw / ~44 KB gzip of well-characterized code;
+  `solid-js` is ~20 KB raw / ~7.5 KB gzip. This delta is near-certain and it
+  is the bulk of the main-chunk win.
+- **Soft projection:** the charting delta depends on which Solid charting
+  library is chosen — `solid-chartjs` (Chart.js) lands around ~190 KB raw;
+  a lighter library would save more, ECharts less. The −50 KB gzip figure
+  assumes `solid-chartjs`.
+- **The one real unknown:** Base UI → Kobalte. Base UI is ~250 KB raw /
+  ~99 KB gzip of this bundle. Kobalte is a comparable accessible-primitives
+  library; whether it lands smaller, similar, or larger was not measured.
+  This could swing the total saving by roughly ±40 KB.
+- **Not counted — upside:** the ~800 KB raw of app code is held flat in the
+  projection. In practice Solid compiles components to compact DOM operations
+  rather than `React.createElement` trees, and the React Compiler's injected
+  memoization — currently woven through all ~275 components — disappears
+  entirely. App code would very likely shrink, possibly materially. It is not
+  banked here because it cannot be measured without doing the port. Treat it
+  as headroom on top of the headline.
+
+## 2. Scope & inventory
 
 Sunlo is a **single-page app** — Vite 8 + React 19, client-rendered, no SSR or
-RSC. It is in scope for this skill. A root `middleware.ts` exists; it is
-deployment-edge logic, not part of the React tree, and sits outside the
-migration surface (worth confirming it does no server rendering, but it does
-not change the SPA classification).
+RSC. It is in scope. A root `middleware.ts` is deployment-edge logic, outside
+the React tree and outside the migration surface.
 
 | Fact                      | Value                                                                |
 | ------------------------- | -------------------------------------------------------------------- |
@@ -22,7 +99,6 @@ not change the SPA classification).
 | Build                     | Vite 8, `@vitejs/plugin-react` 6                                     |
 | React Compiler            | **Enabled** — `babel-plugin-react-compiler` 1.0.0 via a Babel preset |
 | Component files (`.tsx`)  | ~275                                                                 |
-| Other `.ts` files         | ~119                                                                 |
 | Custom hooks              | ~12                                                                  |
 | Feature modules           | 9 (`src/features/*`)                                                 |
 | Data collections          | ~14, across 9 `collections.ts` files                                 |
@@ -31,71 +107,65 @@ not change the SPA classification).
 | Forms                     | ~15, on TanStack Form                                                |
 | Realtime subscriptions    | 2 hooks                                                              |
 
-React-specific escape hatches are **rare**, which matters for the migration:
-`forwardRef` appears once (`components/ui/chart.tsx`), `useImperativeHandle`
-zero times, `createPortal` zero, `useReducer` zero. `useSyncExternalStore`
-appears twice, both in `src/lib/lang-theme.ts`. The app is built on hooks and
-modern patterns, not on imperative React internals.
+React-specific escape hatches are **rare** — `forwardRef` appears once
+(`components/ui/chart.tsx`), `useImperativeHandle` zero times, `createPortal`
+zero, `useReducer` zero, `useSyncExternalStore` twice (`src/lib/lang-theme.ts`).
+The app is built on hooks and modern patterns, not on imperative React
+internals.
 
-## 2. Dependency landscape
+## 3. Dependency landscape
 
 ### Keep — framework-agnostic, zero change
 
 `zod`, `dayjs`, `class-variance-authority`, `clsx`, `tailwind-merge`,
-`tailwindcss` and every Tailwind plugin (`@tailwindcss/vite`,
-container-queries, line-clamp, typography), `tailwind-oklch`,
-`tailwindcss-animate`, `@supabase/supabase-js`, `ts-fsrs`, the Fontsource
-fonts. The `tailwind-oklch` color system and the `cn()` helper carry over
-untouched. Vite itself stays.
-
-This is a large fraction of the dependency list and includes the entire
-styling system — a meaningful point in the app's favor.
+`tailwindcss` and every Tailwind plugin, `tailwind-oklch`, `tailwindcss-animate`,
+`@supabase/supabase-js`, `ts-fsrs`, the Fontsource fonts — and, importantly,
+the `@tanstack` cores and the entire `remark`/`micromark` markdown ecosystem,
+which together are a large slice of the bundle (§1). The `tailwind-oklch` color
+system and the `cn()` helper carry over untouched.
 
 ### Swap — clear leader, one obvious target
 
-| Current                                                                         | Target                   | Note                                                                   |
-| ------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------- |
-| `react` + `react-dom`                                                           | `solid-js`               | The runtime swap.                                                      |
-| `@vitejs/plugin-react`, `@rolldown/plugin-babel`, `babel-plugin-react-compiler` | `vite-plugin-solid`      | The Babel + React-Compiler wiring is **deleted**, not ported (see §5). |
-| `@tanstack/react-query` (+ devtools)                                            | `@tanstack/solid-query`  | Same monorepo; near drop-in.                                           |
-| `@tanstack/react-router` (+ router-plugin, devtools)                            | `@tanstack/solid-router` | Same loader / beforeLoad / context concepts.                           |
-| `@tanstack/react-form`                                                          | `@tanstack/solid-form`   | **Same family** — the form library is not a contested swap.            |
-| `@tanstack/react-db`, `@tanstack/db`, `@tanstack/query-db-collection`           | `@tanstack/solid-db`     | Exists and official — **but pre-1.0 and young.** See §3, seam 2.       |
-| `lucide-react`                                                                  | `lucide-solid`           | Same icon monorepo; drop-in.                                           |
-| `sonner`                                                                        | `solid-sonner`           | API mirrors `sonner`; pre-1.0.                                         |
-| `react-markdown`                                                                | `solid-markdown`         | Community port that tracks `react-markdown`.                           |
-
-One unknown: **`@tanstack/intent` (0.0.29)** is a very new TanStack package; a
-Solid story for it should be verified directly before relying on this row.
+| Current                                               | Target                   | Note                                                                                                                 |
+| ----------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `react` + `react-dom`                                 | `solid-js`               | The runtime collapse — the headline saving.                                                                          |
+| `@vitejs/plugin-react`, `babel-plugin-react-compiler` | `vite-plugin-solid`      | The Babel + React-Compiler wiring is **deleted**, not ported (§6).                                                   |
+| `@tanstack/react-query`                               | `@tanstack/solid-query`  | Same monorepo; near drop-in.                                                                                         |
+| `@tanstack/react-router` (+ router-plugin)            | `@tanstack/solid-router` | Same loader / beforeLoad / context concepts.                                                                         |
+| `@tanstack/react-form`                                | `@tanstack/solid-form`   | **Same family** — forms are not a contested swap.                                                                    |
+| `@tanstack/react-db`, `@tanstack/db`                  | `@tanstack/solid-db`     | Exists and official — **but pre-1.0 and young.** See §4, seam 2.                                                     |
+| `lucide-react`                                        | `lucide-solid`           | Same icon monorepo; the icon SVG data is identical, so this swap is size-neutral.                                    |
+| `sonner`                                              | `solid-sonner`           | API mirrors `sonner`; pre-1.0.                                                                                       |
+| `react-markdown`                                      | `solid-markdown`         | Reuses the same remark/micromark ecosystem — the 116 KB markdown chunk does **not** shrink; only the renderer swaps. |
 
 ### Swap — contested, a real decision with no dominant winner
 
-- **`@base-ui/react` (38 component wrappers).** Base UI has **no SolidJS
-  port** — it is a React-only library from the MUI team. The Solid space
-  offers three credible, non-overlapping options and no default: **Kobalte**
-  (closest to Radix, the de-facto community pick), **Corvu** (complementary
-  primitives, often used alongside Kobalte), and **Ark UI** (Chakra team, on
-  Zag.js — notably exposes the _same component API for React and Solid_).
-  Choosing among these is an architectural decision, not a swap. It is the
-  single most consequential dependency call in the migration.
-- **`vaul` (drawer).** No direct port; re-implement on Corvu's drawer or
-  Kobalte.
-- **`cmdk` (command menu).** Solid ports (`cmdk-solid`) exist but are small
-  and thinly maintained — a wonky corner.
-- **`qrcode.react`.** Minor; a Solid QR component exists but verify maintenance.
-- **The ~12 custom hooks.** Port individually onto `@solid-primitives/*`, a
-  broad and officially-curated catalog, or hand-write.
+- **`@base-ui/react` (38 component wrappers, ~99 KB gzipped of the bundle).**
+  Base UI has **no SolidJS port** — it is React-only. The Solid space offers
+  three credible options and no default: **Kobalte** (closest to Radix, the
+  de-facto community pick), **Corvu** (complementary primitives, often used
+  alongside Kobalte), and **Ark UI** (Chakra team, on Zag.js — exposes the
+  _same component API for React and Solid_). This is the most consequential
+  single choice in the migration, and per §1 it is also the projection's
+  largest unknown.
+- **`vaul` (drawer, ~12 KB gzipped).** No direct port; re-implement on Corvu's
+  drawer or Kobalte.
+- **`cmdk` (command menu).** Solid ports exist but are small and thinly
+  maintained — a wonky corner.
+- **`qrcode.react`.** Minor; a Solid QR component exists, verify maintenance.
+- **The ~12 custom hooks.** Port onto `@solid-primitives/*` or hand-write.
 
 ### No direct equivalent — rebuild on a different paradigm
 
-- **`recharts` 3.7.0.** Solid has no declarative-SVG charting library
-  equivalent to Recharts. The realistic path is `solid-chartjs` (Chart.js,
-  canvas) or an ECharts wrapper — a different rendering model and API. The
-  chart layer is rebuilt, not ported. It is **contained**: three files
+- **`recharts` 3.7.0 (~117 KB gzipped with its d3 dependencies).** Solid has no
+  declarative-SVG charting library equivalent to Recharts. The realistic path
+  is `solid-chartjs` (Chart.js, canvas) or an ECharts wrapper — a _different_
+  rendering model and API. It is **contained**: three files
   (`components/activity-chart.tsx`, `components/library-charts.tsx`,
-  `components/ui/chart.tsx`). Treat it as a scoped soft wall, not a blocker.
+  `components/ui/chart.tsx`) feeding two lazy route chunks. A scoped soft wall,
+  not a blocker — and, per §1, the second-largest bundle saving.
 
-## 3. System-by-system reconnaissance
+## 4. System-by-system reconnaissance
 
 ### Seam 1 — auth, router, mounting, context, data-loader
 
@@ -103,153 +173,140 @@ Solid story for it should be verified directly before relying on this row.
 `components/auth-context.tsx` runs `AuthProvider` off Supabase
 `onAuthStateChange` inside a `useLayoutEffect`; `routes/_user.tsx` is the
 protected layout whose `loader` ensures the profile collection is loaded — and
-notably uses a `fetchQuery` with a 1-second `staleTime` to dodge a post-login
-race; `routes/_user/learn/$lang.tsx` validates the language in `beforeLoad` and
+uses a `fetchQuery` with a 1-second `staleTime` to dodge a post-login race;
+`routes/_user/learn/$lang.tsx` validates the language in `beforeLoad` and
 parallel-preloads ~10 collections in its `loader`.
 
-The **router** half of this seam carries over recognizably:
-`@tanstack/solid-router` keeps `loader`, `beforeLoad`, and route context, so
-the route files are a rewrite of the same shapes, not a redesign. The **auth
-and mount-ordering** half needs careful examination — the `useLayoutEffect`
-timing and that 1-second-`staleTime` race-dodge are a tell that the React mount
-sequence here is delicate. That said, there is real cause for optimism: Solid's
-`createResource` + context + `onMount` tends to express "resolve auth, then
-gate, then preload" more directly than React's effect-timing dance, and the
-race-dodge may simply dissolve. The seam is **contained** — a handful of files
-— which makes it an ideal early spike that surfaces both the router-binding and
-the mount-timing rough edges before any broad commitment.
+The **router** half carries over recognizably: `@tanstack/solid-router` keeps
+`loader` / `beforeLoad` / route context, so route files are a rewrite of the
+same shapes, not a redesign. The **auth and mount-ordering** half needs careful
+examination — the `useLayoutEffect` timing and that 1-second-`staleTime`
+race-dodge signal that the React mount sequence here is delicate. There is real
+cause for optimism, though: Solid's `createResource` + context + `onMount` tend
+to express "resolve auth, then gate, then preload" more directly than React's
+effect-timing dance, and the race-dodge may simply dissolve. The seam is
+**contained** — a handful of files — making it an ideal early spike.
 
 ### Seam 2 — the TanStack DB collections + live-query layer
 
-This is the reactive spine of the app: ~14 collections and ~110 `useLiveQuery`
-call sites. Two things pull in opposite directions. In its favor: the
-collection/live-query model maps **naturally onto Solid's fine-grained
-signals** — arguably more naturally than onto React, since Solid is built for
-exactly this kind of granular subscription. Against it: `@tanstack/solid-db` is
-**pre-1.0 and young** next to the battle-tested `@tanstack/react-db`. The risk
-here is not "missing," it is "new." And because every one of the ~110 call
-sites changes shape, this is the **most sprawling** seam in the app. The
-sensible move is to de-risk it in isolation early (see §6) rather than discover
-binding limitations halfway through 110 rewrites.
+The reactive spine: ~14 collections and ~110 `useLiveQuery` call sites. In its
+favor, the collection/live-query model maps **naturally onto Solid's
+fine-grained signals** — arguably better than onto React. Against it,
+`@tanstack/solid-db` is **pre-1.0 and young** next to the battle-tested
+`@tanstack/react-db`. The risk is "new," not "missing." Because every one of
+~110 call sites changes shape, this is the **most sprawling** seam. De-risk it
+in isolation early rather than discovering binding limits mid-rewrite.
 
 ### Seam 3 — optimistic mutations
 
 The `onInsert` / `onUpdate` / `onDelete` collection handlers and the
-`collection.utils.writeInsert` / `writeUpdate` sync writes are TanStack DB
-_configuration_, not React. They ride along with whatever seam 2 concludes
-about `@tanstack/solid-db`; they carry no independent React coupling.
+`writeInsert` / `writeUpdate` sync writes are TanStack DB _configuration_, not
+React. They ride along with whatever seam 2 concludes about
+`@tanstack/solid-db`; no independent React coupling.
 
 ### Seam 4 — the review feature (Zustand + Context + FSRS)
 
-`features/review/store.ts` builds a per-session Zustand store
-(`createReviewStore(lang, dayString)`), persisted to `localStorage`, wrapped in
-a React Context and exposed through custom hooks. The FSRS algorithm is
-`ts-fsrs` — framework-agnostic, carries over untouched. The Zustand store maps
-to a Solid `createStore`, and the React-Context-for-injection wrapper likely
-**simplifies away** — Solid stores live outside the component tree without
-provider ceremony. This seam is **contained** (the review routes only) and is
-where the "Solid may be cleaner" hypothesis is most testable, so it is a strong
-spike candidate.
+`features/review/store.ts` builds a per-session Zustand store, persisted to
+`localStorage`, wrapped in a React Context and exposed through custom hooks.
+The FSRS algorithm (`ts-fsrs`) is framework-agnostic and carries over untouched.
+The Zustand store maps to a Solid `createStore`, and the React-Context-for-
+injection wrapper likely **simplifies away** — Solid stores live outside the
+component tree without provider ceremony. Contained to the review routes, and
+the clearest test of the "Solid may be cleaner" hypothesis — a strong spike
+candidate.
 
 ### Seam 5 — forms
 
 Forms run on TanStack Form behind a shared `useAppForm` / `withForm` wrapper
-(`src/components/form/`), with field components and form-parts. Because the
-underlying library has a same-family Solid binding (`@tanstack/solid-form`),
-this seam is a swap rather than a rewrite-into-a-foreign-API. The shared
-abstraction is ported once; the ~15 forms then follow a repeatable pattern. The
-`withForm` HOC is the one part that wants rethinking — HOCs are not idiomatic
-in Solid and would become composition.
+(`src/components/form/`). Because the underlying library has a same-family
+Solid binding (`@tanstack/solid-form`), this seam is a swap rather than a
+rewrite into a foreign API. The shared abstraction is ported once; the ~15
+forms then follow a repeatable pattern. The `withForm` HOC is the one part that
+wants rethinking — HOCs are not idiomatic in Solid and become composition.
 
 ### Seam 6 — the UI primitive layer
 
 38 wrappers in `src/components/ui/` over Base UI. With no Base UI Solid port,
-this seam depends on the §2 decision among Kobalte / Corvu / Ark UI, plus
+this seam depends on the §3 choice among Kobalte / Corvu / Ark UI, plus
 re-homing `vaul` and `cmdk`. Its character is **sprawling but shallow**: many
-small, self-contained wrapper files, low conceptual risk, high file count. It
-is not a spike candidate — there is no single rough edge to probe — it is a
-steady body of work. The one `forwardRef` in the app lives here
-(`ui/chart.tsx`) and is hand-rewritten as a callable `ref` prop. If the team is
-willing to leave Base UI anyway, Ark UI's shared React/Solid API can make this
-seam closer to mechanical.
+small, self-contained wrapper files, low conceptual risk, high file count. Not
+a spike candidate — a steady body of work. The app's one `forwardRef` lives
+here (`ui/chart.tsx`) and becomes a callable `ref` prop. If the team accepts
+leaving Base UI, Ark UI's shared React/Solid API can make this seam closer to
+mechanical.
 
 ### Seam 7 — realtime
 
 Two hooks — `useSocialRealtime` and `useNotificationsRealtime` — subscribe to
 Supabase `postgres_changes` channels and write into collections. `supabase-js`
 is framework-agnostic; the only React-specific part is the `useEffect`
-subscribe/unsubscribe, which becomes `onMount` / `onCleanup`. This is the
-easiest seam in the app.
+subscribe/unsubscribe, which becomes `onMount` / `onCleanup`. The easiest seam
+in the app.
 
 ### Seam 8 — charting
 
-`recharts` across three files (§2, bucket D). Rebuilt on a Solid charting
-library with a different rendering model. Contained to those files.
+`recharts` across three files (§3, bucket D). Rebuilt on a Solid charting
+library with a different rendering model; contained to those files. This is
+also bundle saving number two (§1).
 
 ### Seam 9 — code-splitting and odds-and-ends
 
 `_user.tsx` uses `React.lazy` + `<Suspense>` for `AppSidebar` / `AppNav`, and
-the router plugin does `autoCodeSplitting`. `lazy()` and `<Suspense>` both
-exist in Solid; Suspense is reworked in Solid 2.0, but here it is doing
-code-split loading, not data orchestration, so the concern is low. Separately,
-the two `useSyncExternalStore` uses in `lib/lang-theme.ts` become a native
-Solid signal/store — a small, clean rewrite.
+the router plugin does `autoCodeSplitting`. `lazy()` and `<Suspense>` exist in
+Solid; Suspense is reworked in Solid 2.0, but here it does code-split loading,
+not data orchestration, so the concern is low. The two `useSyncExternalStore`
+uses in `lib/lang-theme.ts` become a native Solid signal/store — a small, clean
+rewrite.
 
-## 4. The per-component rewrite
+## 5. The per-component rewrite
 
 Beneath the named seams sits the broad, shallow body of work: rewriting each of
-~275 components' hooks and JSX. Much of it is mechanical — `className` to
-`class`, `useMemo` to `createMemo`, deleting `useCallback`, fragment and
-control-flow renames. The judgment-bearing parts are consistent and learnable:
-the signal getter-call rewrite (`value` becomes `value()` at every read site),
-never destructuring props, effect dependency auto-tracking, and `&&` / `.map()`
-becoming `<Show>` / `<For>`. Because escape hatches are rare here (§1), this
-work is voluminous but low-surprise. It is not estimated in time by design.
+~275 components' hooks and JSX. Much is mechanical — `className` to `class`,
+`useMemo` to `createMemo`, deleting `useCallback`, control-flow renames. The
+judgment-bearing parts are consistent and learnable: the signal getter-call
+rewrite (`value` becomes `value()` at every read site), never destructuring
+props, effect dependency auto-tracking, and `&&` / `.map()` becoming `<Show>` /
+`<For>`. Because escape hatches are rare here (§2), this work is voluminous but
+low-surprise. It is not estimated in time, by design — but note its bundle
+upside is the uncounted headroom from §1.
 
-## 5. Gains, as information
+## 6. Performance profile
 
-- **Framework bundle.** `react` + `react-dom` is roughly 44 KB min+gzip;
-  `solid-js` is roughly 7 KB — a framework-layer reduction of about
-  **37–40 KB**. Against an app of ~275 components plus its own non-framework
-  dependencies, this is real but modest; the app's own code dominates the
-  bundle.
-- **Performance profile.** Solid's fine-grained reactivity removes VDOM
-  diffing and lowers memory. The benchmarked gains concentrate in
-  **update-heavy and large-list UIs** — in Sunlo, the card-by-card review flow
-  and large phrase lists are where a difference could be felt; forms and mostly
-  static pages would see little.
+- **Rendering model.** Solid's fine-grained reactivity removes VDOM diffing and
+  lowers memory. Benchmarked gains concentrate in **update-heavy and large-list
+  UIs** — in Sunlo, the card-by-card review flow and large phrase lists are
+  where a difference could be felt; forms and mostly static pages would see
+  little.
 - **React Compiler interaction.** Sunlo runs the React Compiler today, which
-  already auto-memoizes away unnecessary re-renders. That narrows the
-  _performance_ delta a migration would deliver — much of what Solid gives
-  natively, the Compiler is already approximating. It is, separately, a clean
+  already auto-memoizes away unnecessary re-renders — narrowing the _runtime_
+  performance delta a migration would deliver. It is, separately, a clean
   migration win: the Compiler's entire job is unnecessary in Solid, so its
-  config is deleted rather than ported.
-- **Honesty caveat.** There is no published production React-to-Solid
-  migration case study with before/after numbers to cite. The bundle figure is
-  verifiable; the performance figures are benchmark-derived and
-  workload-dependent.
+  config is deleted rather than ported, and its injected memoization leaves the
+  bundle (§1, uncounted upside).
+- **Honesty caveat.** There is no published production React-to-Solid migration
+  case study with before/after numbers to cite. The bundle figures here are
+  measured and projected from this repo's own build; performance figures in the
+  literature are benchmark-derived and workload-dependent.
 
 Sources: [react-dom — Bundlephobia](https://bundlephobia.com/package/react-dom),
 [solid-js — Bundlephobia](https://bundlephobia.com/package/solid-js),
 [js-framework-benchmark](https://krausest.github.io/js-framework-benchmark/),
 [I tried React Compiler — Developer Way](https://www.developerway.com/posts/i-tried-react-compiler).
 
-## 6. Suggested spikes
+## 7. Suggested spikes
 
-Three contained seams are worth probing first, to surface rough edges before
-any broad commitment:
+Three contained seams worth probing first, to surface rough edges before any
+broad commitment:
 
 1. **`@tanstack/solid-db`** — the highest-risk dependency. Stand up one
    collection and one `useLiveQuery` equivalent in isolation and confirm the
-   pre-1.0 binding does what the app needs. Everything in seam 2 (and ~110 call
-   sites) rests on the answer.
+   pre-1.0 binding does what the app needs. ~110 call sites rest on the answer.
 2. **Auth + router + mount** (seam 1) — port `auth-context.tsx`, `_user.tsx`,
-   and one `$lang` loader. Contained, and it surfaces both the
-   `solid-router` binding and the mount-timing question (does the 1-second
-   race-dodge survive, or dissolve?).
-3. **The review feature** (seam 4) — Zustand to Solid `createStore`. Contained
-   to the review routes, and the clearest test of whether Solid's idioms come
-   out cleaner than the React originals.
+   and one `$lang` loader. Contained, and it exercises both the `solid-router`
+   binding and the mount-timing question.
+3. **The review feature** (seam 4) — Zustand to Solid `createStore`. Contained,
+   and the clearest test of whether Solid's idioms come out cleaner.
 
-Each is small, self-contained, and load-bearing — together they convert the
-biggest unknowns in this report into observed facts.
+A fourth, optional, would settle the §1 unknown directly: port a handful of
+`src/components/ui/` wrappers onto Kobalte and measure the chunk — that turns
+the ±40 KB Base-UI guess into a number.

--- a/.claude/skills/react-to-solid-feasibility/reference/dependency-registry.md
+++ b/.claude/skills/react-to-solid-feasibility/reference/dependency-registry.md
@@ -1,0 +1,116 @@
+# Dependency landing zones: React to SolidJS
+
+A verified snapshot of where common React-ecosystem dependencies land in the
+SolidJS ecosystem. **Snapshot date: 2026-05.** The Solid ecosystem moves; when
+you use this, re-verify maturity for anything load-bearing (npm last-publish
+date, GitHub stars and last commit, version number).
+
+Four buckets, by the quality of the landing zone:
+
+- **A — Keep.** Framework-agnostic. Zero change.
+- **B — Swap, clear leader.** Must change, but there is one obvious target.
+- **C — Swap, contested.** Must change, and the Solid space is fragmented or
+  unsettled — a real choice with no dominant winner.
+- **D — No direct equivalent.** Rebuild on a different paradigm.
+
+## A — Keep (framework-agnostic, zero change)
+
+Anything with no React coupling carries over untouched. Common members:
+
+- **Validation / data:** `zod`, `valibot`, `yup`
+- **Dates:** `dayjs`, `date-fns`, `luxon`
+- **Utility:** `lodash`, `clsx`, `tailwind-merge`, `class-variance-authority`
+- **Styling:** `tailwindcss` and its plugins, `tailwindcss-animate`, plain CSS
+- **Backend SDKs:** `@supabase/supabase-js`, `firebase`, REST/GraphQL clients
+- **Algorithms / domain logic:** anything pure-TS (e.g. `ts-fsrs`)
+- **Fonts, icons-as-data, i18n message catalogs**
+
+Heuristic: if it never imports `react` and emits no JSX, it is bucket A.
+
+## B — Swap, clear leader (one obvious target)
+
+| React                                   | Solid target              | Notes                                                                                                                                                        |
+| --------------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `react` + `react-dom`                   | `solid-js`                | The runtime. ~7 KB gzip vs ~44 KB.                                                                                                                           |
+| `@vitejs/plugin-react`                  | `vite-plugin-solid`       | Official, mature, drop-in plugin swap.                                                                                                                       |
+| `babel-plugin-react-compiler`           | _(deleted)_               | Solid has no re-render to memoize. The compiler's whole job vanishes; remove it, no port.                                                                    |
+| `@tanstack/react-query`                 | `@tanstack/solid-query`   | Same monorepo. `useQuery` takes a thunk; data is a signal. Near drop-in.                                                                                     |
+| `@tanstack/react-router`                | `@tanstack/solid-router`  | Same file-based concepts (`loader`, `beforeLoad`, context). Route files are a real rewrite; the Solid binding is younger than the React one.                 |
+| `@tanstack/react-table`                 | `@tanstack/solid-table`   | Shared headless core; only the adapter differs.                                                                                                              |
+| `@tanstack/react-virtual`               | `@tanstack/solid-virtual` | Shared core. Near drop-in.                                                                                                                                   |
+| `@tanstack/react-form`                  | `@tanstack/solid-form`    | Same family. Near drop-in — the form library itself is _not_ a contested swap.                                                                               |
+| `@tanstack/react-db`                    | `@tanstack/solid-db`      | **Exists, but pre-1.0 and young — see the caveat below.**                                                                                                    |
+| `lucide-react`                          | `lucide-solid`            | Same icon monorepo. Drop-in.                                                                                                                                 |
+| `sonner`                                | `solid-sonner`            | Community; `toast()` API mirrors `sonner`. Pre-1.0.                                                                                                          |
+| `react-helmet` / head mgmt              | `@solidjs/meta`           | Official Solid-core. `<Title>`, `<Meta>`, `<Link>`.                                                                                                          |
+| `react-markdown`                        | `solid-markdown`          | Community port of `react-markdown`, tracks it reasonably closely.                                                                                            |
+| `@uidotdev/usehooks` & ad-hoc hook libs | `@solid-primitives/*`     | The `solid-primitives` org is a broad, curated, officially-blessed catalog (storage, intersection observer, scheduled/debounce, media, etc.). Port per-hook. |
+
+## C — Swap, contested (a real choice, no dominant winner)
+
+### UI primitives (Radix / Base UI)
+
+There is **no Solid port of Base UI or Radix.** Base UI (`@base-ui/react`,
+the MUI-team unstyled library) and Radix are React-only. The Solid space has
+three credible options and no single default:
+
+- **Kobalte** (`@kobalte/core`) — the closest analog to Radix; the de-facto
+  community choice for accessible Solid primitives. Most-used, but community-
+  maintained and not fast-moving.
+- **Corvu** — a complementary set of unstyled primitives (drawer, popover,
+  etc.); often used _alongside_ Kobalte rather than instead of it.
+- **Ark UI** (`@ark-ui/solid`) — by the Chakra team, built on Zag.js finite-
+  state machines. Notably it exposes the **same component API for React and
+  Solid** (and Vue/Svelte). If a team is willing to leave Base UI/Radix
+  anyway, this is the lowest-friction primitive layer and the one place the
+  migration can be made nearly mechanical.
+
+Call this out as a genuine decision, not a swap.
+
+### The ShadCN layer
+
+ShadCN is copy-paste React components over Radix. Solid analogs:
+`shadcn-solid` (built on Kobalte + Corvu) and `solid-ui`. Both are community,
+unofficial, and **less complete and slower-moving than React ShadCN.** Expect
+to port some components by hand regardless.
+
+### Other contested swaps
+
+| React                      | Solid space                                                                        | Character                                                                                             |
+| -------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `react-hook-form`          | `@modular-forms/solid` (modern, recommended) vs `felte` (older, quieter)           | Real rewrite; pick one. _(If the app uses TanStack Form, that is bucket B — `@tanstack/solid-form`.)_ |
+| `framer-motion` / `motion` | `solid-motionone` (active) + `solid-transition-group`; `@motionone/solid` is stale | Usable for enter/exit and basic motion; **no `framer-motion`-grade layout-animation peer.**           |
+| `vaul` (drawer)            | Corvu drawer, or Kobalte                                                           | No direct port; re-implement on a Solid primitive.                                                    |
+| `cmdk` (command menu)      | `cmdk-solid`, or build on Kobalte                                                  | Small, thinly maintained ports; wonky.                                                                |
+| `react-i18next`            | `@solid-primitives/i18n`                                                           | Lightweight; lacks i18next's plugin ecosystem (ICU, backends).                                        |
+| `react-dnd`                | `@thisbeyond/solid-dnd`                                                            | Different API; a rewrite.                                                                             |
+
+## D — No direct equivalent (rebuild on a different paradigm)
+
+- **Charting — `recharts`, `victory`, `nivo`.** Solid has no declarative-SVG
+  charting library equivalent to Recharts. The realistic path is `solid-chartjs`
+  (Chart.js, canvas) or an ECharts wrapper — a _different_ API and rendering
+  model. The chart layer is rebuilt, not ported. Usually contained (charts
+  cluster in a few stats/analytics views), so flag it as a soft wall, not a
+  blocker.
+- **Anything reaching into React internals** — `react-dom` APIs, fiber-aware
+  libraries, `react-test-renderer`, `@testing-library/react`. No port; needs a
+  Solid-native counterpart (`@solidjs/testing-library`).
+- **React-specific devtools / profilers** — replace with Solid devtools.
+
+## The TanStack DB caveat
+
+`@tanstack/solid-db` exists and is official, but it is **pre-1.0 and young**
+relative to `@tanstack/react-db`. For an app whose entire reactive data layer
+runs through TanStack DB collections and `useLiveQuery`, this is the single
+highest-risk binding in the whole migration — not because it is missing, but
+because it is new. Always recommend an early, isolated spike against it.
+
+## Classifying a dependency not listed here
+
+1. Does it import `react` / emit JSX? **No → bucket A.**
+2. Is it part of a framework-agnostic family with an official Solid adapter
+   (TanStack, etc.)? **Yes → bucket B.**
+3. Search `npm` for `solid-<name>` / `@<scope>/solid-*`. One actively-
+   maintained option → **B**. Several, or all thin/stale → **C**.
+4. Nothing credible → **D**; describe what rebuilding it would mean.

--- a/.claude/skills/react-to-solid-feasibility/reference/solid-2-semantic-map.md
+++ b/.claude/skills/react-to-solid-feasibility/reference/solid-2-semantic-map.md
@@ -1,0 +1,103 @@
+# React to SolidJS 2.0: the primitive-level map
+
+How React building blocks translate to SolidJS 2.0. Each item is tagged:
+
+- **MECHANICAL** — a codemod could do it; a rename or a fixed transformation.
+- **JUDGMENT** — needs a human or AI to reason about intent; the trap-prone
+  work where a migration's real cost lives.
+
+This map exists to _characterize_ the per-component rewrite and to make the
+seam narratives concrete. Do not turn the tag counts into an effort estimate.
+
+## The one idea behind all of it
+
+React re-runs a component function on every render; SolidJS runs each
+component function **once** and wires fine-grained reactivity into the parts
+that change. Almost every trap below is a corollary of that single difference.
+
+## Hooks to primitives
+
+| React                          | Solid 2.0                                                                          | Tag        | Trap                                                                                                                                                             |
+| ------------------------------ | ---------------------------------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useState`                     | `createSignal`                                                                     | JUDGMENT   | The getter is a _function call_: `count` becomes `count()`. Every read site changes, and only reads inside a tracking scope (JSX, effects, memos) stay reactive. |
+| `useEffect`                    | `createEffect` (in 2.0, split into a tracked `compute` phase and an `apply` phase) | JUDGMENT   | No dependency array — dependencies are auto-tracked from what is read _synchronously_. Reads after an `await` are not tracked: silent reactivity loss.           |
+| `useEffect(fn, [])` "run once" | `onMount` / 2.0 `onSettled`                                                        | MECHANICAL | —                                                                                                                                                                |
+| `useMemo`                      | `createMemo`                                                                       | MECHANICAL | Drop the dependency array.                                                                                                                                       |
+| `useCallback`                  | _(delete)_                                                                         | MECHANICAL | Components run once; function identity is already stable.                                                                                                        |
+| `useRef` (value box)           | a plain `let` variable                                                             | JUDGMENT   | If `.current` was _read during render_, it must become a signal instead.                                                                                         |
+| `useRef` (DOM)                 | `let el; <div ref={el}>`                                                           | MECHANICAL | Different mechanism, simple shape.                                                                                                                               |
+| `useContext`                   | `createContext` + `useContext`                                                     | MECHANICAL | Near-identical API.                                                                                                                                              |
+| `useReducer`                   | `createStore` + a dispatch function                                                | JUDGMENT   | No built-in `useReducer`; hand-roll the pattern.                                                                                                                 |
+| `useSyncExternalStore`         | a signal / store wrapping the external source                                      | JUDGMENT   | Solid subscribes natively; the React shim disappears.                                                                                                            |
+| custom hooks                   | "composables" — plain functions returning signals/stores                           | JUDGMENT   | Must obey call-once. Conditional/looped calls are _legal_ in Solid, but logic that assumed per-render re-execution must be rewritten.                            |
+
+## The reactivity-model traps (all JUDGMENT)
+
+- **Components run once.** Code that recomputed a derived value in the body on
+  each render must move into a `createMemo` or an accessor function.
+- **Never destructure props.** Props are reactive getters. `const { x } = props`
+  reads once and freezes it. Use `props.x` directly; `splitProps` to split
+  reactively; `mergeProps` for defaults. Spreading props through `Object.assign`
+  also breaks reactivity.
+- **No stale-closure bug class** (no dependency arrays) — but a new trap:
+  reading a signal _outside_ a tracking scope yields a one-time snapshot.
+
+## JSX and control flow
+
+| React                | Solid                                                    | Tag        | Notes                                                                                                                                                                                 |
+| -------------------- | -------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `{cond && <X/>}`     | `<Show when={cond()}>`                                   | JUDGMENT   | Raw `&&` won't re-evaluate; also handle falsy `0`/`''`.                                                                                                                               |
+| `{list.map(...)}`    | `<For>` (keyed by reference) or `<For keyed={false}>`    | JUDGMENT   | In 2.0 `<Index>` is removed; `<For keyed={false}>` replaces it. Choose `<For>` for reorderable lists, `keyed={false}` for fixed-position/primitive lists. Children receive accessors. |
+| ternary chains       | `<Switch>` / `<Match>`                                   | JUDGMENT   | —                                                                                                                                                                                     |
+| `className`          | `class` (plus `classList`)                               | MECHANICAL | —                                                                                                                                                                                     |
+| `<>...</>` fragments | same                                                     | MECHANICAL | —                                                                                                                                                                                     |
+| `createPortal`       | `<Portal>`                                               | MECHANICAL | —                                                                                                                                                                                     |
+| `<Suspense>`         | `<Suspense>`, reworked in 2.0 (`isPending`, `<Loading>`) | JUDGMENT   | Semantics differ; data-driven suspense needs review.                                                                                                                                  |
+| `ErrorBoundary`      | `<ErrorBoundary>`                                        | MECHANICAL | —                                                                                                                                                                                     |
+| `React.lazy`         | `lazy()`                                                 | MECHANICAL | —                                                                                                                                                                                     |
+| event handlers       | `onClick` etc., delegated; `on:` for native              | MECHANICAL | Mostly identical.                                                                                                                                                                     |
+
+## State management
+
+- **Signals** for atomic values; **`createStore`** (a proxy) for nested
+  objects/arrays with fine-grained per-property updates. Choosing between them
+  is JUDGMENT.
+- React `useState(object)` often becomes a `createStore`. `useReducer` + Context
+  becomes `createStore` + a provider. **Zustand** becomes a module-level Solid
+  store — and Solid stores live happily outside components with no provider
+  ceremony, so this is frequently a _cleaner_ result, not just a port.
+
+## Genuinely hard — no clean analog (all JUDGMENT)
+
+- **`forwardRef` / `useImperativeHandle`.** No equivalent. `ref` is just a prop
+  you may call: `props.ref?.(api)`. It works, but every imperative-handle
+  component is hand-rewritten.
+- **Render props / HOCs.** Render props mostly work if they respect call-once.
+  HOCs that wrap-and-re-render are an anti-pattern in Solid; rethink as
+  primitives or `<Dynamic>`.
+- **Suspense-for-data.** Solid 2.0 reworks Suspense around first-class async;
+  data-fetching layers tied to React Suspense need real rethinking.
+- Anything depending on VDOM reconciliation, key-based remounting, or
+  `StrictMode` double-invocation.
+
+## React Compiler
+
+`babel-plugin-react-compiler` auto-inserts memoization to skip re-renders
+_within React's component-re-execution model_. Solid has **no re-execution to
+skip** — fine-grained reactivity updates DOM nodes directly. So the compiler's
+entire job is unnecessary in Solid. Practical consequences for a migration:
+
+- The compiler config and any `babel`/plugin wiring is **deleted**, not ported.
+- A React-Compiler codebase tends to carry _less_ manual `useMemo`/`useCallback`
+  bloat, which makes it marginally _easier_ to migrate.
+- `useCallback` disappears entirely; most `useMemo` does too.
+
+## Solid 2.0 specifics to keep in mind
+
+- `createEffect` is split into a tracked `compute` phase and an `apply` phase.
+- `<Index>` is removed — use `<For keyed={false}>`.
+- `onMount` gains `onSettled` (can return cleanup).
+- First-class async: memos/computations may return Promises; the graph
+  suspends and resumes; Suspense is reworked. For SPA package-level analysis
+  this is a _forward consideration_ — name it, don't model it.
+- Solid 2.0 is recent. Treat 2.0-specific guidance as projection, and say so.

--- a/.claude/skills/react-to-solid-feasibility/reference/system-archetypes.md
+++ b/.claude/skills/react-to-solid-feasibility/reference/system-archetypes.md
@@ -1,0 +1,129 @@
+# Architectural seam archetypes
+
+A React SPA is not a uniform mass of components — it is a handful of
+_systems_, each with its own migration character. This catalog lists the
+archetypal seams and how each tends to port to SolidJS. Use it to structure
+the report's system-by-system reconnaissance.
+
+For each seam present in the target repo, write a short narrative covering:
+
+- **Carries over** — what survives with little change.
+- **Needs examination** — the specific parts where React/library quirks are
+  load-bearing and the port is uncertain.
+- **Cause for optimism / pessimism** — honestly. Solid's idioms are sometimes
+  cleaner than the React original; sometimes they are genuinely worse or
+  immature. Say which.
+- **Contained or sprawling** — is this seam a small set of files (a good early
+  spike) or diffuse across the whole app?
+
+Do not score or time-estimate. Narrate.
+
+## 1. Auth → router → mounting → context → data-loader
+
+The wiring from "is the user logged in" through route guards, the router's
+context object, app mount order, and route loaders that preload data. In React
+this is usually a tangle of `AuthProvider` + `onAuthStateChange` +
+`useLayoutEffect` + router `beforeLoad`/`loader` + a context object threaded
+through routes.
+
+- **Carries over:** if the router is TanStack Router, `@tanstack/solid-router`
+  keeps the same `loader` / `beforeLoad` / route-context concepts — the
+  _router_ part of the seam is a recognizable rewrite, not a redesign.
+- **Needs examination:** the auth provider and _mount ordering_ — `useLayoutEffect`
+  timing, the race between auth resolution and the first data fetch, what
+  exactly is ready before the first protected route renders.
+- **Cause for optimism:** Solid's `createResource` + context + `onMount` often
+  expresses "load auth, then gate, then preload" _more cleanly_ than the React
+  effect-timing dance. There is reasonable cause to expect this goes smoothly.
+- **Contained:** usually yes — a few files. An ideal early spike: it surfaces
+  router-binding and mount-timing rough edges before any broad commitment.
+
+## 2. The data / sync layer
+
+The reactive data backbone: TanStack DB collections + live queries, or React
+Query, or SWR, or RTK Query, or a hand-rolled store.
+
+- **TanStack Query / Table / Virtual:** official Solid bindings, near drop-in.
+- **TanStack DB:** `@tanstack/solid-db` exists but is pre-1.0 — the highest-
+  risk binding when the _whole app_ depends on it. The reactivity model itself
+  maps _naturally_ to Solid signals (often more naturally than to React), so
+  the concern is binding maturity, not conceptual fit.
+- **Redux / Zustand / Jotai:** see seam 3.
+- **Needs examination:** every `useLiveQuery` / `useQuery` call site changes
+  shape (thunks, signal access). Sprawling — this seam usually touches the
+  most files of any. Recommend an isolated spike on the binding first.
+
+## 3. Global state stores
+
+Zustand, Redux, Jotai, Valtio, or Context-as-store.
+
+- **Carries over:** the _shape_ of the state and the actions.
+- **Cause for optimism:** Solid's `createStore` is fine-grained and lives
+  outside the component tree with no provider ceremony. Zustand/Redux stores
+  frequently become _simpler_ in Solid — this seam often improves.
+- **Needs examination:** any store wrapped in React Context purely for
+  injection (the Context wrapper may simply disappear); middleware,
+  persistence, and selector-based subscription patterns.
+- **Contained:** usually — store files are few and central.
+
+## 4. Forms
+
+- **TanStack Form** → `@tanstack/solid-form`, same family — a clean swap.
+- **react-hook-form** → `@modular-forms/solid` or `felte` — a real rewrite into
+  a different API (contested space).
+- **Needs examination:** any shared form abstraction (a `useAppForm` wrapper,
+  field-component registry, `withForm`-style HOC) is ported once; individual
+  forms then follow a repeatable pattern.
+- **Contained-ish:** the abstraction is central; the forms themselves are
+  many but repetitive.
+
+## 5. The UI primitive layer
+
+Radix / Base UI primitives + a ShadCN-style wrapper set.
+
+- **No port exists** for Radix or Base UI — pick Kobalte, Corvu, or Ark UI
+  (see the dependency registry). This is a genuine architectural decision.
+- **Character:** sprawling but _shallow_ — many small wrapper files, each a
+  self-contained port. Low conceptual risk, high file count. Not a spike
+  candidate (no single rough edge); rather a steady body of work.
+- **Cause for optimism:** Ark UI offers the same API on React and Solid, which
+  can make this seam nearly mechanical _if_ the team accepts leaving Base UI.
+
+## 6. Charting / data visualization
+
+- **No declarative-SVG equivalent** in Solid (see registry bucket D). Rebuild
+  on `solid-chartjs` or ECharts — a different rendering model.
+- **Usually contained:** charts cluster in a few analytics/stats views. Flag
+  as a soft wall, scoped to those files.
+
+## 7. Realtime / websockets
+
+Supabase channels, raw WebSockets, Pusher, socket.io.
+
+- **Carries over almost entirely:** the client SDKs are framework-agnostic.
+  The only React-specific part is the `useEffect` subscribe/unsubscribe, which
+  becomes `onMount` / `onCleanup`.
+- **Cause for optimism:** trivial seam. Often the easiest thing in the report.
+
+## 8. Animation
+
+- **framer-motion** has no full peer; `solid-motionone` + `solid-transition-group`
+  cover enter/exit and basic motion. Complex layout/shared-element animation
+  needs rethinking. Scope it to where the heavy animation actually is.
+
+## 9. Code-splitting, lazy, Suspense
+
+- `React.lazy` → `lazy()`; `<Suspense>` exists but is **reworked in Solid 2.0**.
+- **Needs examination:** anywhere Suspense is doing _data_ orchestration rather
+  than just code-split loading.
+
+## 10. Imperative escape hatches
+
+`forwardRef`, `useImperativeHandle`, `createPortal`, direct DOM refs, focus
+management.
+
+- **Portals** map cleanly (`<Portal>`).
+- **`forwardRef` / `useImperativeHandle`** have no analog — each is hand-
+  rewritten (`ref` is just a callable prop). Grep for these; a high count in
+  one seam makes that seam harder. Usually they cluster in the UI primitive
+  layer, so they fold into seam 5.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ supabase start
 supabase db reset
 ```
 
+**Build environment — `.env` must be populated before any production build.** `src/lib/supabase-client.ts` throws when `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` are unset. A `vite build` with those vars missing does **not** error — instead the guard constant-folds to `if (true) throw`, the `createClient()` call below it becomes dead code, and the bundler silently tree-shakes out the **entire `@supabase/*` SDK (~640 KB)**. The build "succeeds" but ships without Supabase, and any bundle-size measurement is off by roughly a third. Always build with `.env` populated — dummy-but-truthy `VITE_*` values are enough, the build never connects — and sanity-check that large expected dependencies actually appear in `dist/` (e.g. `grep -l GoTrueClient dist/assets/*.js`). The same applies to any tooling that builds the app, including bundle analyzers.
+
 ### Development
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds `react-to-solid-feasibility`, a **report-only** Claude Code skill that assesses migrating a React single-page app to SolidJS 2.0. It builds the app, measures the bundle and attributes kilobytes to packages, projects the SolidJS bundle from default dependency replacements, and narrates the architectural seams a migration would touch. It produces *information*, not a go/no-go verdict, and does not estimate effort in time.
- Ships a verified dependency landing-zone registry, a React→Solid 2.0 primitive map (mechanical vs judgment), a catalog of seam archetypes, and a worked example report run against this repo (`examples/sunlo-report.md`).
- `CLAUDE.md`: documents a build-environment gotcha surfaced while building the skill — a `vite build` with `VITE_SUPABASE_*` unset silently dead-code-eliminates the entire `@supabase/*` SDK (~640 KB), so any bundle measurement must use a credentialed build.

All changes are markdown under `.claude/skills/` plus a 2-line `CLAUDE.md` note. No migration files touched — fast-track per the deployment strategy.

## Test plan

- [ ] Skill appears in the skills list and is invocable as `/react-to-solid-feasibility`
- [ ] Markdown-only change; no application code touched — `pnpm build` / `pnpm check` unaffected

https://claude.ai/code/session_013kRvd8M9EnUNUjXPLv4di6

---
_Generated by [Claude Code](https://claude.ai/code/session_013kRvd8M9EnUNUjXPLv4di6)_