### PR TITLE
Hide right sidebar in focus mode when empty

### DIFF
--- a/src/components/navs/right-sidebar.tsx
+++ b/src/components/navs/right-sidebar.tsx
@@ -13,10 +13,12 @@ export function RightSidebar() {
 	)
 	const links = useLinks(contextMenu)
 	const fixedHeight = matches.some((m) => m.staticData.fixedHeight)
+	const focusMode = matches.some((m) => m.staticData.focusMode)
 
-	// In fixedHeight mode (chats, review), hide when empty to reclaim space.
+	// In fixedHeight (chats, review) and focusMode (onboarding) pages, hide when
+	// empty to reclaim space and keep content centred on the viewport.
 	// In default mode, render the empty placeholder for visual consistency.
-	if (!links?.length && fixedHeight) return null
+	if (!links?.length && (fixedHeight || focusMode)) return null
 
 	return (
 		<aside className="sticky top-4 hidden w-(--sidebar-width) shrink-0 self-start ps-8 pt-4 @3xl:block">


### PR DESCRIPTION
## Summary
Extends the right sidebar hide-when-empty behavior to focus mode pages (like onboarding), in addition to the existing fixed-height pages (chats, review).

## Changes
- Added `focusMode` detection from route static data, mirroring the existing `fixedHeight` check
- Updated the sidebar visibility condition to hide when empty in both `fixedHeight` and `focusMode` contexts
- Updated the comment to clarify that both modes benefit from hiding the empty sidebar to reclaim space and keep content centered

## Details
The right sidebar now respects the same empty-state hiding logic for focus mode pages as it does for fixed-height pages. This improves the onboarding experience by keeping content centered on the viewport when the sidebar has no links to display, rather than rendering an empty placeholder.

https://claude.ai/code/session_01J6aMheoYLAPX1HHzM5gkLF