### PR TITLE
Add deck setup dialog when bookmarking phrases without active deck

### DIFF
--- a/scenetest/TEST_IDS.md
+++ b/scenetest/TEST_IDS.md
@@ -122,40 +122,44 @@ natural wrapper element to label.
 
 ## Card Management
 
-| Selector                   | Attribute   | Component/Location | Description                                                                           |
-| -------------------------- | ----------- | ------------------ | ------------------------------------------------------------------------------------- |
-| `phrase-detail-page`       | data-testid | Phrase route       | Phrase detail page container                                                          |
-| `card-status-dropdown`     | data-testid | Phrase page        | Dropdown for card status                                                              |
-| `add-to-deck-option`       | data-testid | Status dropdown    | "Add to deck" option                                                                  |
-| `set-learned-option`       | data-testid | Status dropdown    | "Set learned" option                                                                  |
-| `ignore-card-option`       | data-testid | Status dropdown    | "Ignore card" option                                                                  |
-| `activate-card-option`     | data-testid | Status dropdown    | "Activate card" option                                                                |
-| `add-phrase-page`          | data-testid | Add phrase route   | Container for /learn/$lang/phrases/new                                                |
-| `add-phrase-form`          | data-testid | Add phrase route   | Form element (scope `phrase-text-input` / `translation-text-input` / `submit-button`) |
-| `bulk-add-link`            | data-testid | Add phrase page    | Link to bulk-add page                                                                 |
-| `add-translations-trigger` | data-testid | Big phrase card    | Pencil icon that opens the manage-translations dialog                                 |
-| `add-translations-dialog`  | data-testid | Dialog             | Manage-translations dialog (scope `translation-text-input` / `submit-button`)         |
-| `add-tags-trigger`         | data-testid | Big phrase card    | Tags icon that opens the edit-tags dialog                                             |
-| `add-tags-dialog`          | data-testid | Dialog             | Edit-tags dialog (contains `add-tags-form`)                                           |
-| `bulk-add-page`            | data-testid | Bulk add route     | Container for /learn/$lang/bulk-add                                                   |
-| `inline-add-bar`           | data-testid | Bulk add page      | Inline phrase/translation entry bar                                                   |
-| `inline-phrase-input`      | data-testid | Inline add bar     | Phrase text input                                                                     |
-| `inline-translation-input` | data-testid | Inline add bar     | Translation text input                                                                |
-| `inline-add-button`        | data-testid | Inline add bar     | Button that stages the typed phrase                                                   |
-| `empty-state-hint`         | data-testid | Bulk add page      | Hint shown when no phrases are staged                                                 |
-| `staged-phrases-list`      | data-testid | Bulk add page      | Container listing staged phrases                                                      |
-| `staged-count`             | data-testid | Bulk add page      | "N phrases ready" label                                                               |
-| `staged-phrase-text`       | data-testid | Staged phrase row  | Staged phrase native text                                                             |
-| `staged-translation-text`  | data-testid | Staged phrase row  | Staged phrase translation text                                                        |
-| `edit-staged-phrase`       | data-testid | Staged phrase row  | Opens the edit dialog for that row                                                    |
-| `remove-staged-phrase`     | data-testid | Staged phrase row  | Removes that row from the staging list                                                |
-| `clear-staged-phrases`     | data-testid | Bulk add page      | "Clear all" button — empties the staging list                                         |
-| `edit-phrase-text`         | data-testid | Edit phrase dialog | Phrase text input inside the edit dialog                                              |
-| `edit-translation-0`       | data-testid | Edit phrase dialog | First translation input inside the edit dialog                                        |
-| `edit-save-button`         | data-testid | Edit phrase dialog | Saves edits and closes the dialog                                                     |
-| `submit-staged-phrases`    | data-testid | Bulk add page      | Submits all staged phrases to the database                                            |
-| `success-section`          | data-testid | Bulk add page      | "Successfully Added" section after a submit                                           |
-| `success-phrase-list`      | data-testid | Success section    | List of newly created phrase cards                                                    |
+| Selector                        | Attribute   | Component/Location    | Description                                                                                                                 |
+| ------------------------------- | ----------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `phrase-detail-page`            | data-testid | Phrase route          | Phrase detail page container                                                                                                |
+| `card-status-dropdown`          | data-testid | Phrase page           | Dropdown for card status                                                                                                    |
+| `add-to-deck-option`            | data-testid | Status dropdown       | "Add to deck" option                                                                                                        |
+| `set-learned-option`            | data-testid | Status dropdown       | "Set learned" option                                                                                                        |
+| `ignore-card-option`            | data-testid | Status dropdown       | "Ignore card" option                                                                                                        |
+| `activate-card-option`          | data-testid | Status dropdown       | "Activate card" option                                                                                                      |
+| `card-status-heart`             | data-name   | Phrase tiny card      | Bookmark/heart toggle on phrase tiny cards (scope by `[data-key={phrase.id}]`)                                              |
+| `start-learning-dialog`         | data-testid | Dialog                | Yes/no dialog shown when bookmarking a phrase whose language you aren't learning yet (data-mode is "create" or "unarchive") |
+| `confirm-start-learning-button` | data-testid | Start-learning dialog | "Yes, start/restore and add" button                                                                                         |
+| `cancel-start-learning-button`  | data-testid | Start-learning dialog | "No, not now" button                                                                                                        |
+| `add-phrase-page`               | data-testid | Add phrase route      | Container for /learn/$lang/phrases/new                                                                                      |
+| `add-phrase-form`               | data-testid | Add phrase route      | Form element (scope `phrase-text-input` / `translation-text-input` / `submit-button`)                                       |
+| `bulk-add-link`                 | data-testid | Add phrase page       | Link to bulk-add page                                                                                                       |
+| `add-translations-trigger`      | data-testid | Big phrase card       | Pencil icon that opens the manage-translations dialog                                                                       |
+| `add-translations-dialog`       | data-testid | Dialog                | Manage-translations dialog (scope `translation-text-input` / `submit-button`)                                               |
+| `add-tags-trigger`              | data-testid | Big phrase card       | Tags icon that opens the edit-tags dialog                                                                                   |
+| `add-tags-dialog`               | data-testid | Dialog                | Edit-tags dialog (contains `add-tags-form`)                                                                                 |
+| `bulk-add-page`                 | data-testid | Bulk add route        | Container for /learn/$lang/bulk-add                                                                                         |
+| `inline-add-bar`                | data-testid | Bulk add page         | Inline phrase/translation entry bar                                                                                         |
+| `inline-phrase-input`           | data-testid | Inline add bar        | Phrase text input                                                                                                           |
+| `inline-translation-input`      | data-testid | Inline add bar        | Translation text input                                                                                                      |
+| `inline-add-button`             | data-testid | Inline add bar        | Button that stages the typed phrase                                                                                         |
+| `empty-state-hint`              | data-testid | Bulk add page         | Hint shown when no phrases are staged                                                                                       |
+| `staged-phrases-list`           | data-testid | Bulk add page         | Container listing staged phrases                                                                                            |
+| `staged-count`                  | data-testid | Bulk add page         | "N phrases ready" label                                                                                                     |
+| `staged-phrase-text`            | data-testid | Staged phrase row     | Staged phrase native text                                                                                                   |
+| `staged-translation-text`       | data-testid | Staged phrase row     | Staged phrase translation text                                                                                              |
+| `edit-staged-phrase`            | data-testid | Staged phrase row     | Opens the edit dialog for that row                                                                                          |
+| `remove-staged-phrase`          | data-testid | Staged phrase row     | Removes that row from the staging list                                                                                      |
+| `clear-staged-phrases`          | data-testid | Bulk add page         | "Clear all" button — empties the staging list                                                                               |
+| `edit-phrase-text`              | data-testid | Edit phrase dialog    | Phrase text input inside the edit dialog                                                                                    |
+| `edit-translation-0`            | data-testid | Edit phrase dialog    | First translation input inside the edit dialog                                                                              |
+| `edit-save-button`              | data-testid | Edit phrase dialog    | Saves edits and closes the dialog                                                                                           |
+| `submit-staged-phrases`         | data-testid | Bulk add page         | Submits all staged phrases to the database                                                                                  |
+| `success-section`               | data-testid | Bulk add page         | "Successfully Added" section after a submit                                                                                 |
+| `success-phrase-list`           | data-testid | Success section       | List of newly created phrase cards                                                                                          |
 
 ## Sidebar Navigation
 

