### PR TITLE
Add scenetest coverage for the password-reset flow

### DIFF
--- a/scenetest/TEST_IDS.md
+++ b/scenetest/TEST_IDS.md
@@ -45,26 +45,28 @@ natural wrapper element to label.
 
 ## Authentication & Navigation
 
-| Selector                          | Attribute   | Component/Location     | Description                                                 |
-| --------------------------------- | ----------- | ---------------------- | ----------------------------------------------------------- |
-| `login-link`                      | data-testid | Sidebar                | Link to login page for logged-out users                     |
-| `login-form`                      | data-testid | Login page             | The login form container                                    |
-| `login-signup-link`               | data-testid | Login page             | "Create account" link to /signup                            |
-| `login-forgot-password-link`      | data-testid | Login page             | "Forgot password?" link to /forgot-password                 |
-| `login-error-invalid-credentials` | data-testid | Login page             | One-line error shown when the email/password don't match    |
-| `reset-link-invalid`              | data-testid | Set-new-password page  | Card shown when the recovery link is invalid or expired     |
-| `request-new-link`                | data-testid | Set-new-password page  | Link to /forgot-password from the invalid-link card         |
-| `email-input`                     | data-testid | Form fields            | Email input                                                 |
-| `password-input`                  | data-testid | Form fields            | Password input                                              |
-| `submit-button`                   | data-testid | Form submit            | Generic submit button (scope by parent form when ambiguous) |
-| `welcome-page`                    | data-testid | Welcome route          | Welcome page container                                      |
-| `community-norms-dialog`          | data-testid | Welcome page           | Community norms intro dialog                                |
-| `affirm-community-norms-button`   | data-testid | Community norms dialog | Button to affirm norms                                      |
-| `sunlo-welcome-explainer`         | data-testid | Welcome page           | Welcome content after affirming                             |
-| `go-to-decks-link`                | data-testid | Welcome page           | Link to /learn                                              |
-| `sidebar-profile-settings-link`   | data-testid | Sidebar                | Avatar row that links to /profile (Profile & settings)      |
-| `sidebar-display-settings-link`   | data-testid | Sidebar                | Unauthenticated link to /profile (Display settings)         |
-| `profile-signout-button`          | data-testid | Profile page           | Sign out button at bottom of profile page                   |
+| Selector                          | Attribute   | Component/Location     | Description                                                   |
+| --------------------------------- | ----------- | ---------------------- | ------------------------------------------------------------- |
+| `login-link`                      | data-testid | Sidebar                | Link to login page for logged-out users                       |
+| `login-form`                      | data-testid | Login page             | The login form container                                      |
+| `login-signup-link`               | data-testid | Login page             | "Create account" link to /signup                              |
+| `login-forgot-password-link`      | data-testid | Login page             | "Forgot password?" link to /forgot-password                   |
+| `login-error-invalid-credentials` | data-testid | Login page             | One-line error shown when the email/password don't match      |
+| `reset-link-invalid`              | data-testid | Set-new-password page  | Card shown when the recovery link is invalid or expired       |
+| `request-new-link`                | data-testid | Set-new-password page  | Link to /forgot-password from the invalid-link card           |
+| `forgot-password-form`            | data-testid | Forgot-password page   | Recovery-request form (scope `email-input` / `submit-button`) |
+| `password-reset-form`             | data-testid | Set-new-password page  | New-password form (scope `password-input` / `submit-button`)  |
+| `email-input`                     | data-testid | Form fields            | Email input                                                   |
+| `password-input`                  | data-testid | Form fields            | Password input                                                |
+| `submit-button`                   | data-testid | Form submit            | Generic submit button (scope by parent form when ambiguous)   |
+| `welcome-page`                    | data-testid | Welcome route          | Welcome page container                                        |
+| `community-norms-dialog`          | data-testid | Welcome page           | Community norms intro dialog                                  |
+| `affirm-community-norms-button`   | data-testid | Community norms dialog | Button to affirm norms                                        |
+| `sunlo-welcome-explainer`         | data-testid | Welcome page           | Welcome content after affirming                               |
+| `go-to-decks-link`                | data-testid | Welcome page           | Link to /learn                                                |
+| `sidebar-profile-settings-link`   | data-testid | Sidebar                | Avatar row that links to /profile (Profile & settings)        |
+| `sidebar-display-settings-link`   | data-testid | Sidebar                | Unauthenticated link to /profile (Display settings)           |
+| `profile-signout-button`          | data-testid | Profile page           | Sign out button at bottom of profile page                     |
 
 ## Deck Management
 

