### PR TITLE
Migrate playlists e2e spec to scenetest (issue #632)

### DIFF
--- a/scenetest/scenes/playlist-mutations.spec.ts
+++ b/scenetest/scenes/playlist-mutations.spec.ts
@@ -1,0 +1,89 @@
+import { test } from '@scenetest/scenes'
+import { createClient } from '@supabase/supabase-js'
+import type { Database } from '../../src/types/supabase'
+
+const supabase = createClient<Database>(
+	process.env.VITE_SUPABASE_URL ?? 'http://127.0.0.1:54321',
+	process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+test('learner deletes their playlist', async ({ actor, team }) => {
+	const lang = team.tags!.lang_full
+	const learner = await actor('learner')
+	const nonce = Date.now().toString(36)
+	const title = `Playlist to delete ${nonce}`
+	let playlistId = ''
+
+	try {
+		const { data: playlist } = await supabase
+			.from('phrase_playlist')
+			.insert({ lang, title, uid: learner.key })
+			.select()
+			.single()
+			.throwOnError()
+		playlistId = playlist!.id
+
+		await learner
+			.openTo('/login')
+			.typeInto('email-input', learner.email!)
+			.typeInto('password-input', learner.password!)
+			.click('submit-button')
+			.notSee('login-form')
+			.openTo(`/learn/${lang}/playlists/${playlistId}`)
+			.up()
+			.see('playlist-detail-page')
+			.seeText(title)
+			.click('delete-playlist-button')
+			.up()
+			.see('delete-playlist-dialog')
+			.click('confirm-delete-button')
+			.up()
+			.seeToast('toast-success')
+			// delete navigates back to the language home (deck feed)
+			.see('deck-feed-page')
+	} finally {
+		// Hard-delete; the UI does a soft-delete (deleted: true).
+		if (playlistId)
+			await supabase.from('phrase_playlist').delete().eq('id', playlistId)
+	}
+})
+
+test('a non-owner sees no owner controls on a playlist', async ({
+	actor,
+	team,
+}) => {
+	const lang = team.tags!.lang_full
+	const learner = await actor('learner')
+	const friend = await actor('friend')
+	const nonce = Date.now().toString(36)
+	const title = `Friend's playlist ${nonce}`
+	let playlistId = ''
+
+	try {
+		// A playlist owned by someone other than the viewing learner.
+		const { data: playlist } = await supabase
+			.from('phrase_playlist')
+			.insert({ lang, title, uid: friend.key })
+			.select()
+			.single()
+			.throwOnError()
+		playlistId = playlist!.id
+
+		await learner
+			.openTo('/login')
+			.typeInto('email-input', learner.email!)
+			.typeInto('password-input', learner.password!)
+			.click('submit-button')
+			.notSee('login-form')
+			.openTo(`/learn/${lang}/playlists/${playlistId}`)
+			.up()
+			.see('playlist-detail-page')
+			.seeText(title)
+			.notSee('update-playlist-button')
+			.notSee('delete-playlist-button')
+			.notSee('manage-phrases-button')
+	} finally {
+		if (playlistId)
+			await supabase.from('phrase_playlist').delete().eq('id', playlistId)
+	}
+})

--- a/scenetest/scenes/playlists.spec.md
+++ b/scenetest/scenes/playlists.spec.md
@@ -17,46 +17,6 @@ learner:
 - seeToast toast-success
 - seeText Test: Updated Playlist Title
 
-// # learner deletes their playlist
-//
-// learner:
-//
-// - login
-// - openTo /learn
-// - see decks-list-grid
-// - click [team.lang_full] deck-link
-// - up
-// - see deck-feed-page
-// - click feed-item-playlist
-// - up
-// - see playlist-detail-page
-// - up
-// - click delete-playlist-button
-// - see delete-playlist-dialog
-// - click confirm-delete-button
-// - up
-// - seeToast toast-success
-// - up
-// - see deck-feed-page
-
-// # non-owner cannot manage playlist
-//
-// learner:
-//
-// - openTo /login
-// - typeInto email-input [self.email]
-// - typeInto password-input [self.password]
-// - click submit-button
-// - openTo /learn
-// - see decks-list-grid
-// - click [team.lang_full] deck-link
-// - see deck-feed-page
-// - click other-user-playlist-item
-// - see playlist-detail-page
-// - notSee update-playlist-button
-// - notSee delete-playlist-button
-// - notSee manage-phrases-button
-
 // # learner adds phrase to playlist
 //
 // learner:


### PR DESCRIPTION
## Summary

Continues the `e2e/` → scenetest migration (issue #632). Ports `e2e/mutations/playlists.spec.ts` to the scenetest `test()` surface.

**This commit** — the two tests that need no component changes:

- **delete playlist** — create a playlist, delete it via the confirm dialog, land back on the deck feed
- **non-owner controls** — a playlist owned by another user shows no update/delete/manage buttons to a viewer who isn't the owner

The e2e "update playlist" test is already covered by `playlists.spec.md` ("learner edits their playlist"), so it is not re-ported.

## Still to come (this PR will grow)

`e2e/mutations/playlists.spec.ts` stays in place until the manage-phrases tests are ported:

- add a phrase to a playlist
- remove a phrase
- reorder phrases
- edit a phrase's timestamp href

Those need testids added first — the manage dialog's `HrefInput` has none, `SelectPhrasesForComment`'s search/checkbox/confirm internals have none, and `manage-phrase-card` repeats a `data-testid` per row rather than carrying a `data-key`. Follow-up commit.

## Test plan

- [ ] `pnpm scene scenetest/scenes/playlist-mutations.spec.ts` — two scenes pass against local dev + Supabase

https://claude.ai/code/session_018k6FdKokRrTsbHem6VeF44

---
_Generated by [Claude Code](https://claude.ai/code/session_018k6FdKokRrTsbHem6VeF44)_