### PR TITLE
Update button solid variant background color from bg-5-mhi to bg-7-mhi

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 import { Slot } from '@/lib/slot'
 
-const solids = 'bg-5-mhi text-white hover:bg-lc-up-1'
+const solids = 'bg-7-mhi text-white hover:bg-lc-up-1'
 const softs = 'bg-1-mlo text-7-mid hover:bg-lc-down-1 hover:text-lc-up-1'
 
 const buttonVariants = cva(


### PR DESCRIPTION
## Summary
Updates the solid button variant to use a darker background color (`bg-7-mhi` instead of `bg-5-mhi`) while maintaining the existing text color and hover state styling.

## Changes
- Changed the `solids` constant in the button component to use `bg-7-mhi` as the background color for solid button variants
- Hover state (`hover:bg-lc-up-1`) and text color (`text-white`) remain unchanged

## Details
This is a visual refinement to the button component's solid variant, adjusting the background color to a darker shade in the design system's color scale.

https://claude.ai/code/session_01FqGTjBTmX6kbXGEaC13MXM