--- a/scenetest/scenes/password-reset.spec.md
+++ b/scenetest/scenes/password-reset.spec.md
@@ -1,0 +1,31 @@
+# the login page links to the forgot-password form
+
+visitor:
+
+- openTo /login
+- see login-forgot-password-link
+- click login-forgot-password-link
+- up
+- see forgot-password-form
+- see email-input
+- see submit-button
+
+# set-new-password without a recovery session shows the invalid-link card
+
+visitor:
+
+- openTo /set-new-password
+- up
+- see reset-link-invalid
+- see request-new-link
+- notSee password-reset-form
+
+# an expired recovery link surfaces the error instead of a doomed form
+
+visitor:
+
+- openTo /set-new-password#error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired
+- up
+- see reset-link-invalid
+- seeText Email link is invalid or has expired
+- notSee password-reset-form

--- a/scenetest/scenes/password-reset.spec.ts
+++ b/scenetest/scenes/password-reset.spec.ts
@@ -1,0 +1,77 @@
+// Happy-path coverage for the password-reset flow. Markdown can't drive this:
+// it needs a recovery link minted server-side. The admin API's generateLink
+// returns the link without dispatching an email, so this works in CI where
+// the Inbucket mail catcher is disabled. We point the browser at the link,
+// set a new password, and confirm that password actually works for signing in.
+//
+// A throwaway user is created and torn down per run, so no shared seed actor's
+// password is disturbed.
+
+import { test } from '@scenetest/scenes'
+import { createClient } from '@supabase/supabase-js'
+import type { Database } from '../../src/types/supabase'
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL ?? 'http://127.0.0.1:54321'
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!
+
+const admin = createClient<Database>(SUPABASE_URL, SERVICE_KEY)
+
+const TEST_EMAIL = 'sunloapp+pwreset@gmail.com'
+const NEW_PASSWORD = 'a-freshly-chosen-password'
+
+async function deleteTestUser() {
+	const { data } = await admin.auth.admin.listUsers()
+	const existing = data.users.find((u) => u.email === TEST_EMAIL)
+	if (existing) await admin.auth.admin.deleteUser(existing.id)
+}
+
+test('a recovery link lets the user set a new password', async ({ actor }) => {
+	const user = await actor('visitor')
+
+	// Fresh throwaway user — drop any leftover from a failed prior run first.
+	await deleteTestUser()
+	const { error: createError } = await admin.auth.admin.createUser({
+		email: TEST_EMAIL,
+		password: 'the-password-being-reset',
+		email_confirm: true,
+	})
+	if (createError) throw createError
+
+	// Mint a recovery link the way the email flow would, then follow it.
+	const { data: link, error: linkError } = await admin.auth.admin.generateLink({
+		type: 'recovery',
+		email: TEST_EMAIL,
+		options: { redirectTo: 'http://localhost:5173/set-new-password' },
+	})
+	if (linkError || !link.properties) {
+		throw linkError ?? new Error('generateLink returned no properties')
+	}
+
+	await user
+		.openTo(link.properties.action_link)
+		.up()
+		.see('password-reset-form')
+		.typeInto('password-input', NEW_PASSWORD)
+		.click('submit-button')
+		.up()
+		.seeToast('toast-success')
+		.do(async () => {
+			try {
+				// The reset only counts if the new password actually works for a
+				// fresh login. A separate client with persistSession off keeps
+				// this check self-contained.
+				const checkClient = createClient<Database>(SUPABASE_URL, SERVICE_KEY, {
+					auth: { persistSession: false, autoRefreshToken: false },
+				})
+				const { error } = await checkClient.auth.signInWithPassword({
+					email: TEST_EMAIL,
+					password: NEW_PASSWORD,
+				})
+				if (error) {
+					throw new Error(`new password rejected at login: ${error.message}`)
+				}
+			} finally {
+				await deleteTestUser()
+			}
+		})
+})


### PR DESCRIPTION
## Summary

Test coverage for the password-reset flow, following up the merged fix
"Surface password-reset errors instead of a doomed form" (`da0ed52`). That
fix shipped without specs — this PR adds them.

- **`password-reset.spec.md`** — markdown scenes for the error paths the fix
  introduced:
  - login → forgot-password navigation, form renders
  - `/set-new-password` with no recovery session → invalid-link card
  - an expired-link hash (`#error_code=otp_expired…`) → surfaces the error
    instead of a form that can only fail
- **`password-reset.spec.ts`** — TypeScript scene for the happy path: mints a
  recovery link with the admin API, follows it, sets a new password, and
  verifies that password works for a fresh sign-in. Runs on a throwaway user
  (created/deleted per run) so no shared actor is disturbed.
- **`TEST_IDS.md`** — registers `forgot-password-form` and `password-reset-form`.

## Notes

- `generateLink` returns the recovery link without dispatching an email, so
  the happy-path scene runs in CI without the Inbucket mail catcher. The
  actual `resetPasswordForEmail` → email-delivery step is intentionally not
  exercised — the forgot-password scene stops at rendering the form.
- Scenetest-only; no component changes.

## Test plan

- [ ] `pnpm scene scenetest/scenes/password-reset.spec.md`
- [ ] `pnpm scene scenetest/scenes/password-reset.spec.ts`

https://claude.ai/code/session_01KUKsez5tPBXMTpY4swoQPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUKsez5tPBXMTpY4swoQPF)_