### PR TITLE
Add message-level grouping and admin-curated tags for requests

### DIFF
--- a/src/features/requests/collections.ts
+++ b/src/features/requests/collections.ts
@@ -12,6 +12,12 @@ import {
 	type CommentPhraseLinkType,
 	CommentUpvoteSchema,
 	type CommentUpvoteType,
+	MessageSchema,
+	type MessageType,
+	MessageTagSchema,
+	type MessageTagType,
+	MessageTagLinkSchema,
+	type MessageTagLinkType,
 } from './schemas'
 import { queryClient } from '@/lib/query-client'
 import supabase from '@/lib/supabase-client'
@@ -193,5 +199,94 @@ export const commentUpvotesCollection = createCollection(
 		getKey: (item: CommentUpvoteType) => item.comment_id,
 		queryClient,
 		schema: CommentUpvoteSchema,
+	})
+)
+
+// `message` is the cross-language object behind each phrase_request. Today
+// it's 1:1 with a request (auto-created by a DB trigger on insert), but
+// holds the tag links and will later group reposts of the same underlying
+// message across languages. See migration 20260526120000.
+export const messagesCollection = createCollection(
+	queryCollectionOptions({
+		id: 'messages',
+		queryKey: ['public', 'message'],
+		queryFn: async () => {
+			console.log(`Loading messagesCollection`)
+			const { data } = await supabase.from('message').select().throwOnError()
+			return data?.map((item) => MessageSchema.parse(item)) ?? []
+		},
+		getKey: (item: MessageType) => item.id,
+		queryClient,
+		schema: MessageSchema,
+	})
+)
+
+export const messageTagsCollection = createCollection(
+	queryCollectionOptions({
+		id: 'message_tags',
+		queryKey: ['public', 'message_tag'],
+		queryFn: async () => {
+			console.log(`Loading messageTagsCollection`)
+			const { data } = await supabase
+				.from('message_tag')
+				.select()
+				.order('sort_order', { ascending: true })
+				.throwOnError()
+			return data?.map((item) => MessageTagSchema.parse(item)) ?? []
+		},
+		getKey: (item: MessageTagType) => item.slug,
+		queryClient,
+		schema: MessageTagSchema,
+		autoIndex: 'eager',
+		defaultIndexType: BasicIndex,
+	})
+)
+
+export const messageTagLinksCollection = createCollection(
+	queryCollectionOptions({
+		id: 'message_tag_links',
+		queryKey: ['public', 'message_tag_link'],
+		queryFn: async () => {
+			console.log(`Loading messageTagLinksCollection`)
+			const { data } = await supabase
+				.from('message_tag_link')
+				.select()
+				.throwOnError()
+			return data?.map((item) => MessageTagLinkSchema.parse(item)) ?? []
+		},
+		// composite PK; getKey just needs to be stable+unique per row
+		getKey: (item: MessageTagLinkType) =>
+			`${item.message_id}--${item.tag_slug}`,
+		queryClient,
+		schema: MessageTagLinkSchema,
+		autoIndex: 'eager',
+		defaultIndexType: BasicIndex,
+		onInsert: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map(async (m) => {
+					await supabase
+						.from('message_tag_link')
+						.insert({
+							message_id: m.modified.message_id,
+							tag_slug: m.modified.tag_slug,
+						})
+						.throwOnError()
+				})
+			)
+			return { refetch: false }
+		},
+		onDelete: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map(async (m) => {
+					await supabase
+						.from('message_tag_link')
+						.delete()
+						.eq('message_id', m.original.message_id)
+						.eq('tag_slug', m.original.tag_slug)
+						.throwOnError()
+				})
+			)
+			return { refetch: false }
+		},
 	})
 )

--- a/src/features/requests/hooks.ts
+++ b/src/features/requests/hooks.ts
@@ -5,11 +5,14 @@ import {
 	commentPhraseLinksCollection,
 	commentUpvotesCollection,
 	commentsCollection,
+	messageTagLinksCollection,
+	messageTagsCollection,
 	phraseRequestsCollection,
 	phraseRequestUpvotesCollection,
 } from './collections'
 import type {
 	CommentPhraseLinkType,
+	MessageTagType,
 	PhraseRequestType,
 	RequestCommentType,
 } from './schemas'