--- a/src/components/card-pieces/card-status-dropdown.tsx
+++ b/src/components/card-pieces/card-status-dropdown.tsx
@@ -1,15 +1,26 @@
+import { useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
 import {
+	ArchiveRestore,
 	Bookmark,
 	BookmarkCheck,
 	BookmarkPlus,
 	BookmarkX,
 	ChevronDown,
 	PlusCircle,
+	Sparkles,
 } from 'lucide-react'
 
 import { useRequireAuth } from '@/hooks/use-require-auth'
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog'
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -19,13 +30,17 @@ import {
 import { useUserId } from '@/lib/use-auth'
 import {
 	useDecks,
+	useDeckMeta,
 	useMyCard,
 	type CardWithSibling,
 } from '@/features/deck/hooks'
+import languages from '@/lib/languages'
 import { Button } from '@/components/ui/button'
 import { phrasesCollection } from '@/features/phrases/collections'
-import { cardsCollection } from '@/features/deck/collections'
+import { cardsCollection, decksCollection } from '@/features/deck/collections'
 import { directionsForPhrase } from '@/features/deck/card-directions'
+import { postNewDeck } from '@/features/deck/mutations'
+import { DeckMetaSchema, type DeckMetaType } from '@/features/deck/schemas'
 import {
 	PhraseFullFilteredType,
 	PhraseFullFullType,
@@ -292,35 +307,185 @@ export function CardStatusHeart({
 }) {
 	const requireAuth = useRequireAuth()
 	const { data: card } = useMyCard(phrase.id)
+	const { data: deck } = useDeckMeta(phrase.lang)
 	const setCardStatus = useCardStatusMutator(phrase, card)
 	const statusToPost = card?.status === 'active' ? 'skipped' : 'active'
+
+	// FK constraint: user_card(uid, lang) → user_deck(uid, lang). No deck row
+	// would throw. An archived deck would technically satisfy the FK, but the
+	// card would land in a deck the user can't see — also wrong UX. Both cases
+	// route through the dialog.
+	const needsDeckSetup = !deck || deck.archived
+	const [dialogOpen, setDialogOpen] = useState(false)
+
 	return (
-		<Button
-			variant={card?.status === 'active' ? 'soft' : 'ghost'}
-			size="icon"
-			data-name="card-status-heart"
-			data-key={phrase.id}
-			onClick={(e) => {
-				e.preventDefault()
-				e.stopPropagation()
-				requireAuth(
-					() => setCardStatus(statusToPost),
-					'Please log in to add phrases to your library'
-				)
-			}}
-			aria-label={
-				card?.status === 'active'
-					? 'Skip this phrase (remove it from your active deck)'
-					: 'Learn this phrase (add to your active deck)'
-			}
-		>
-			<Bookmark
-				className={
+		<>
+			<Button
+				variant={card?.status === 'active' ? 'soft' : 'ghost'}
+				size="icon"
+				data-name="card-status-heart"
+				data-key={phrase.id}
+				onClick={(e) => {
+					e.preventDefault()
+					e.stopPropagation()
+					requireAuth(() => {
+						if (needsDeckSetup) {
+							setDialogOpen(true)
+						} else {
+							setCardStatus(statusToPost)
+						}
+					}, 'Please log in to add phrases to your library')
+				}}
+				aria-label={
 					card?.status === 'active'
-						? 'text-primary fill-current/50'
-						: 'text-muted-foreground'
+						? 'Skip this phrase (remove it from your active deck)'
+						: 'Learn this phrase (add to your active deck)'
 				}
-			/>
-		</Button>
+			>
+				<Bookmark
+					className={
+						card?.status === 'active'
+							? 'text-primary fill-current/50'
+							: 'text-muted-foreground'
+					}
+				/>
+			</Button>
+			{needsDeckSetup && (
+				<StartLearningDialog
+					open={dialogOpen}
+					onOpenChange={setDialogOpen}
+					lang={phrase.lang}
+					archivedDeck={deck?.archived ? deck : null}
+					onConfirmed={() => setCardStatus(statusToPost)}
+				/>
+			)}
+		</>
+	)
+}
+
+/**
+ * Yes/no dialog shown when the user taps the bookmark on a phrase whose
+ * language they aren't actively learning. Creates the deck (or unarchives an
+ * existing one) and then runs `onConfirmed` to add the card.
+ */
+function StartLearningDialog({
+	open,
+	onOpenChange,
+	lang,
+	archivedDeck,
+	onConfirmed,
+}: {
+	open: boolean
+	onOpenChange: (open: boolean) => void
+	lang: string
+	archivedDeck: DeckMetaType | null
+	onConfirmed: () => void
+}) {
+	const [pending, setPending] = useState(false)
+	const language = languages[lang] ?? lang
+	const isUnarchive = !!archivedDeck
+
+	const handleConfirm = async () => {
+		setPending(true)
+		try {
+			if (isUnarchive) {
+				const tx = decksCollection.update(lang, (draft) => {
+					draft.archived = false
+				})
+				await tx.isPersisted.promise
+			} else {
+				const row = await postNewDeck(lang)
+				decksCollection.utils.writeInsert(
+					DeckMetaSchema.parse({ ...row, language })
+				)
+			}
+			toastSuccess(
+				isUnarchive
+					? `Restored your ${language} deck`
+					: `Started a new ${language} deck`
+			)
+			onConfirmed()
+			onOpenChange(false)
+		} catch (err) {
+			console.error('StartLearningDialog: failed to set up deck', err)
+			toastError(
+				isUnarchive
+					? `Couldn't restore your ${language} deck`
+					: `Couldn't start a new ${language} deck`
+			)
+		} finally {
+			setPending(false)
+		}
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent
+				data-testid="start-learning-dialog"
+				data-key={lang}
+				data-mode={isUnarchive ? 'unarchive' : 'create'}
+				className="max-w-md"
+			>
+				<DialogHeader>
+					<DialogTitle>
+						{isUnarchive
+							? `Restore your ${language} deck?`
+							: `Start learning ${language}?`}
+					</DialogTitle>
+					<DialogDescription>
+						{isUnarchive
+							? `You have an archived ${language} deck. Restore it and add this phrase to start learning again.`
+							: `You aren't learning ${language} yet. Start a new deck and add this phrase?`}
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="grid grid-cols-1 gap-3 @sm:grid-cols-2">
+					<button
+						type="button"
+						onClick={() => void handleConfirm()}
+						disabled={pending}
+						data-testid="confirm-start-learning-button"
+						className="from-5-mhi-primary to-6-mid-primary text-primary-foreground hover:from-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 text-start shadow transition-transform hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-70"
+					>
+						{isUnarchive ? (
+							<ArchiveRestore className="size-6" />
+						) : (
+							<Sparkles className="size-6" />
+						)}
+						<div>
+							<div className="text-base leading-tight font-semibold">
+								{pending
+									? isUnarchive
+										? 'Restoring…'
+										: 'Starting…'
+									: isUnarchive
+										? 'Yes, restore and add'
+										: 'Yes, start and add'}
+							</div>
+							<div className="text-primary-foreground/80 text-xs">
+								{isUnarchive
+									? 'Reactivate your deck and bookmark this phrase'
+									: `Create your ${language} deck and bookmark this phrase`}
+							</div>
+						</div>
+					</button>
+
+					<DialogClose
+						data-testid="cancel-start-learning-button"
+						className="border-2-lo-neutral bg-1-mlo-neutral text-7-mid-neutral hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl border p-4 text-start shadow transition-transform hover:-translate-y-0.5"
+					>
+						<Bookmark className="size-6" />
+						<div>
+							<div className="text-base leading-tight font-semibold">
+								No, not now
+							</div>
+							<div className="text-muted-foreground text-xs">
+								Just browsing — leave my decks alone
+							</div>
+						</div>
+					</DialogClose>
+				</div>
+			</DialogContent>
+		</Dialog>
 	)
 }

--- a/src/features/deck/mutations.ts
+++ b/src/features/deck/mutations.ts
@@ -9,7 +9,7 @@ import languages from '@/lib/languages'
 import { decksCollection } from './collections'
 import { DeckMetaSchema } from './schemas'
 
-async function postNewDeck(lang: string) {
+export async function postNewDeck(lang: string) {
 	// console.log(`postNewDeck ${lang}`)
 	if (typeof lang !== 'string' || lang.length !== 3)
 		throw new Error('Form not right. Maybe refresh. Or tell the devs.')

--- a/src/routes/_user.tsx
+++ b/src/routes/_user.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/features/profile/collections'
 import { queryClient } from '@/lib/query-client'
 import { decksCollection } from '@/features/deck/collections'
+import { useDeckMeta } from '@/features/deck/hooks'
 import { friendSummariesCollection } from '@/features/social/collections'
 import { useSocialRealtime } from '@/features/social'
 import { notificationsCollection } from '@/features/notifications/collections'
@@ -114,7 +115,6 @@ function UserLayout() {
 
 	// Skip the AppNav chunk entirely when no route declares an appnav
 	const appnav = matches.findLast((m) => m.staticData.appnav)?.staticData.appnav
-	const hasAppNav = !!resolveNavList(appnav, auth.isAuth).length
 
 	// Resolve the search overlay the same way titleBar / appnav are resolved:
 	// the deepest match that declares `search` wins.
@@ -125,6 +125,16 @@ function UserLayout() {
 	const router = useRouter()
 	const { lang } = useParams({ strict: false })
 	const initialLangs = lang && lang in languages ? [lang] : undefined
+
+	// $lang appnav is deck-specific (feed/review/contributions/stats). Hide it
+	// when the visitor has no active deck for this language — they're browsing,
+	// not learning, and the deck-scoped links would only lead to dead pages.
+	const langGatesAppNav = !!lang && lang in languages
+	const { data: currentDeck } = useDeckMeta(langGatesAppNav ? lang : '')
+	const hasActiveDeckForLang =
+		!langGatesAppNav || (!!currentDeck && !currentDeck.archived)
+	const hasAppNav =
+		hasActiveDeckForLang && !!resolveNavList(appnav, auth.isAuth).length
 
 	const closeSearch = useCallback(() => {
 		void router.navigate({ to: setSearchParam('search', null), replace: true })


### PR DESCRIPTION
## Summary

When a user bookmarks a phrase in a language they aren't actively learning, show a confirmation dialog that creates a new deck (or unarchives an existing one) before adding the card. This prevents foreign key constraint violations and improves UX by making the deck creation explicit and intentional.

## Changes

- **CardStatusHeart component**: Modified to detect when a deck doesn't exist or is archived (`needsDeckSetup`), and open a dialog instead of immediately adding the card
- **StartLearningDialog component**: New dialog that:
  - Shows different messaging for creating a new deck vs. unarchiving an existing one
  - Calls `postNewDeck()` to create a new deck, or updates the existing deck to set `archived: false`
  - Optimistically writes the deck to the collection after creation
  - Shows appropriate success/error toasts
  - Calls `onConfirmed()` to proceed with adding the card after deck setup succeeds
- **UserLayout**: Added `useDeckMeta` hook to check if the current language has an active deck, and hide the language-scoped appnav (feed/review/contributions/stats) when browsing without an active deck
- **postNewDeck export**: Made the mutation function public so it can be called from the dialog
- **TEST_IDS.md**: Added test IDs for the new dialog and its buttons (`start-learning-dialog`, `confirm-start-learning-button`, `cancel-start-learning-button`), and documented the `card-status-heart` selector

## Implementation Details

- The dialog respects the FK constraint `user_card(uid, lang) → user_deck(uid, lang)` by ensuring a deck row exists before allowing card creation
- Archived decks are treated the same as missing decks — both trigger the dialog, but with different messaging and behavior
- The dialog uses optimistic updates via `decksCollection.utils.writeInsert()` and `decksCollection.update()` to keep the UI responsive
- Language names are resolved from the `languages` map for consistent messaging

https://claude.ai/code/session_01Kvhc9u1u8coze48Cz8YwXH