### PR TITLE
Add scenetest linking/unlinking npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
 		"scene": "scenetest --no-panel",
 		"scene:ui": "scenetest",
 		"scene:ci": "scenetest --no-panel --format both --report scenetest/.reports",
+		"st:link": "pnpm link ../scenetest-js/packages/scenes && pnpm link ../scenetest-js/packages/vite-plugin && pnpm link ../scenetest-js/packages/checks-panel && pnpm link ../scenetest-js/packages/checks-react",
+		"st:unlink": "pnpm unlink @scenetest/scenes @scenetest/vite-plugin @scenetest/checks-panel @scenetest/checks-react && pnpm install",
 		"test:unit": "vitest run",
 		"migrate": "supabase db diff --use-pg-delta -f new_migration",
 		"types": "supabase gen types typescript --local > ./src/types/supabase.ts",


### PR DESCRIPTION
## Summary
Add convenience npm scripts to link and unlink scenetest packages from a local monorepo during development.

## Changes
- **`install:st`**: Links four scenetest packages from `../scenetest-js/packages/` using `pnpm link`:
  - `@scenetest/scenes`
  - `@scenetest/vite-plugin`
  - `@scenetest/checks-panel`
  - `@scenetest/checks-react`

- **`uninstall:st`**: Unlinks the same four packages and reinstalls dependencies to restore npm registry versions

## Details
These scripts enable developers to test local changes to scenetest packages without publishing to npm. The `uninstall:st` script includes a `pnpm install` to ensure the lockfile is updated after unlinking.

https://claude.ai/code/session_01Gd4qBAFh3ArXXTRx7YoMxW