### PR TITLE
Optimize bundle caching with vendor code splitting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -304,50 +304,110 @@ jobs:
       - name: Build PR branch
         run: pnpm build:test
 
-      - name: Measure PR bundle
-        run: |
-          PR_FILE=$(ls -S dist/assets/index-*.js | head -1)
-          echo "PR_RAW=$(stat -c%s "$PR_FILE")" >> $GITHUB_ENV
-          echo "PR_GZ=$(gzip -c "$PR_FILE" | wc -c)" >> $GITHUB_ENV
-
       - name: Build base branch
         run: |
           git worktree add /tmp/base-branch origin/${{ github.base_ref }}
           cd /tmp/base-branch
           pnpm install --frozen-lockfile --silent
           pnpm build:test
-          BASE_FILE=$(ls -S dist/assets/index-*.js | head -1)
-          echo "BASE_RAW=$(stat -c%s "$BASE_FILE")" >> $GITHUB_ENV
-          echo "BASE_GZ=$(gzip -c "$BASE_FILE" | wc -c)" >> $GITHUB_ENV
-          cd $GITHUB_WORKSPACE
-          git worktree remove --force /tmp/base-branch
 
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require('fs');
+            const path = require('path');
+            const zlib = require('zlib');
+
+            // Measure the eager-load JS of a built dist/ dir: the entry <script>
+            // plus every <link rel="modulepreload"> chunk listed in index.html.
+            const measure = (dist) => {
+              const html = fs.readFileSync(path.join(dist, 'index.html'), 'utf8');
+              const files = [...new Set(
+                [...html.matchAll(/assets\/[A-Za-z0-9._-]+\.js/g)].map((m) => m[0])
+              )];
+              let eagerRaw = 0, eagerGz = 0;
+              let index = { raw: 0, gz: 0 };
+              const vendors = {};
+              for (const rel of files) {
+                const buf = fs.readFileSync(path.join(dist, rel));
+                const raw = buf.length, gz = zlib.gzipSync(buf).length;
+                eagerRaw += raw; eagerGz += gz;
+                const name = rel.slice('assets/'.length);
+                if (name.includes('-vendor-')) {
+                  // strip Vite's trailing 8-char content hash for a stable key
+                  vendors[name.replace(/-[A-Za-z0-9_-]{8}\.js$/, '')] = { file: name, raw, gz };
+                } else if (name.startsWith('index-')) {
+                  index = { raw, gz };
+                }
+              }
+              return { eagerRaw, eagerGz, index, vendors };
+            };
+
+            const pr = measure('dist');
+            const base = measure('/tmp/base-branch/dist');
+
             const fmt = (n) => (n / 1024).toFixed(2) + ' kB';