@@ -129,6 +132,37 @@ export const useHasCommentUpvote = (commentId: uuid): boolean =>
 				.where(({ upvote }) => eq(upvote.comment_id, commentId)),
 		[commentId]
 	).data?.length
+
+/** All curated message tags, ordered by sort_order. */
+export const useMessageTags = () =>
+	useLiveQuery(
+		(q) =>
+			q
+				.from({ tag: messageTagsCollection })
+				.orderBy(({ tag }) => tag.sort_order, 'asc'),
+		[]
+	)
+
+/** Tags attached to a single message, ordered by sort_order. */
+export const useMessageTagsForMessage = (
+	messageId: uuid | undefined | null
+): UseLiveQueryResult<MessageTagType[]> =>
+	useLiveQuery(
+		(q) =>
+			!messageId
+				? undefined
+				: q
+						.from({ link: messageTagLinksCollection })
+						.where(({ link }) => eq(link.message_id, messageId))
+						.join(
+							{ tag: messageTagsCollection },
+							({ link, tag }) => eq(link.tag_slug, tag.slug),
+							'inner'
+						)
+						.select(({ tag }) => tag)
+						.orderBy(({ tag }) => tag.sort_order, 'asc'),
+		[messageId]
+	)
 
 export function useAnyonesComments(
 	uid: uuid,

--- a/src/features/requests/index.ts
+++ b/src/features/requests/index.ts
@@ -15,6 +15,12 @@ export {
 	type CommentPhraseLinkType,
 	CommentUpvoteSchema,
 	type CommentUpvoteType,
+	MessageSchema,
+	type MessageType,
+	MessageTagSchema,
+	type MessageTagType,
+	MessageTagLinkSchema,
+	type MessageTagLinkType,
 } from './schemas'
 
 // Collections
@@ -24,6 +30,9 @@ export {
 	commentsCollection,
 	commentPhraseLinksCollection,
 	commentUpvotesCollection,
+	messagesCollection,
+	messageTagsCollection,
+	messageTagLinksCollection,
 } from './collections'
 
 // Live collections
@@ -40,4 +49,6 @@ export {
 	useCommentPhraseLinks,
 	useHasCommentUpvote,
 	useAnyonesComments,
+	useMessageTags,
+	useMessageTagsForMessage,
 } from './hooks'

--- a/src/features/requests/schemas.ts
+++ b/src/features/requests/schemas.ts
@@ -16,9 +16,38 @@ export const PhraseRequestSchema = z.object({
 	upvote_count: z.number().default(0),
 	deleted: z.boolean().default(false),
 	updated_at: z.string().nullable().optional(),
+	// Server-side trigger auto-creates a message row on insert if not
+	// provided, so this is optional at insert time. The synced row always
+	// has it set; the client just doesn't need to know the value upfront.
+	message_id: z.string().uuid().optional(),
 })
 
 export type PhraseRequestType = z.infer<typeof PhraseRequestSchema>
+
+export const MessageSchema = z.object({
+	id: z.string().uuid(),
+	created_at: z.string(),
+})
+
+export type MessageType = z.infer<typeof MessageSchema>
+
+export const MessageTagSchema = z.object({
+	slug: z.string(),
+	label: z.string(),
+	description: z.string().nullable(),
+	sort_order: z.number().default(0),
+	created_at: z.string(),
+})
+
+export type MessageTagType = z.infer<typeof MessageTagSchema>
+
+export const MessageTagLinkSchema = z.object({
+	message_id: z.string().uuid(),
+	tag_slug: z.string(),
+	created_at: z.string(),
+})
+
+export type MessageTagLinkType = z.infer<typeof MessageTagLinkSchema>
 
 export const PhraseRequestUpvoteSchema = z.object({
 	request_id: z.string().uuid(),

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -462,6 +462,78 @@ export type Database = {
 					},
 				]
 			}
+			message: {
+				Row: {
+					created_at: string
+					id: string
+				}
+				Insert: {
+					created_at?: string
+					id?: string
+				}
+				Update: {
+					created_at?: string
+					id?: string
+				}
+				Relationships: []
+			}
+			message_tag: {
+				Row: {
+					created_at: string
+					description: string | null
+					label: string
+					slug: string
+					sort_order: number
+				}
+				Insert: {
+					created_at?: string
+					description?: string | null
+					label: string
+					slug: string
+					sort_order?: number
+				}
+				Update: {
+					created_at?: string
+					description?: string | null
+					label?: string
+					slug?: string
+					sort_order?: number
+				}
+				Relationships: []
+			}
+			message_tag_link: {
+				Row: {
+					created_at: string
+					message_id: string
+					tag_slug: string
+				}
+				Insert: {
+					created_at?: string
+					message_id: string
+					tag_slug: string
+				}
+				Update: {
+					created_at?: string
+					message_id?: string
+					tag_slug?: string
+				}
+				Relationships: [
+					{
+						foreignKeyName: 'message_tag_link_message_id_fkey'
+						columns: ['message_id']
+						isOneToOne: false
+						referencedRelation: 'message'
+						referencedColumns: ['id']
+					},
+					{
+						foreignKeyName: 'message_tag_link_tag_slug_fkey'
+						columns: ['tag_slug']
+						isOneToOne: false
+						referencedRelation: 'message_tag'
+						referencedColumns: ['slug']
+					},
+				]
+			}
 			phrase: {
 				Row: {
 					added_by: string
@@ -694,6 +766,7 @@ export type Database = {
 					deleted: boolean
 					id: string
 					lang: string
+					message_id: string
 					prompt: string
 					requester_uid: string
 					updated_at: string | null
@@ -704,6 +777,7 @@ export type Database = {
 					deleted?: boolean
 					id?: string
 					lang: string
+					message_id?: string
 					prompt: string
 					requester_uid: string
 					updated_at?: string | null
@@ -714,6 +788,7 @@ export type Database = {
 					deleted?: boolean
 					id?: string
 					lang?: string
+					message_id?: string
 					prompt?: string
 					requester_uid?: string
 					updated_at?: string | null
@@ -733,6 +808,13 @@ export type Database = {
 						isOneToOne: false
 						referencedRelation: 'meta_language'
 						referencedColumns: ['lang']
+					},
+					{
+						foreignKeyName: 'phrase_request_message_id_fkey'
+						columns: ['message_id']
+						isOneToOne: false
+						referencedRelation: 'message'
+						referencedColumns: ['id']
 					},
 					{
 						foreignKeyName: 'phrase_request_requester_uid_fkey'

--- a/supabase/migrations/20260526120000_request_messages_and_tags.sql
+++ b/supabase/migrations/20260526120000_request_messages_and_tags.sql
@@ -1,0 +1,193 @@
+-- Stage 1: introduce the `message` object that sits behind phrase_request.
+--
+-- A message is the cross-language thing a request expresses ("how do I say
+-- hello"). Today every phrase_request gets its own message 1:1; later, when
+-- cross-posting / reposting lands, multiple requests can share one message
+-- and the tags will travel with it.
+--
+-- Tags here are a CLOSED, admin-curated vocabulary (slug PK, no per-user
+-- tags). Contrast with the language-scoped `tag` table for phrases.
+--
+-- Shape:
+--   message              (id, created_at)
+--   message_tag          (slug, label, description, sort_order)
+--   message_tag_link     (message_id, tag_slug)  -- join
+--   phrase_request.message_id  -- new FK, auto-populated by trigger
+--
+-- ── 1. message ──────────────────────────────────────────────────────
+create table if not exists public.message (id uuid primary key default gen_random_uuid(), created_at timestamptz not null default now());
+
+alter table public.message owner to postgres;
+
+alter table public.message enable row level security;
+
+create policy "Enable read access for all users" on public.message for
+select
+	using (true);
+
+create policy "Admins can update messages" on public.message
+for update
+	to authenticated using (public.is_admin ())
+with
+	check (public.is_admin ());
+
+grant
+select
+	on public.message to anon,
+	authenticated;
+
+grant all on public.message to service_role;
+
+-- ── 2. message_tag (admin-curated vocabulary) ───────────────────────
+create table if not exists public.message_tag (
+	slug text primary key,
+	label text not null,
+	description text,
+	sort_order integer not null default 0,
+	created_at timestamptz not null default now()
+);
+
+alter table public.message_tag owner to postgres;
+
+alter table public.message_tag enable row level security;
+
+create policy "Enable read access for all users" on public.message_tag for
+select
+	using (true);
+
+create policy "Admins can insert message tags" on public.message_tag for insert to authenticated
+with
+	check (public.is_admin ());
+
+create policy "Admins can update message tags" on public.message_tag
+for update
+	to authenticated using (public.is_admin ())
+with
+	check (public.is_admin ());
+
+create policy "Admins can delete message tags" on public.message_tag for delete to authenticated using (public.is_admin ());
+
+grant
+select
+	on public.message_tag to anon,
+	authenticated;
+
+grant all on public.message_tag to service_role;
+
+-- ── 3. message_tag_link ─────────────────────────────────────────────
+create table if not exists public.message_tag_link (
+	message_id uuid not null references public.message (id) on delete cascade,
+	tag_slug text not null references public.message_tag (slug) on delete cascade,
+	created_at timestamptz not null default now(),
+	primary key (message_id, tag_slug)
+);
+
+alter table public.message_tag_link owner to postgres;
+
+alter table public.message_tag_link enable row level security;
+
+create policy "Enable read access for all users" on public.message_tag_link for
+select
+	using (true);
+
+create policy "Admins can insert message tag links" on public.message_tag_link for insert to authenticated
+with
+	check (public.is_admin ());
+
+create policy "Admins can delete message tag links" on public.message_tag_link for delete to authenticated using (public.is_admin ());
+
+grant
+select
+	on public.message_tag_link to anon,
+	authenticated;
+
+grant all on public.message_tag_link to service_role;
+
+create index if not exists message_tag_link_tag_slug_idx on public.message_tag_link (tag_slug);
+
+-- ── 4. phrase_request.message_id ────────────────────────────────────
+alter table public.phrase_request
+add column if not exists message_id uuid references public.message (id) on delete restrict;
+
+-- Backfill: each existing phrase_request gets its own message row.
+-- Generate the (request_id, new_message_id) mapping up front in a CTE,
+-- then use it in both the INSERT and the UPDATE so the pairing is
+-- deterministic — the alternative (matching via row_number across the
+-- INSERT's RETURNING) relies on undefined ordering.
+with
+	-- MATERIALIZED forces the CTE to evaluate once. Without it, Postgres
+	-- may inline the CTE into both downstream references, which would
+	-- call gen_random_uuid() twice per request and produce mismatched
+	-- IDs in the INSERT vs the UPDATE.
+	mapping as materialized (
+		select
+			id as request_id,
+			gen_random_uuid() as new_message_id
+		from
+			public.phrase_request
+		where
+			message_id is null
+	),
+	inserted_messages as (
+		insert into
+			public.message (id)
+		select
+			new_message_id
+		from
+			mapping
+		returning
+			id
+	)
+update public.phrase_request pr
+set
+	message_id = m.new_message_id
+from
+	mapping m
+where
+	pr.id = m.request_id;
+
+-- After backfill, lock it down.
+alter table public.phrase_request
+alter column message_id
+set not null;
+
+-- ── 5. auto-create message on phrase_request insert ─────────────────
+-- security definer so the trigger can write to public.message without
+-- the inserting user needing a direct INSERT policy on it. The trigger
+-- only fires when message_id is null on the incoming row, so a client
+-- that wants to attach to an existing message can do so by passing the
+-- message_id explicitly (used later for reposts / cross-posting).
+create or replace function public.ensure_phrase_request_message () returns trigger language plpgsql security definer as $$
+declare
+  new_message_id uuid;
+begin
+  if new.message_id is null then
+    insert into public.message default values returning id into new_message_id;
+    new.message_id := new_message_id;
+  end if;
+  return new;
+end;
+$$;
+
+alter function public.ensure_phrase_request_message () owner to postgres;
+
+drop trigger if exists ensure_phrase_request_message on public.phrase_request;
+
+create trigger ensure_phrase_request_message
+before insert on public.phrase_request for each row
+execute function public.ensure_phrase_request_message ();
+
+-- ── 6. seed the initial tags ────────────────────────────────────────
+insert into
+	public.message_tag (slug, label, sort_order)
+values
+	('day-1', 'Day 1', 10),
+	('introductions', 'Introductions', 20),
+	('getting-around', 'Getting around', 30),
+	('safety', 'Safety ⚠️', 40),
+	('pronouns', 'Pronouns', 50),
+	('counting', 'Counting', 60),
+	('odd-numbers', 'Odd numbers', 70),
+	('eating', 'Eating', 80),
+	('daily-life', 'Daily life', 90)
+on conflict (slug) do nothing;

--- a/supabase/migrations/20260526120000_request_messages_and_tags.sql
+++ b/supabase/migrations/20260526120000_request_messages_and_tags.sql
@@ -177,6 +177,12 @@ create trigger ensure_phrase_request_message
 before insert on public.phrase_request for each row
 execute function public.ensure_phrase_request_message ();
 
+-- The seed loader runs with `session_replication_role = replica` to skip
+-- triggers for speed, but this trigger is the only thing populating the
+-- new not-null message_id column. ENABLE ALWAYS makes it fire in replica
+-- mode too, so seed inserts that omit message_id still get one.
+alter table public.phrase_request enable always trigger ensure_phrase_request_message;
+
 -- ── 6. seed the initial tags ────────────────────────────────────────
 insert into
 	public.message_tag (slug, label, sort_order)


### PR DESCRIPTION
## Summary

Stage 1 of request tagging: introduces a `message` table that sits behind each `phrase_request` as the cross-language thing the request expresses, plus a closed admin-curated tag vocabulary that attaches to messages (not directly to requests).

Why on `message` rather than `request`: when cross-posting / reposting lands later, multiple language-specific requests will share one message, and the tags should travel with all of them. Putting tags on the request itself would force a backfill / split the first time a repost happens. Every request today gets its own message 1:1 via a `BEFORE INSERT` trigger, so behavior is identical to tagging requests directly — but the future move is already shaped correctly.

## Schema (`20260526120000_request_messages_and_tags.sql`)

- `message` (id, created_at) — public read, admin update
- `message_tag` (slug PK, label, description, sort_order) — admin-only writes; seeded with 9 starter categories (Day 1, Introductions, Getting around, Safety, Pronouns, Counting, Odd numbers, Eating, Daily life)
- `message_tag_link` (message_id, tag_slug) — admin-only writes
- `phrase_request.message_id` FK + `BEFORE INSERT` trigger (SECURITY DEFINER) that auto-creates a message when none is provided
- Deterministic backfill via a `MATERIALIZED` CTE so each existing request gets exactly one new message
- Trigger marked `ENABLE ALWAYS` so it fires under `session_replication_role = replica` (seed loader)

Tags are a **bootstrap floor**, not source of truth: the migration's `ON CONFLICT DO NOTHING` guarantees a fresh install has the starter list, but admin edits via Studio (or the eventual admin UI) are durable. Treat `slug` as immutable from creation; `label` / `description` are free to edit anytime.

## Client (`features/requests/`)

- `MessageSchema`, `MessageTagSchema`, `MessageTagLinkSchema` and types
- `messagesCollection`, `messageTagsCollection`, `messageTagLinksCollection` (the link collection wires admin `onInsert` / `onDelete` for Stage 2)
- `useMessageTags()`, `useMessageTagsForMessage(messageId)` hooks
- `PhraseRequestSchema.message_id` optional at insert time since the trigger fills it

`src/types/supabase.ts` is hand-patched in this PR so type-checking passes; `pnpm run types` should be re-run after merge to regenerate the canonical version.

## What's NOT in this PR

Stage 2 (UI to display tag chips on request cards, filter the requests feed by tag, admin tag editor) ships separately on the fast track once this lands.

## Test plan

- [x] `supabase db reset` succeeds — migration applies, seed loads through with the trigger firing in replica mode
- [x] After reset, every existing seeded `phrase_request` has a non-null `message_id` pointing to a unique row in `message`
- [ ] The 9 starter tags exist in `message_tag` with the right slugs and `sort_order` ordering
- [ ] Creating a new request via the existing UI auto-creates its message (no client-side message handling needed)
- [ ] As a non-admin, `INSERT INTO message_tag_link` is denied by RLS; as admin, it succeeds
- [ ] `pnpm run types` regenerates `src/types/supabase.ts` and the build still passes
- [ ] `pnpm check` and `pnpm lint` clean

https://claude.ai/code/session_01C5BBVxcdfKzyjtm89N1bm2

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5BBVxcdfKzyjtm89N1bm2)_