### PR TITLE
Add chromeless route flag for distraction-free pages

### DIFF
--- a/src/routes/_user.tsx
+++ b/src/routes/_user.tsx
@@ -107,6 +107,7 @@ function UserLayout() {
 	// Layout A (default): page flows naturally, one browser scrollbar
 	// Layout B (fixedHeight): viewport-locked container with internal scroll
 	const fixedHeight = matches.some((m) => m.staticData.fixedHeight)
+	const chromeless = matches.some((m) => m.staticData.chromeless)
 
 	// Skip the AppNav chunk entirely when no route declares an appnav
 	const appnav = matches.findLast((m) => m.staticData.appnav)?.staticData.appnav
@@ -190,7 +191,7 @@ function UserLayout() {
 							fixedHeight && 'min-h-0 overflow-y-auto'
 						)}
 					>
-						<Navbar />
+						{!chromeless && <Navbar />}
 						{hasAppNav && (
 							<Suspense
 								fallback={

--- a/src/routes/_user/getting-started.tsx
+++ b/src/routes/_user/getting-started.tsx
@@ -36,10 +36,7 @@ export const Route = createFileRoute('/_user/getting-started')({
 	component: GettingStartedPage,
 	staticData: {
 		focusMode: true,
-		titleBar: {
-			title: 'Getting Started',
-			subtitle: 'Set your username and dive in!',
-		},
+		chromeless: true,
 	},
 	beforeLoad: ({ context }) => {
 		if (!context.auth.isAuth) {

--- a/src/types/route-static-data.ts
+++ b/src/types/route-static-data.ts
@@ -47,6 +47,13 @@ declare module '@tanstack/react-router' {
 		wideContent?: boolean
 		fixedHeight?: boolean
 		titleBar?: TitleBarStatic
+		/**
+		 * Drop the top navbar entirely — title bar, back button, and sidebar
+		 * opener. For forward-only pages with their own heading (e.g. signup
+		 * onboarding) where there is nowhere to go "back" to. Orthogonal to
+		 * `focusMode`; combine both for a fully distraction-free page.
+		 */
+		chromeless?: boolean
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a `chromeless?: boolean` flag to `StaticDataRouteOption`. When set, the `_user` layout skips rendering the top `<Navbar />` entirely — no title bar, no back chevron, no sidebar opener.
- Orthogonal to `focusMode`: combine the two for a fully distraction-free layout, or use `chromeless` alone on pages that just don't want a navbar.
- Applies it to `/getting-started`. The page is a forward-only signup step with nowhere to go "back" to, and it already carries its own "Welcome to Sunlo" hero, so the title bar was pure duplication. Dropped the now-dead `titleBar` config too (`useTitleBar` is only read by the navbar).

## Test plan

- [ ] Visit `/getting-started` as a fresh signed-up user — page renders centered with no navbar (no back chevron, no title bar, no sidebar trigger).
- [ ] Other `_user` routes (e.g. `/learn`, `/learn/$lang`, `/learn/$lang/review/go`) still render their navbar normally — the flag is opt-in per route.
- [ ] `pnpm check` passes.

https://claude.ai/code/session_01J6aMheoYLAPX1HHzM5gkLF

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6aMheoYLAPX1HHzM5gkLF)_