-            const diff = (pr, base) => {
-              const d = pr - base;
-              const pct = base ? ((d / base) * 100).toFixed(2) : '0.00';
+            const diff = (p, b) => {
+              const d = p - b;
+              const pct = b ? ((d / b) * 100).toFixed(2) : '0.00';
               const sign = d > 0 ? '+' : '';
               const emoji = d > 0 ? '🔺' : d < 0 ? '🟢' : '➖';
               return `${emoji} ${sign}${(d / 1024).toFixed(2)} kB (${sign}${pct}%)`;
             };
-            const prRaw = parseInt(process.env.PR_RAW);
-            const prGz = parseInt(process.env.PR_GZ);
-            const baseRaw = parseInt(process.env.BASE_RAW);
-            const baseGz = parseInt(process.env.BASE_GZ);
+            const table = (pRaw, pGz, bRaw, bGz) => [
+              '|         | Base            | PR              | Δ                    |',
+              '|---------|-----------------|-----------------|----------------------|',
+              `| Raw     | ${fmt(bRaw).padEnd(15)} | ${fmt(pRaw).padEnd(15)} | ${diff(pRaw, bRaw)} |`,
+              `| Gzipped | ${fmt(bGz).padEnd(15)} | ${fmt(pGz).padEnd(15)} | ${diff(pGz, bGz)} |`,
+            ].join('\n');
+
+            // Vendor chunks compared by logical name — an identical hash means identical content.
+            const vendorNames = [...new Set([...Object.keys(base.vendors), ...Object.keys(pr.vendors)])].sort();
+            const changed = [];
+            const unchanged = [];
+            let unchangedRaw = 0, unchangedGz = 0;
+            for (const n of vendorNames) {
+              const b = base.vendors[n], p = pr.vendors[n];
+              if (b && p && b.file === p.file) {
+                unchanged.push(n);
+                unchangedRaw += p.raw;
+                unchangedGz += p.gz;
+              } else {
+                changed.push({ n, b, p });
+              }
+            }
+
+            let vendorSection;
+            if (vendorNames.length === 0) {
+              vendorSection = '_No vendor chunks in the eager set._';
+            } else if (changed.length === 0) {
+              vendorSection = `✅ **Vendor chunks unchanged** — ${unchanged.join(', ')} totalling `
+                + `${fmt(unchangedRaw)} raw (${fmt(unchangedGz)} gzipped), all still cached for repeat visitors.`;
+            } else {
+              const rows = changed.map(({ n, b, p }) => {
+                if (!b) return `- 🆕 \`${n}\` added — ${fmt(p.raw)} raw (${fmt(p.gz)} gz)`;
+                if (!p) return `- ❌ \`${n}\` removed — was ${fmt(b.raw)} raw`;
+                return `- 🔺 \`${n}\` — ${fmt(b.raw)} → ${fmt(p.raw)} raw (${diff(p.raw, b.raw)})`;
+              });
+              const stable = unchanged.length
+                ? `\n\n${unchanged.length} other vendor chunk(s) unchanged — ${fmt(unchangedRaw)} raw (${fmt(unchangedGz)} gz).`
+                : '';
+              vendorSection = `**Vendor chunks changed:**\n${rows.join('\n')}${stable}`;
+            }
 
             const body = [
               '### Main bundle size',
               '',
-              '`dist/assets/index-*.js` (largest chunk)',
+              '**Eager load** — entry chunk + every `modulepreload` in `index.html` (what a first paint downloads)',
               '',
-              '|         | Base            | PR              | Δ                    |',
-              '|---------|-----------------|-----------------|----------------------|',
-              `| Raw     | ${fmt(baseRaw).padEnd(15)} | ${fmt(prRaw).padEnd(15)} | ${diff(prRaw, baseRaw)} |`,
-              `| Gzipped | ${fmt(baseGz).padEnd(15)} | ${fmt(prGz).padEnd(15)} | ${diff(prGz, baseGz)} |`,
+              table(pr.eagerRaw, pr.eagerGz, base.eagerRaw, base.eagerGz),
+              '',
+              '**`index-*.js`** — the non-vendored entry chunk, re-downloaded on every deploy',
+              '',
+              table(pr.index.raw, pr.index.gz, base.index.raw, base.index.gz),
+              '',
+              vendorSection,
             ].join('\n');
 
             const marker = '### Main bundle size';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig(() => {
 					// Split rarely-changing deps into their own content-hashed
 					// chunks so repeat visitors keep them cached across the many
 					// app-code deploys that happen between dependency bumps.
-					advancedChunks: {
+					codeSplitting: {
 						groups: [
 							{
 								name: 'react-vendor',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,16 @@ export default defineConfig(() => {
 								name: 'supabase-vendor',
 								test: /[\\/]node_modules[\\/]@supabase[\\/]/,
 							},
+							{
+								name: 'markdown-vendor',
+								test: /[\\/]node_modules[\\/](react-markdown|unified|remark-[a-z-]+|rehype-[a-z-]+|micromark[a-z-]*|mdast-[a-z-]+|hast-[a-z-]+|unist-[a-z-]+|vfile[a-z-]*|property-information)[\\/]/,
+							},
+							{
+								// every lucide icon the app actually imports, in one
+								// chunk — tree-shaking still drops unused icons.
+								name: 'lucide-vendor',
+								test: /[\\/]node_modules[\\/]lucide-react[\\/]/,
+							},
 						],
 					},
 				},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,25 @@ export default defineConfig(() => {
 		},
 		build: {
 			chunkSizeWarningLimit: 750,
+			rollupOptions: {
+				output: {
+					// Split rarely-changing deps into their own content-hashed
+					// chunks so repeat visitors keep them cached across the many
+					// app-code deploys that happen between dependency bumps.
+					advancedChunks: {
+						groups: [
+							{
+								name: 'react-vendor',
+								test: /[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/,
+							},
+							{
+								name: 'supabase-vendor',
+								test: /[\\/]node_modules[\\/]@supabase[\\/]/,
+							},
+						],
+					},
+				},
+			},
 		},
 		envPrefix: ['VITE_'],
 		server: {


### PR DESCRIPTION
## Summary
Configures Vite's rollup output to split vendor dependencies into separate content-hashed chunks, allowing repeat visitors to keep rarely-changing libraries cached across app deployments.

## Changes
- Added `rollupOptions.output` configuration with vendor-specific code splitting groups:
  - **react-vendor**: React, ReactDOM, and scheduler — core framework dependencies
  - **supabase-vendor**: All `@supabase/*` packages — backend integration
  - **markdown-vendor**: Markdown processing ecosystem (remark, rehype, unified, micromark, etc.) — large but stable
  - **lucide-vendor**: Lucide React icons — tree-shaking still removes unused icons despite bundling

## Implementation Details
Each vendor group uses a regex pattern to match `node_modules` paths, ensuring dependencies are isolated into their own chunks with content hashing. This strategy keeps app code (which changes frequently) separate from stable dependencies, so returning users benefit from browser cache hits on vendor chunks across multiple deployments without waiting for re-downloads.

https://claude.ai/code/session_01LVpqGwtsPZw84KzNoUctyj