### PR TITLE
Admin tag editor at /admin/messages

### DIFF
--- a/scenetest/TEST_IDS.md
+++ b/scenetest/TEST_IDS.md
@@ -198,31 +198,66 @@ natural wrapper element to label.
 
 ## Phrase Requests
 
-| Selector                       | Attribute   | Component/Location  | Description                                                                                        |
-| ------------------------------ | ----------- | ------------------- | -------------------------------------------------------------------------------------------------- |
-| `contributions-page`           | data-testid | Contributions route | Contributions page container                                                                       |
-| `contributions-tab--requests`  | data-testid | Contributions page  | Tab for requests                                                                                   |
-| `contributions-tab--phrases`   | data-testid | Contributions page  | Tab for phrases                                                                                    |
-| `contributions-tab--playlists` | data-testid | Contributions page  | Tab for playlists                                                                                  |
-| `contributions-tab--answers`   | data-testid | Contributions page  | Tab for answers                                                                                    |
-| `contributions-tab--comments`  | data-testid | Contributions page  | Tab for comments                                                                                   |
-| `contributions-comment-item`   | data-testid | Comments tab        | Comment card on the comments tab (use with `data-key={commentId}`)                                 |
-| `new-request-link`             | data-testid | Contributions page  | Link to create new request                                                                         |
-| `new-request-form`             | data-testid | New request page    | Request form container (scope `prompt-input` and `submit-button` by this)                          |
-| `request-detail-page`          | data-testid | Request route       | Request detail container                                                                           |
-| `request-item`                 | data-testid | Request list        | A request list item (own user)                                                                     |
-| `other-user-request-item`      | data-testid | Request list        | A request by another user                                                                          |
-| `update-request-button`        | data-testid | Request page        | Edit button (owner only)                                                                           |
-| `edit-request-dialog`          | data-testid | Dialog              | Edit request dialog                                                                                |
-| `edit-request-form`            | data-testid | Edit dialog         | Form container inside the edit dialog (scope `prompt-input` and `submit-button` by this)           |
-| `delete-request-button`        | data-testid | Request page        | Delete button (owner only)                                                                         |
-| `delete-request-dialog`        | data-testid | Dialog              | Delete confirmation                                                                                |
-| `confirm-delete-button`        | data-testid | Dialog              | Confirm delete button                                                                              |
-| `comment-item`                 | data-name   | Request page        | Comment container (use with data-key for a specific comment)                                       |
-| `show-replies-button`          | data-name   | Comment item        | Toggle to expand/collapse the reply subthread (select via `comment-item {id} show-replies-button`) |
-| `add-reply-inline`             | data-name   | Comment subthread   | Inline prompt to open the reply dialog (select via `comment-item {id} add-reply-inline`)           |
-| `comment-context-menu-trigger` | data-testid | Comment             | Context menu button                                                                                |
-| `copy-link-menu-item`          | data-testid | Context menu        | Copy link option                                                                                   |
+| Selector                        | Attribute   | Component/Location  | Description                                                                                        |
+| ------------------------------- | ----------- | ------------------- | -------------------------------------------------------------------------------------------------- |
+| `contributions-page`            | data-testid | Contributions route | Contributions page container                                                                       |
+| `contributions-tab--requests`   | data-testid | Contributions page  | Tab for requests                                                                                   |
+| `contributions-tab--phrases`    | data-testid | Contributions page  | Tab for phrases                                                                                    |
+| `contributions-tab--playlists`  | data-testid | Contributions page  | Tab for playlists                                                                                  |
+| `contributions-tab--answers`    | data-testid | Contributions page  | Tab for answers                                                                                    |
+| `contributions-tab--comments`   | data-testid | Contributions page  | Tab for comments                                                                                   |
+| `contributions-comment-item`    | data-testid | Comments tab        | Comment card on the comments tab (use with `data-key={commentId}`)                                 |
+| `new-request-link`              | data-testid | Contributions page  | Link to create new request                                                                         |
+| `new-request-form`              | data-testid | New request page    | Request form container (scope `prompt-input` and `submit-button` by this)                          |
+| `request-detail-page`           | data-testid | Request route       | Request detail container                                                                           |
+| `message-tags-row`              | data-testid | Request detail      | Container for tag chips on a request's message (read-only)                                         |
+| `message-tag-chip`              | data-testid | Request detail      | A single tag chip (list item — has `data-key={slug}`)                                              |
+| `admin-request-gear-link`       | data-testid | Request detail      | Gear icon link to admin page (admin only)                                                          |
+| `admin-messages-page`           | data-testid | /admin/messages     | Page container                                                                                     |
+| `admin-messages-tags-strip`     | data-testid | /admin/messages     | Tag filter strip                                                                                   |
+| `tag-filter-all`                | data-testid | /admin/messages     | "All" pill (clears tag filter)                                                                     |
+| `tag-filter-chip`               | data-testid | /admin/messages     | Individual tag filter chip (has `data-key={slug}`)                                                 |
+| `new-tag-button`                | data-testid | /admin/messages     | Trigger for the "New tag" popover                                                                  |
+| `new-tag-slug`                  | data-testid | New-tag popover     | Slug input                                                                                         |
+| `new-tag-label`                 | data-testid | New-tag popover     | Label input                                                                                        |
+| `new-tag-description`           | data-testid | New-tag popover     | Description textarea                                                                               |
+| `new-tag-submit`                | data-testid | New-tag popover     | Submit button                                                                                      |
+| `edit-tags-button`              | data-testid | /admin/messages     | Trigger for the edit-tags dialog (next to "New tag")                                               |
+| `edit-tags-list`                | data-testid | Edit-tags dialog    | The list of tag rows                                                                               |
+| `edit-tag-row`                  | data-testid | Edit-tags dialog    | A tag row in the list (has `data-key={slug}`)                                                      |
+| `edit-tag-pencil`               | data-testid | Edit-tags dialog    | Pencil button to enter inline edit mode                                                            |
+| `edit-tag-label`                | data-testid | Edit-tags dialog    | Label input (edit mode)                                                                            |
+| `edit-tag-save`                 | data-testid | Edit-tags dialog    | Save button (edit mode)                                                                            |
+| `archive-tag-button`            | data-testid | Edit-tags dialog    | Archive icon opens confirm dialog (active tags)                                                    |
+| `archive-tag-confirm`           | data-testid | Confirm dialog      | Final confirm-archive button                                                                       |
+| `restore-tag-button`            | data-testid | Edit-tags dialog    | Undo icon to restore an archived tag                                                               |
+| `admin-messages-bulk-add`       | data-testid | /admin/messages     | Bulk-add section container                                                                         |
+| `bulk-add-textarea`             | data-testid | Bulk-add            | The textarea for pasted prompts                                                                    |
+| `bulk-add-submit`               | data-testid | Bulk-add            | "Add N messages" button                                                                            |
+| `admin-messages-search`         | data-testid | /admin/messages     | Filter-by-text input                                                                               |
+| `admin-messages-selection-bar`  | data-testid | /admin/messages     | Visible when ≥1 message is selected                                                                |
+| `apply-tag-button`              | data-testid | Selection bar       | Opens apply/remove-tag popover                                                                     |
+| `apply-tag-option`              | data-testid | Apply-tag popover   | Plus button per tag (has `data-key={slug}`)                                                        |
+| `admin-messages-table`          | data-testid | /admin/messages     | Container for the rows (list items have `data-name="message-row"`)                                 |
+| `select-all-visible`            | data-testid | /admin/messages     | Header checkbox                                                                                    |
+| `message-row`                   | data-testid | /admin/messages     | A single message row (has `data-key={message_id}`)                                                 |
+| `message-row-checkbox`          | data-testid | /admin/messages     | Per-row selection checkbox                                                                         |
+| `row-tag-chip`                  | data-testid | /admin/messages     | Tag chip on a row (has `data-key={slug}`, X to detach)                                             |
+| `row-open-request`              | data-testid | /admin/messages     | Link to the admin request detail page                                                              |
+| `admin-request-message-section` | data-testid | Admin request page  | Message section on the admin request detail page                                                   |
+| `request-item`                  | data-testid | Request list        | A request list item (own user)                                                                     |
+| `other-user-request-item`       | data-testid | Request list        | A request by another user                                                                          |
+| `update-request-button`         | data-testid | Request page        | Edit button (owner only)                                                                           |
+| `edit-request-dialog`           | data-testid | Dialog              | Edit request dialog                                                                                |
+| `edit-request-form`             | data-testid | Edit dialog         | Form container inside the edit dialog (scope `prompt-input` and `submit-button` by this)           |
+| `delete-request-button`         | data-testid | Request page        | Delete button (owner only)                                                                         |
+| `delete-request-dialog`         | data-testid | Dialog              | Delete confirmation                                                                                |
+| `confirm-delete-button`         | data-testid | Dialog              | Confirm delete button                                                                              |
+| `comment-item`                  | data-name   | Request page        | Comment container (use with data-key for a specific comment)                                       |
+| `show-replies-button`           | data-name   | Comment item        | Toggle to expand/collapse the reply subthread (select via `comment-item {id} show-replies-button`) |
+| `add-reply-inline`              | data-name   | Comment subthread   | Inline prompt to open the reply dialog (select via `comment-item {id} add-reply-inline`)           |
+| `comment-context-menu-trigger`  | data-testid | Comment             | Context menu button                                                                                |
+| `copy-link-menu-item`           | data-testid | Context menu        | Copy link option                                                                                   |
 
 ## Playlists
 

--- a/src/components/requests/message-tags-row.tsx
+++ b/src/components/requests/message-tags-row.tsx
@@ -1,0 +1,27 @@
+import type { uuid } from '@/types/main'
+import { Badge } from '@/components/ui/badge'
+import { useMessageTagsForMessage } from '@/features/requests/hooks'
+
+export function MessageTagsRow({ messageId }: { messageId: uuid }) {
+	const { data: currentTags } = useMessageTagsForMessage(messageId)
+
+	if (!currentTags?.length) return null
+
+	return (
+		<div
+			className="flex flex-wrap items-center gap-2"
+			data-testid="message-tags-row"
+		>
+			{currentTags.map((tag) => (
+				<Badge
+					key={tag.slug}
+					variant="outline"
+					data-testid="message-tag-chip"
+					data-key={tag.slug}
+				>
+					{tag.label}
+				</Badge>
+			))}
+		</div>
+	)
+}

--- a/src/components/requests/request-header.tsx
+++ b/src/components/requests/request-header.tsx
@@ -1,13 +1,19 @@
+import { Link } from '@tanstack/react-router'
+import { Settings } from 'lucide-react'
+
 import { PhraseRequestType } from '@/features/requests/schemas'
 import { CardDescription, CardHeader } from '@/components/ui/card'
 import { UidPermalink } from '../card-pieces/user-permalink'
 import { LangBadge } from '@/components/ui/badge'
+import { buttonVariants } from '@/components/ui/button'
 import { useProfile } from '@/features/profile/hooks'
+import { useAuth } from '@/lib/use-auth'
 import { UpdateRequestDialog } from './update-request-dialog'
 import { DeleteRequestDialog } from './delete-request-dialog'
 
 export function RequestHeader({ request }: { request: PhraseRequestType }) {
 	const { data: profile } = useProfile()
+	const { isAdmin } = useAuth()
 	const isOwner = profile?.uid === request.requester_uid
 
 	return (
@@ -26,6 +32,17 @@ export function RequestHeader({ request }: { request: PhraseRequestType }) {
 							<UpdateRequestDialog request={request} />
 							<DeleteRequestDialog request={request} />
 						</div>
+					)}
+					{isAdmin && (
+						<Link
+							to="/admin/$lang/requests/$id"
+							params={{ lang: request.lang, id: request.id }}
+							className={buttonVariants({ variant: 'ghost', size: 'icon' })}
+							aria-label="Manage request (admin)"
+							data-testid="admin-request-gear-link"
+						>
+							<Settings className="h-4 w-4" />
+						</Link>
 					)}
 					<LangBadge lang={request.lang} />
 				</div>

--- a/src/features/requests/collections.ts
+++ b/src/features/requests/collections.ts
@@ -239,6 +239,46 @@ export const messageTagsCollection = createCollection(
 		schema: MessageTagSchema,
 		autoIndex: 'eager',
 		defaultIndexType: BasicIndex,
+		onInsert: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map(async (m) => {
+					await supabase
+						.from('message_tag')
+						.insert({
+							slug: m.modified.slug,
+							label: m.modified.label,
+							description: m.modified.description,
+							sort_order: m.modified.sort_order,
+						})
+						.throwOnError()
+				})
+			)
+			return { refetch: false }
+		},
+		onUpdate: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map(async (m) => {
+					await supabase
+						.from('message_tag')
+						.update(m.changes)
+						.eq('slug', m.original.slug)
+						.throwOnError()
+				})
+			)
+			return { refetch: false }
+		},
+		onDelete: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map(async (m) => {
+					await supabase
+						.from('message_tag')
+						.delete()
+						.eq('slug', m.original.slug)
+						.throwOnError()
+				})
+			)
+			return { refetch: false }
+		},
 	})
 )
 

--- a/src/features/requests/hooks.ts
+++ b/src/features/requests/hooks.ts
@@ -133,17 +133,18 @@ export const useHasCommentUpvote = (commentId: uuid): boolean =>
 		[commentId]
 	).data?.length
 
-/** All curated message tags, ordered by sort_order. */
+/** All active (non-archived) message tags, ordered by sort_order. */
 export const useMessageTags = () =>
 	useLiveQuery(
 		(q) =>
 			q
 				.from({ tag: messageTagsCollection })
+				.where(({ tag }) => eq(tag.archived, false))
 				.orderBy(({ tag }) => tag.sort_order, 'asc'),
 		[]
 	)
 
-/** Tags attached to a single message, ordered by sort_order. */
+/** Active tags attached to a single message, ordered by sort_order. */
 export const useMessageTagsForMessage = (
 	messageId: uuid | undefined | null
 ): UseLiveQueryResult<MessageTagType[]> =>
@@ -159,6 +160,7 @@ export const useMessageTagsForMessage = (
 							({ link, tag }) => eq(link.tag_slug, tag.slug),
 							'inner'
 						)
+						.where(({ tag }) => eq(tag.archived, false))
 						.select(({ tag }) => tag)
 						.orderBy(({ tag }) => tag.sort_order, 'asc'),
 		[messageId]

--- a/src/features/requests/schemas.ts
+++ b/src/features/requests/schemas.ts
@@ -36,6 +36,7 @@ export const MessageTagSchema = z.object({
 	label: z.string(),
 	description: z.string().nullable(),
 	sort_order: z.number().default(0),
+	archived: z.boolean().default(false),
 	created_at: z.string(),
 })
 

--- a/src/hooks/links.ts
+++ b/src/hooks/links.ts
@@ -30,6 +30,7 @@ import {
 	Search,
 	Settings,
 	Share,
+	Tags,
 	UserPlus,
 } from 'lucide-react'
 import languages, { LangKey } from '@/lib/languages'
@@ -140,6 +141,15 @@ export const links = (lang?: LangKey): Record<string, LinkType> => {
 				to: '/notifications',
 			},
 			useBadge: () => useUnreadCount(),
+		},
+		'/admin/messages': {
+			name: 'Messages',
+			title: 'Admin: Messages',
+			Icon: Tags,
+			inexact: true,
+			link: {
+				to: '/admin/messages',
+			},
 		},
 		'/profile': {
 			name: 'Profile',

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -44,9 +44,11 @@ import { Route as UserFriendsChatsRouteImport } from './routes/_user/friends/cha
 import { Route as UserFriendsUidRouteImport } from './routes/_user/friends/$uid'
 import { Route as UserBrowseChartsRouteImport } from './routes/_user/browse.charts'
 import { Route as UserAdminRoutesRouteImport } from './routes/_user/admin/routes'
+import { Route as UserAdminMessagesRouteImport } from './routes/_user/admin/messages'
 import { Route as UserAdminLangRouteImport } from './routes/_user/admin/$lang'
 import { Route as UserLearnLangIndexRouteImport } from './routes/_user/learn/$lang.index'
 import { Route as UserFriendsChatsIndexRouteImport } from './routes/_user/friends/chats.index'
+import { Route as UserAdminMessagesIndexRouteImport } from './routes/_user/admin/messages.index'
 import { Route as UserAdminLangIndexRouteImport } from './routes/_user/admin/$lang.index'
 import { Route as UserLearnLangStatsRouteImport } from './routes/_user/learn/$lang.stats'
 import { Route as UserLearnLangReviewRouteImport } from './routes/_user/learn/$lang.review'
@@ -57,6 +59,7 @@ import { Route as UserLearnLangDeckSettingsRouteImport } from './routes/_user/le
 import { Route as UserLearnLangContributionsRouteImport } from './routes/_user/learn/$lang.contributions'
 import { Route as UserLearnLangBulkAddRouteImport } from './routes/_user/learn/$lang.bulk-add'
 import { Route as UserFriendsChatsFriendUidRouteImport } from './routes/_user/friends/chats.$friendUid'
+import { Route as UserAdminMessagesIdRouteImport } from './routes/_user/admin/messages.$id'
 import { Route as UserAdminLangRequestsRouteImport } from './routes/_user/admin/$lang.requests'
 import { Route as UserAdminLangPhrasesRouteImport } from './routes/_user/admin/$lang.phrases'
 import { Route as UserLearnLangReviewIndexRouteImport } from './routes/_user/learn/$lang.review.index'
@@ -346,6 +349,13 @@ const UserAdminRoutesRoute = UserAdminRoutesRouteImport.update({
 } as any).lazy(() =>
   import('./routes/_user/admin/routes.lazy').then((d) => d.Route),
 )
+const UserAdminMessagesRoute = UserAdminMessagesRouteImport.update({
+  id: '/messages',
+  path: '/messages',
+  getParentRoute: () => UserAdminLazyRoute,
+} as any).lazy(() =>
+  import('./routes/_user/admin/messages.lazy').then((d) => d.Route),
+)
 const UserAdminLangRoute = UserAdminLangRouteImport.update({
   id: '/$lang',
   path: '/$lang',
@@ -363,6 +373,13 @@ const UserFriendsChatsIndexRoute = UserFriendsChatsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => UserFriendsChatsRoute,
 } as any)
+const UserAdminMessagesIndexRoute = UserAdminMessagesIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => UserAdminMessagesRoute,
+} as any).lazy(() =>
+  import('./routes/_user/admin/messages.index.lazy').then((d) => d.Route),
+)
 const UserAdminLangIndexRoute = UserAdminLangIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -416,6 +433,13 @@ const UserFriendsChatsFriendUidRoute =
     path: '/$friendUid',
     getParentRoute: () => UserFriendsChatsRoute,
   } as any)
+const UserAdminMessagesIdRoute = UserAdminMessagesIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => UserAdminMessagesRoute,
+} as any).lazy(() =>
+  import('./routes/_user/admin/messages.$id.lazy').then((d) => d.Route),
+)
 const UserAdminLangRequestsRoute = UserAdminLangRequestsRouteImport.update({
   id: '/requests',
   path: '/requests',
@@ -562,6 +586,7 @@ export interface FileRoutesByFullPath {
   '/chats/': typeof ChatsIndexLazyRoute
   '/themes/': typeof ThemesIndexLazyRoute
   '/admin/$lang': typeof UserAdminLangRouteWithChildren
+  '/admin/messages': typeof UserAdminMessagesRouteWithChildren
   '/admin/routes': typeof UserAdminRoutesRoute
   '/browse/charts': typeof UserBrowseChartsRoute
   '/friends/$uid': typeof UserFriendsUidRoute
@@ -583,6 +608,7 @@ export interface FileRoutesByFullPath {
   '/search/': typeof UserSearchIndexLazyRoute
   '/admin/$lang/phrases': typeof UserAdminLangPhrasesRouteWithChildren
   '/admin/$lang/requests': typeof UserAdminLangRequestsRouteWithChildren
+  '/admin/messages/$id': typeof UserAdminMessagesIdRoute
   '/friends/chats/$friendUid': typeof UserFriendsChatsFriendUidRouteWithChildren
   '/learn/$lang/bulk-add': typeof UserLearnLangBulkAddRoute
   '/learn/$lang/contributions': typeof UserLearnLangContributionsRoute
@@ -593,6 +619,7 @@ export interface FileRoutesByFullPath {
   '/learn/$lang/review': typeof UserLearnLangReviewRouteWithChildren
   '/learn/$lang/stats': typeof UserLearnLangStatsRoute
   '/admin/$lang/': typeof UserAdminLangIndexRoute
+  '/admin/messages/': typeof UserAdminMessagesIndexRoute
   '/friends/chats/': typeof UserFriendsChatsIndexRoute
   '/learn/$lang/': typeof UserLearnLangIndexRoute
   '/friends/chats/$friendUid/recommend': typeof UserFriendsChatsFriendUidRecommendRoute
@@ -647,6 +674,7 @@ export interface FileRoutesByTo {
   '/learn': typeof UserLearnIndexRoute
   '/profile': typeof UserProfileIndexRoute
   '/search': typeof UserSearchIndexLazyRoute
+  '/admin/messages/$id': typeof UserAdminMessagesIdRoute
   '/friends/chats/$friendUid': typeof UserFriendsChatsFriendUidRouteWithChildren
   '/learn/$lang/bulk-add': typeof UserLearnLangBulkAddRoute
   '/learn/$lang/contributions': typeof UserLearnLangContributionsRoute
@@ -655,6 +683,7 @@ export interface FileRoutesByTo {
   '/learn/$lang/manage-deck': typeof UserLearnLangManageDeckRoute
   '/learn/$lang/stats': typeof UserLearnLangStatsRoute
   '/admin/$lang': typeof UserAdminLangIndexRoute
+  '/admin/messages': typeof UserAdminMessagesIndexRoute
   '/friends/chats': typeof UserFriendsChatsIndexRoute
   '/learn/$lang': typeof UserLearnLangIndexRoute
   '/friends/chats/$friendUid/recommend': typeof UserFriendsChatsFriendUidRecommendRoute
@@ -704,6 +733,7 @@ export interface FileRoutesById {
   '/chats/': typeof ChatsIndexLazyRoute
   '/themes/': typeof ThemesIndexLazyRoute
   '/_user/admin/$lang': typeof UserAdminLangRouteWithChildren
+  '/_user/admin/messages': typeof UserAdminMessagesRouteWithChildren
   '/_user/admin/routes': typeof UserAdminRoutesRoute
   '/_user/browse/charts': typeof UserBrowseChartsRoute
   '/_user/friends/$uid': typeof UserFriendsUidRoute
@@ -725,6 +755,7 @@ export interface FileRoutesById {
   '/_user/search/': typeof UserSearchIndexLazyRoute
   '/_user/admin/$lang/phrases': typeof UserAdminLangPhrasesRouteWithChildren
   '/_user/admin/$lang/requests': typeof UserAdminLangRequestsRouteWithChildren
+  '/_user/admin/messages/$id': typeof UserAdminMessagesIdRoute
   '/_user/friends/chats/$friendUid': typeof UserFriendsChatsFriendUidRouteWithChildren
   '/_user/learn/$lang/bulk-add': typeof UserLearnLangBulkAddRoute
   '/_user/learn/$lang/contributions': typeof UserLearnLangContributionsRoute
@@ -735,6 +766,7 @@ export interface FileRoutesById {
   '/_user/learn/$lang/review': typeof UserLearnLangReviewRouteWithChildren
   '/_user/learn/$lang/stats': typeof UserLearnLangStatsRoute
   '/_user/admin/$lang/': typeof UserAdminLangIndexRoute
+  '/_user/admin/messages/': typeof UserAdminMessagesIndexRoute
   '/_user/friends/chats/': typeof UserFriendsChatsIndexRoute
   '/_user/learn/$lang/': typeof UserLearnLangIndexRoute
   '/_user/friends/chats/$friendUid/recommend': typeof UserFriendsChatsFriendUidRecommendRoute
@@ -783,6 +815,7 @@ export interface FileRouteTypes {
     | '/chats/'
     | '/themes/'
     | '/admin/$lang'
+    | '/admin/messages'
     | '/admin/routes'
     | '/browse/charts'
     | '/friends/$uid'
@@ -804,6 +837,7 @@ export interface FileRouteTypes {
     | '/search/'
     | '/admin/$lang/phrases'
     | '/admin/$lang/requests'
+    | '/admin/messages/$id'
     | '/friends/chats/$friendUid'
     | '/learn/$lang/bulk-add'
     | '/learn/$lang/contributions'
@@ -814,6 +848,7 @@ export interface FileRouteTypes {
     | '/learn/$lang/review'
     | '/learn/$lang/stats'
     | '/admin/$lang/'
+    | '/admin/messages/'
     | '/friends/chats/'
     | '/learn/$lang/'
     | '/friends/chats/$friendUid/recommend'
@@ -868,6 +903,7 @@ export interface FileRouteTypes {
     | '/learn'
     | '/profile'
     | '/search'
+    | '/admin/messages/$id'
     | '/friends/chats/$friendUid'
     | '/learn/$lang/bulk-add'
     | '/learn/$lang/contributions'
@@ -876,6 +912,7 @@ export interface FileRouteTypes {
     | '/learn/$lang/manage-deck'
     | '/learn/$lang/stats'
     | '/admin/$lang'
+    | '/admin/messages'
     | '/friends/chats'
     | '/learn/$lang'
     | '/friends/chats/$friendUid/recommend'
@@ -924,6 +961,7 @@ export interface FileRouteTypes {
     | '/chats/'
     | '/themes/'
     | '/_user/admin/$lang'
+    | '/_user/admin/messages'
     | '/_user/admin/routes'
     | '/_user/browse/charts'
     | '/_user/friends/$uid'
@@ -945,6 +983,7 @@ export interface FileRouteTypes {
     | '/_user/search/'
     | '/_user/admin/$lang/phrases'
     | '/_user/admin/$lang/requests'
+    | '/_user/admin/messages/$id'
     | '/_user/friends/chats/$friendUid'
     | '/_user/learn/$lang/bulk-add'
     | '/_user/learn/$lang/contributions'
@@ -955,6 +994,7 @@ export interface FileRouteTypes {
     | '/_user/learn/$lang/review'
     | '/_user/learn/$lang/stats'
     | '/_user/admin/$lang/'
+    | '/_user/admin/messages/'
     | '/_user/friends/chats/'
     | '/_user/learn/$lang/'
     | '/_user/friends/chats/$friendUid/recommend'
@@ -1311,6 +1351,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UserAdminRoutesRouteImport
       parentRoute: typeof UserAdminLazyRoute
     }
+    '/_user/admin/messages': {
+      id: '/_user/admin/messages'
+      path: '/messages'
+      fullPath: '/admin/messages'
+      preLoaderRoute: typeof UserAdminMessagesRouteImport
+      parentRoute: typeof UserAdminLazyRoute
+    }
     '/_user/admin/$lang': {
       id: '/_user/admin/$lang'
       path: '/$lang'
@@ -1331,6 +1378,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/friends/chats/'
       preLoaderRoute: typeof UserFriendsChatsIndexRouteImport
       parentRoute: typeof UserFriendsChatsRoute
+    }
+    '/_user/admin/messages/': {
+      id: '/_user/admin/messages/'
+      path: '/'
+      fullPath: '/admin/messages/'
+      preLoaderRoute: typeof UserAdminMessagesIndexRouteImport
+      parentRoute: typeof UserAdminMessagesRoute
     }
     '/_user/admin/$lang/': {
       id: '/_user/admin/$lang/'
@@ -1401,6 +1455,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/friends/chats/$friendUid'
       preLoaderRoute: typeof UserFriendsChatsFriendUidRouteImport
       parentRoute: typeof UserFriendsChatsRoute
+    }
+    '/_user/admin/messages/$id': {
+      id: '/_user/admin/messages/$id'
+      path: '/$id'
+      fullPath: '/admin/messages/$id'
+      preLoaderRoute: typeof UserAdminMessagesIdRouteImport
+      parentRoute: typeof UserAdminMessagesRoute
     }
     '/_user/admin/$lang/requests': {
       id: '/_user/admin/$lang/requests'
@@ -1775,14 +1836,29 @@ const UserAdminLangRouteWithChildren = UserAdminLangRoute._addFileChildren(
   UserAdminLangRouteChildren,
 )
 
+interface UserAdminMessagesRouteChildren {
+  UserAdminMessagesIdRoute: typeof UserAdminMessagesIdRoute
+  UserAdminMessagesIndexRoute: typeof UserAdminMessagesIndexRoute
+}
+
+const UserAdminMessagesRouteChildren: UserAdminMessagesRouteChildren = {
+  UserAdminMessagesIdRoute: UserAdminMessagesIdRoute,
+  UserAdminMessagesIndexRoute: UserAdminMessagesIndexRoute,
+}
+
+const UserAdminMessagesRouteWithChildren =
+  UserAdminMessagesRoute._addFileChildren(UserAdminMessagesRouteChildren)
+
 interface UserAdminLazyRouteChildren {
   UserAdminLangRoute: typeof UserAdminLangRouteWithChildren
+  UserAdminMessagesRoute: typeof UserAdminMessagesRouteWithChildren
   UserAdminRoutesRoute: typeof UserAdminRoutesRoute
   UserAdminIndexRoute: typeof UserAdminIndexRoute
 }
 
 const UserAdminLazyRouteChildren: UserAdminLazyRouteChildren = {
   UserAdminLangRoute: UserAdminLangRouteWithChildren,
+  UserAdminMessagesRoute: UserAdminMessagesRouteWithChildren,
   UserAdminRoutesRoute: UserAdminRoutesRoute,
   UserAdminIndexRoute: UserAdminIndexRoute,
 }

--- a/src/routes/_user/admin.lazy.tsx
+++ b/src/routes/_user/admin.lazy.tsx
@@ -1,5 +1,13 @@
 import { createLazyFileRoute, Outlet } from '@tanstack/react-router'
 
 export const Route = createLazyFileRoute('/_user/admin')({
-	component: () => <Outlet />,
+	component: AdminLayout,
 })
+
+function AdminLayout() {
+	return (
+		<div className="bg-card/50 rounded border p-4 @md:p-6">
+			<Outlet />
+		</div>
+	)
+}

--- a/src/routes/_user/admin/$lang.phrases.$id.lazy.tsx
+++ b/src/routes/_user/admin/$lang.phrases.$id.lazy.tsx
@@ -3,7 +3,6 @@ import { createLazyFileRoute, Link } from '@tanstack/react-router'
 import { useMutation } from '@tanstack/react-query'
 import {
 	Archive,
-	ArrowLeft,
 	Brain,
 	Check,
 	ExternalLink,
@@ -20,7 +19,7 @@ import type {
 } from '@/features/phrases/schemas'
 import { TranslationSchema } from '@/features/phrases/schemas'
 import { Badge, LangBadge } from '@/components/ui/badge'
-import { Button, buttonVariants } from '@/components/ui/button'
+import { Button } from '@/components/ui/button'
 import Callout from '@/components/ui/callout'
 import { Input } from '@/components/ui/input'
 import { Loader } from '@/components/ui/loader'
@@ -45,7 +44,7 @@ export const Route = createLazyFileRoute('/_user/admin/$lang/phrases/$id')({
 })
 
 function AdminPhraseDetail() {
-	const { lang, id } = Route.useParams()
+	const { id } = Route.useParams()
 	const { isAdmin } = useAuth()
 	const { data: phrase, isLoading } = useOnePhrase(id)
 
@@ -53,19 +52,14 @@ function AdminPhraseDetail() {
 
 	if (!phrase) {
 		return (
-			<div className="space-y-4">
-				<BackLink lang={lang} />
-				<Callout variant="problem">
-					<p>Phrase not found.</p>
-				</Callout>
-			</div>
+			<Callout variant="problem">
+				<p>Phrase not found.</p>
+			</Callout>
 		)
 	}
 
 	return (
 		<div className="space-y-6" data-testid="admin-phrase-detail">
-			<BackLink lang={lang} />
-
 			<div className="space-y-2">
 				<div className="flex items-start justify-between gap-2">
 					<div className="min-w-0 flex-1 space-y-1">
@@ -470,18 +464,5 @@ function AdminTranslationRow({
 				)}
 			</div>
 		</div>
-	)
-}
-
-function BackLink({ lang }: { lang: string }) {
-	return (
-		<Link
-			to="/admin/$lang/phrases"
-			params={{ lang }}
-			className={buttonVariants({ variant: 'ghost', size: 'sm' })}
-		>
-			<ArrowLeft className="me-1 h-4 w-4" />
-			All phrases
-		</Link>
 	)
 }

--- a/src/routes/_user/admin/$lang.phrases.tsx
+++ b/src/routes/_user/admin/$lang.phrases.tsx
@@ -2,7 +2,11 @@ import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/_user/admin/$lang/phrases')({
 	staticData: {
-		appnav: ['/admin/$lang/phrases', '/admin/$lang/requests'],
+		appnav: [
+			'/admin/$lang/phrases',
+			'/admin/$lang/requests',
+			'/admin/messages',
+		],
 		titleBar: { title: 'Admin', subtitle: 'Phrase Management' },
 	},
 })

--- a/src/routes/_user/admin/$lang.requests.$id.lazy.tsx
+++ b/src/routes/_user/admin/$lang.requests.$id.lazy.tsx
@@ -1,34 +1,53 @@
 import { useState } from 'react'
 import { createLazyFileRoute, Link } from '@tanstack/react-router'
 import { useMutation } from '@tanstack/react-query'
-import { eq } from '@tanstack/db'
+import { and, eq, not } from '@tanstack/db'
 import { useLiveQuery } from '@tanstack/react-db'
 import {
 	Archive,
-	ArrowLeft,
 	Check,
+	ExternalLink,
 	Pencil,
+	Plus,
 	ThumbsUp,
 	Undo2,
+	X,
 } from 'lucide-react'
 
-import { Badge } from '@/components/ui/badge'
+import { Badge, LangBadge } from '@/components/ui/badge'
 import { Button, buttonVariants } from '@/components/ui/button'
 import Callout from '@/components/ui/callout'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Loader } from '@/components/ui/loader'
 import { Separator } from '@/components/ui/separator'
 import { Textarea } from '@/components/ui/textarea'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from '@/components/ui/popover'
+import { WithPhrase } from '@/components/with-phrase'
 import { UidPermalink } from '@/components/card-pieces/user-permalink'
-import { phraseRequestsCollection } from '@/features/requests/collections'
+import { Markdown } from '@/components/my-markdown'
+import {
+	messageTagLinksCollection,
+	phraseRequestsCollection,
+} from '@/features/requests/collections'
 import {
 	PhraseRequestSchema,
 	type PhraseRequestType,
 } from '@/features/requests/schemas'
+import {
+	useMessageTags,
+	useMessageTagsForMessage,
+	useRequestLinksPhraseIds,
+} from '@/features/requests/hooks'
+import type { PhraseFullFilteredType } from '@/features/phrases/schemas'
 import { useAuth } from '@/lib/use-auth'
 import supabase from '@/lib/supabase-client'
-import { Markdown } from '@/components/my-markdown'
 import { ago } from '@/lib/dayjs'
+import type { uuid } from '@/types/main'
 
 export const Route = createLazyFileRoute('/_user/admin/$lang/requests/$id')({
 	component: AdminRequestDetail,
@@ -50,19 +69,14 @@ function AdminRequestDetail() {
 
 	if (!request) {
 		return (
-			<div className="space-y-4">
-				<BackLink lang={lang} />
-				<Callout variant="problem">
-					<p>Request not found.</p>
-				</Callout>
-			</div>
+			<Callout variant="problem">
+				<p>Request not found.</p>
+			</Callout>
 		)
 	}
 
 	return (
 		<div className="space-y-6" data-testid="admin-request-detail">
-			<BackLink lang={lang} />
-
 			<div className="space-y-2">
 				<div className="flex items-start justify-between gap-2">
 					<div className="min-w-0 flex-1 space-y-1">
@@ -121,6 +135,14 @@ function AdminRequestDetail() {
 
 			<Separator />
 
+			<MessageSection requestId={request.id} messageId={request.message_id!} />
+
+			<Separator />
+
+			<AttachedPhrasesSection requestId={request.id} lang={lang} />
+
+			<Separator />
+
 			<div>
 				<Link
 					to="/learn/$lang/requests/$id"
@@ -130,6 +152,260 @@ function AdminRequestDetail() {
 					View public request page
 				</Link>
 			</div>
+		</div>
+	)
+}
+
+function MessageSection({
+	requestId,
+	messageId,
+}: {
+	requestId: uuid
+	messageId: uuid
+}) {
+	const { data: tags } = useMessageTagsForMessage(messageId)
+	return (
+		<div className="space-y-3" data-testid="admin-request-message-section">
+			<div className="flex items-center justify-between">
+				<h3 className="text-lg font-semibold">Message</h3>
+				<Link
+					to="/admin/messages/$id"
+					params={{ id: messageId }}
+					className={buttonVariants({ variant: 'soft', size: 'sm' })}
+				>
+					View this message <ExternalLink className="ms-1 h-3 w-3" />
+				</Link>
+			</div>
+			<dl className="text-sm">
+				<div className="flex items-baseline gap-2 py-1">
+					<dt className="text-muted-foreground min-w-[100px] shrink-0">
+						Message ID
+					</dt>
+					<dd className="text-muted-foreground font-mono text-xs break-all">
+						{messageId}
+					</dd>
+				</div>
+				<div className="flex items-baseline gap-2 py-1">
+					<dt className="text-muted-foreground min-w-[100px] shrink-0">Tags</dt>
+					<dd className="flex flex-wrap items-center gap-1">
+						{tags?.map((tag) => (
+							<Badge
+								key={tag.slug}
+								variant="outline"
+								data-testid="admin-request-tag-chip"
+								data-key={tag.slug}
+							>
+								{tag.label}
+								<button
+									type="button"
+									className="hover:text-c-hi ms-1 -me-1 inline-flex items-center"
+									aria-label={`Remove ${tag.label}`}
+									onClick={() => detachTag(messageId, tag.slug)}
+								>
+									<X className="h-3 w-3" />
+								</button>
+							</Badge>
+						))}
+						{!tags?.length && (
+							<span className="text-muted-foreground italic">No tags</span>
+						)}
+						<AddTagPopover
+							messageId={messageId}
+							currentSlugs={new Set(tags?.map((t) => t.slug) ?? [])}
+						/>
+					</dd>
+				</div>
+			</dl>
+			<RelatedRequestsSection
+				messageId={messageId}
+				currentRequestId={requestId}
+			/>
+		</div>
+	)
+}
+
+function AddTagPopover({
+	messageId,
+	currentSlugs,
+}: {
+	messageId: uuid
+	currentSlugs: Set<string>
+}) {
+	const [open, setOpen] = useState(false)
+	const { data: allTags } = useMessageTags()
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button
+					size="sm"
+					variant="ghost"
+					data-testid="admin-request-add-tag"
+					aria-label="Edit tags"
+				>
+					<Plus className="h-3 w-3" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent align="start" className="w-64 p-2">
+				<p className="text-muted-foreground px-2 pb-2 text-xs">
+					Toggle tags for this message
+				</p>
+				<ul className="flex flex-col">
+					{allTags?.map((tag) => {
+						const isOn = currentSlugs.has(tag.slug)
+						return (
+							<li key={tag.slug}>
+								<label
+									className="hover:bg-1-lo-neutral flex cursor-pointer items-center gap-2 rounded p-2 text-sm"
+									data-testid="admin-request-tag-option"
+									data-key={tag.slug}
+								>
+									<Checkbox
+										checked={isOn}
+										onCheckedChange={(checked) => {
+											if (checked) attachTag(messageId, tag.slug)
+											else detachTag(messageId, tag.slug)
+										}}
+									/>
+									<span>{tag.label}</span>
+								</label>
+							</li>
+						)
+					})}
+				</ul>
+			</PopoverContent>
+		</Popover>
+	)
+}
+
+function attachTag(messageId: uuid, tagSlug: string) {
+	const tx = messageTagLinksCollection.insert({
+		message_id: messageId,
+		tag_slug: tagSlug,
+		created_at: new Date().toISOString(),
+	})
+	tx.isPersisted.promise.catch((err: unknown) => {
+		toastError('Failed to add tag')
+		console.error(err)
+	})
+}
+
+function detachTag(messageId: uuid, tagSlug: string) {
+	const tx = messageTagLinksCollection.delete(`${messageId}--${tagSlug}`)
+	tx.isPersisted.promise.catch((err: unknown) => {
+		toastError('Failed to remove tag')
+		console.error(err)
+	})
+}
+
+function RelatedRequestsSection({
+	messageId,
+	currentRequestId,
+}: {
+	messageId: uuid
+	currentRequestId: uuid
+}) {
+	const { data: siblings } = useLiveQuery(
+		(q) =>
+			q
+				.from({ req: phraseRequestsCollection })
+				.where(({ req }) =>
+					and(eq(req.message_id, messageId), not(eq(req.id, currentRequestId)))
+				)
+				.orderBy(({ req }) => req.created_at, 'desc'),
+		[messageId, currentRequestId]
+	)
+
+	if (!siblings || siblings.length === 0) return null
+
+	return (
+		<div className="space-y-1 pt-2">
+			<h4 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+				Other requests on this message ({siblings.length})
+			</h4>
+			<ul className="divide-y border" data-testid="related-requests-list">
+				{siblings.map((req) => (
+					<li
+						key={req.id}
+						className="flex items-center gap-2 p-2 text-sm"
+						data-testid="related-request"
+						data-key={req.id}
+					>
+						<LangBadge lang={req.lang} />
+						<span className="min-w-0 flex-1 truncate">{req.prompt}</span>
+						<Link
+							to="/admin/$lang/requests/$id"
+							params={{ lang: req.lang, id: req.id }}
+							className={buttonVariants({ variant: 'ghost', size: 'sm' })}
+							aria-label="Open admin page"
+						>
+							<ExternalLink className="h-3 w-3" />
+						</Link>
+					</li>
+				))}
+			</ul>
+		</div>
+	)
+}
+
+function AttachedPhrasesSection({
+	requestId,
+	lang,
+}: {
+	requestId: uuid
+	lang: string
+}) {
+	const { data: links } = useRequestLinksPhraseIds(requestId)
+	return (
+		<div className="space-y-2" data-testid="admin-request-phrases-section">
+			<h3 className="text-lg font-semibold">
+				Phrases attached ({links?.length ?? 0})
+			</h3>
+			{!links?.length ? (
+				<p className="text-muted-foreground italic">
+					No phrases have been suggested as answers yet.
+				</p>
+			) : (
+				<ul className="divide-y border">
+					{links.map((link) => (
+						<li
+							key={link.phrase_id}
+							className="p-2"
+							data-testid="attached-phrase"
+							data-key={link.phrase_id}
+						>
+							<WithPhrase
+								pid={link.phrase_id}
+								Component={(props) => (
+									<AttachedPhraseRow phrase={props.phrase} lang={lang} />
+								)}
+							/>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	)
+}
+
+function AttachedPhraseRow({
+	phrase,
+	lang,
+}: {
+	phrase: PhraseFullFilteredType
+	lang: string
+}) {
+	return (
+		<div className="flex items-center gap-2 text-sm">
+			<LangBadge lang={phrase.lang} />
+			<span className="min-w-0 flex-1 truncate">{phrase.text}</span>
+			<Link
+				to="/admin/$lang/phrases/$id"
+				params={{ lang, id: phrase.id }}
+				className={buttonVariants({ variant: 'ghost', size: 'sm' })}
+				aria-label="Open admin phrase page"
+			>
+				<ExternalLink className="h-3 w-3" />
+			</Link>
 		</div>
 	)
 }
@@ -275,18 +551,5 @@ function ArchiveRequestButton({
 				<Archive className="text-destructive size-4" />
 			)}
 		</Button>
-	)
-}
-
-function BackLink({ lang }: { lang: string }) {
-	return (
-		<Link
-			to="/admin/$lang/requests"
-			params={{ lang }}
-			className={buttonVariants({ variant: 'ghost', size: 'sm' })}
-		>
-			<ArrowLeft className="me-1 h-4 w-4" />
-			All requests
-		</Link>
 	)
 }

--- a/src/routes/_user/admin/$lang.requests.tsx
+++ b/src/routes/_user/admin/$lang.requests.tsx
@@ -2,7 +2,11 @@ import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/_user/admin/$lang/requests')({
 	staticData: {
-		appnav: ['/admin/$lang/phrases', '/admin/$lang/requests'],
+		appnav: [
+			'/admin/$lang/phrases',
+			'/admin/$lang/requests',
+			'/admin/messages',
+		],
 		titleBar: { title: 'Admin', subtitle: 'Request Management' },
 	},
 })

--- a/src/routes/_user/admin/messages.$id.lazy.tsx
+++ b/src/routes/_user/admin/messages.$id.lazy.tsx
@@ -1,0 +1,233 @@
+import { useState } from 'react'
+import { createLazyFileRoute, Link } from '@tanstack/react-router'
+import { eq, useLiveQuery } from '@tanstack/react-db'
+import { ExternalLink, Plus, X } from 'lucide-react'
+
+import { Badge, LangBadge } from '@/components/ui/badge'
+import { Button, buttonVariants } from '@/components/ui/button'
+import Callout from '@/components/ui/callout'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Loader } from '@/components/ui/loader'
+import { Separator } from '@/components/ui/separator'
+import { toastError } from '@/components/ui/sonner'
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from '@/components/ui/popover'
+import { ago } from '@/lib/dayjs'
+import {
+	messageTagLinksCollection,
+	messagesCollection,
+	phraseRequestsCollection,
+} from '@/features/requests/collections'
+import {
+	useMessageTags,
+	useMessageTagsForMessage,
+} from '@/features/requests/hooks'
+import type { uuid } from '@/types/main'
+
+export const Route = createLazyFileRoute('/_user/admin/messages/$id')({
+	component: AdminMessageDetail,
+})
+
+function AdminMessageDetail() {
+	const { id } = Route.useParams()
+	const { data: message, isLoading } = useLiveQuery(
+		(q) =>
+			q
+				.from({ msg: messagesCollection })
+				.where(({ msg }) => eq(msg.id, id))
+				.findOne(),
+		[id]
+	)
+	const { data: tags } = useMessageTagsForMessage(id)
+	const { data: requests } = useLiveQuery(
+		(q) =>
+			q
+				.from({ req: phraseRequestsCollection })
+				.where(({ req }) => eq(req.message_id, id))
+				.orderBy(({ req }) => req.created_at, 'asc'),
+		[id]
+	)
+
+	if (isLoading) return <Loader />
+
+	if (!message) {
+		return (
+			<Callout variant="problem">
+				<p>Message not found.</p>
+			</Callout>
+		)
+	}
+
+	return (
+		<div className="space-y-6" data-testid="admin-message-detail">
+			<header className="space-y-1">
+				<h1 className="text-2xl font-bold">Message</h1>
+				<p className="text-muted-foreground font-mono text-xs break-all">
+					{message.id}
+				</p>
+			</header>
+
+			<dl className="text-sm">
+				<div className="flex items-baseline gap-2 py-1">
+					<dt className="text-muted-foreground min-w-[100px] shrink-0">
+						Created
+					</dt>
+					<dd>{ago(message.created_at)}</dd>
+				</div>
+			</dl>
+
+			<Separator />
+
+			<section className="space-y-2">
+				<h2 className="text-lg font-semibold">Tags</h2>
+				<div
+					className="flex flex-wrap items-center gap-1"
+					data-testid="message-tags"
+				>
+					{tags?.map((tag) => (
+						<Badge
+							key={tag.slug}
+							variant="outline"
+							data-testid="message-tag-chip"
+							data-key={tag.slug}
+						>
+							{tag.label}
+							<button
+								type="button"
+								className="hover:text-c-hi ms-1 -me-1 inline-flex items-center"
+								aria-label={`Remove ${tag.label}`}
+								onClick={() => detachTag(message.id, tag.slug)}
+							>
+								<X className="h-3 w-3" />
+							</button>
+						</Badge>
+					))}
+					{!tags?.length && (
+						<span className="text-muted-foreground italic">No tags</span>
+					)}
+					<AddTagPopover
+						messageId={message.id}
+						currentSlugs={new Set(tags?.map((t) => t.slug) ?? [])}
+					/>
+				</div>
+			</section>
+
+			<Separator />
+
+			<section className="space-y-2">
+				<h2 className="text-lg font-semibold">
+					Linked requests ({requests?.length ?? 0})
+				</h2>
+				{!requests?.length ? (
+					<p className="text-muted-foreground italic">
+						No requests are linked to this message.
+					</p>
+				) : (
+					<ul className="divide-y border" data-testid="message-linked-requests">
+						{requests.map((req) => (
+							<li
+								key={req.id}
+								className="flex items-center gap-2 p-2 text-sm"
+								data-testid="message-linked-request"
+								data-key={req.id}
+							>
+								<LangBadge lang={req.lang} />
+								<span className="min-w-0 flex-1 truncate">{req.prompt}</span>
+								<span className="text-muted-foreground hidden text-xs @md:inline">
+									{ago(req.created_at)}
+								</span>
+								<Link
+									to="/admin/$lang/requests/$id"
+									params={{ lang: req.lang, id: req.id }}
+									className={buttonVariants({
+										variant: 'ghost',
+										size: 'sm',
+									})}
+									aria-label="Open admin request page"
+								>
+									<ExternalLink className="h-3 w-3" />
+								</Link>
+							</li>
+						))}
+					</ul>
+				)}
+			</section>
+		</div>
+	)
+}
+
+function AddTagPopover({
+	messageId,
+	currentSlugs,
+}: {
+	messageId: uuid
+	currentSlugs: Set<string>
+}) {
+	const [open, setOpen] = useState(false)
+	const { data: allTags } = useMessageTags()
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button
+					size="sm"
+					variant="ghost"
+					data-testid="message-add-tag"
+					aria-label="Edit tags"
+				>
+					<Plus className="h-3 w-3" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent align="start" className="w-64 p-2">
+				<p className="text-muted-foreground px-2 pb-2 text-xs">
+					Toggle tags for this message
+				</p>
+				<ul className="flex flex-col">
+					{allTags?.map((tag) => {
+						const isOn = currentSlugs.has(tag.slug)
+						return (
+							<li key={tag.slug}>
+								<label
+									className="hover:bg-1-lo-neutral flex cursor-pointer items-center gap-2 rounded p-2 text-sm"
+									data-testid="message-tag-option"
+									data-key={tag.slug}
+								>
+									<Checkbox
+										checked={isOn}
+										onCheckedChange={(checked) => {
+											if (checked) attachTag(messageId, tag.slug)
+											else detachTag(messageId, tag.slug)
+										}}
+									/>
+									<span>{tag.label}</span>
+								</label>
+							</li>
+						)
+					})}
+				</ul>
+			</PopoverContent>
+		</Popover>
+	)
+}
+
+function attachTag(messageId: uuid, tagSlug: string) {
+	const tx = messageTagLinksCollection.insert({
+		message_id: messageId,
+		tag_slug: tagSlug,
+		created_at: new Date().toISOString(),
+	})
+	tx.isPersisted.promise.catch((err: unknown) => {
+		toastError('Failed to add tag')
+		console.error(err)
+	})
+}
+
+function detachTag(messageId: uuid, tagSlug: string) {
+	const tx = messageTagLinksCollection.delete(`${messageId}--${tagSlug}`)
+	tx.isPersisted.promise.catch((err: unknown) => {
+		toastError('Failed to remove tag')
+		console.error(err)
+	})
+}

--- a/src/routes/_user/admin/messages.$id.tsx
+++ b/src/routes/_user/admin/messages.$id.tsx
@@ -1,0 +1,25 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { languagesCollection } from '@/features/languages/collections'
+import { publicProfilesCollection } from '@/features/profile/collections'
+import {
+	messageTagLinksCollection,
+	messageTagsCollection,
+	messagesCollection,
+	phraseRequestsCollection,
+} from '@/features/requests/collections'
+
+export const Route = createFileRoute('/_user/admin/messages/$id')({
+	staticData: {
+		titleBar: { title: 'Admin', subtitle: 'Message detail' },
+	},
+	loader: async () => {
+		await Promise.all([
+			languagesCollection.preload(),
+			publicProfilesCollection.preload(),
+			messagesCollection.preload(),
+			phraseRequestsCollection.preload(),
+			messageTagsCollection.preload(),
+			messageTagLinksCollection.preload(),
+		])
+	},
+})

--- a/src/routes/_user/admin/messages.index.lazy.tsx
+++ b/src/routes/_user/admin/messages.index.lazy.tsx
@@ -1,0 +1,1107 @@
+import { useId, useMemo, useState } from 'react'
+import { createLazyFileRoute, Link } from '@tanstack/react-router'
+import { useMutation } from '@tanstack/react-query'
+import { eq, useLiveQuery } from '@tanstack/react-db'
+import {
+	Archive,
+	Check,
+	ChevronsUpDown,
+	ExternalLink,
+	Pencil,
+	Plus,
+	Search,
+	Tags,
+	Undo2,
+	X,
+} from 'lucide-react'
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { Badge, LangBadge } from '@/components/ui/badge'
+import { Button, buttonVariants } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Loader } from '@/components/ui/loader'
+import { Textarea } from '@/components/ui/textarea'
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from '@/components/ui/popover'
+import { SelectOneLanguage } from '@/components/select-one-language'
+import { toastError, toastSuccess } from '@/components/ui/sonner'
+import { cn } from '@/lib/utils'
+import { ago } from '@/lib/dayjs'
+import { useAuth } from '@/lib/use-auth'
+import supabase from '@/lib/supabase-client'
+import {
+	messageTagLinksCollection,
+	messageTagsCollection,
+	messagesCollection,
+	phraseRequestsCollection,
+} from '@/features/requests/collections'
+import {
+	MessageTagLinkSchema,
+	PhraseRequestSchema,
+	type MessageTagType,
+} from '@/features/requests/schemas'
+
+export const Route = createLazyFileRoute('/_user/admin/messages/')({
+	component: AdminMessagesPage,
+})
+
+type MessageRow = {
+	message_id: string
+	created_at: string
+	prompt: string
+	lang: string
+	request_id: string
+}
+
+function AdminMessagesPage() {
+	const { userId } = useAuth()
+	const [search, setSearch] = useState('')
+	const [activeTagSlug, setActiveTagSlug] = useState<string | null>(null)
+	const [selected, setSelected] = useState<Set<string>>(new Set())
+
+	const { data: rawRows, isLoading } = useLiveQuery(
+		(q) =>
+			q
+				.from({ msg: messagesCollection })
+				.join(
+					{ req: phraseRequestsCollection },
+					({ msg, req }) => eq(req.message_id, msg.id),
+					'inner'
+				)
+				.orderBy(({ msg }) => msg.created_at, 'desc')
+				.select(({ msg, req }) => ({
+					message_id: msg.id,
+					created_at: msg.created_at,
+					prompt: req.prompt,
+					lang: req.lang,
+					request_id: req.id,
+				})),
+		[]
+	)
+
+	const { data: allTags } = useLiveQuery(
+		(q) =>
+			q
+				.from({ tag: messageTagsCollection })
+				.where(({ tag }) => eq(tag.archived, false))
+				.orderBy(({ tag }) => tag.sort_order, 'asc'),
+		[]
+	)
+
+	const { data: allLinks } = useLiveQuery(
+		(q) => q.from({ link: messageTagLinksCollection }),
+		[]
+	)
+
+	const tagsByMessage = useMemo(() => {
+		const tagBySlug = new Map(allTags?.map((t) => [t.slug, t]) ?? [])
+		const out = new Map<string, MessageTagType[]>()
+		for (const link of allLinks ?? []) {
+			const tag = tagBySlug.get(link.tag_slug)
+			if (!tag) continue
+			const arr = out.get(link.message_id) ?? []
+			arr.push(tag)
+			out.set(link.message_id, arr)
+		}
+		for (const arr of out.values()) {
+			arr.sort((a, b) => a.sort_order - b.sort_order)
+		}
+		return out
+	}, [allTags, allLinks])
+
+	const tagCounts = useMemo(() => {
+		const counts = new Map<string, number>()
+		for (const link of allLinks ?? []) {
+			counts.set(link.tag_slug, (counts.get(link.tag_slug) ?? 0) + 1)
+		}
+		return counts
+	}, [allLinks])
+
+	const rows: MessageRow[] = useMemo(() => {
+		const all = (rawRows ?? []) as MessageRow[]
+		const messageIdsForTag =
+			activeTagSlug == null
+				? null
+				: new Set(
+						(allLinks ?? [])
+							.filter((l) => l.tag_slug === activeTagSlug)
+							.map((l) => l.message_id)
+					)
+		const q = search.trim().toLowerCase()
+		return all.filter((r) => {
+			if (messageIdsForTag && !messageIdsForTag.has(r.message_id)) return false
+			if (q && !r.prompt.toLowerCase().includes(q)) return false
+			return true
+		})
+	}, [rawRows, allLinks, activeTagSlug, search])
+
+	const toggleSelected = (id: string) => {
+		setSelected((prev) => {
+			const next = new Set(prev)
+			if (next.has(id)) next.delete(id)
+			else next.add(id)
+			return next
+		})
+	}
+
+	const toggleVisibleAll = () => {
+		setSelected((prev) => {
+			const next = new Set(prev)
+			const allVisibleSelected = rows.every((r) => next.has(r.message_id))
+			if (allVisibleSelected) {
+				for (const r of rows) next.delete(r.message_id)
+			} else {
+				for (const r of rows) next.add(r.message_id)
+			}
+			return next
+		})
+	}
+
+	return (
+		<div className="space-y-6" data-testid="admin-messages-page">
+			<header className="space-y-1">
+				<h1 className="text-2xl font-bold">Messages</h1>
+				<p className="text-muted-foreground text-sm">
+					Each message is the cross-language thing behind a request. Tag, edit
+					vocabulary, and bulk-add seed content.
+				</p>
+			</header>
+
+			<TagsStrip
+				allTags={allTags ?? []}
+				tagCounts={tagCounts}
+				activeTagSlug={activeTagSlug}
+				setActiveTagSlug={setActiveTagSlug}
+			/>
+
+			<BulkAddSection userId={userId} allTags={allTags ?? []} />
+
+			<div className="space-y-3">
+				<div className="flex flex-col gap-3 @md:flex-row @md:items-center @md:justify-between">
+					<div className="relative max-w-md grow">
+						<Search className="text-muted-foreground pointer-events-none absolute start-3 top-1/2 h-4 w-4 -translate-y-1/2" />
+						<Input
+							placeholder="Filter by request text..."
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+							className="ps-9"
+							data-testid="admin-messages-search"
+						/>
+					</div>
+					<div className="flex shrink-0 items-center gap-2">
+						<p className="text-muted-foreground text-sm">
+							{rows.length} of {rawRows?.length ?? 0}
+						</p>
+					</div>
+				</div>
+
+				{selected.size > 0 && (
+					<SelectionBar
+						selected={selected}
+						clear={() => setSelected(new Set())}
+						allTags={allTags ?? []}
+					/>
+				)}
+
+				{isLoading ? (
+					<Loader />
+				) : (
+					<MessagesTable
+						rows={rows}
+						selected={selected}
+						toggleSelected={toggleSelected}
+						toggleVisibleAll={toggleVisibleAll}
+						tagsByMessage={tagsByMessage}
+					/>
+				)}
+			</div>
+		</div>
+	)
+}
+
+function TagsStrip({
+	allTags,
+	tagCounts,
+	activeTagSlug,
+	setActiveTagSlug,
+}: {
+	allTags: MessageTagType[]
+	tagCounts: Map<string, number>
+	activeTagSlug: string | null
+	setActiveTagSlug: (slug: string | null) => void
+}) {
+	return (
+		<section
+			className="space-y-2"
+			aria-label="Tag filter"
+			data-testid="admin-messages-tags-strip"
+		>
+			<div className="flex items-center justify-between">
+				<h2 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+					Tags
+				</h2>
+				<div className="flex items-center gap-1">
+					<EditTagsDialog tagCounts={tagCounts} />
+					<NewTagButton />
+				</div>
+			</div>
+			<div className="flex flex-wrap items-center gap-2">
+				<button
+					type="button"
+					onClick={() => setActiveTagSlug(null)}
+					className={cn(
+						buttonVariants({
+							variant: activeTagSlug == null ? 'soft' : 'ghost',
+							size: 'sm',
+						})
+					)}
+					data-testid="tag-filter-all"
+				>
+					All
+				</button>
+				{allTags.map((tag) => (
+					<button
+						key={tag.slug}
+						type="button"
+						onClick={() =>
+							setActiveTagSlug(activeTagSlug === tag.slug ? null : tag.slug)
+						}
+						className={cn(
+							buttonVariants({
+								variant: activeTagSlug === tag.slug ? 'soft' : 'ghost',
+								size: 'sm',
+							}),
+							'gap-1'
+						)}
+						data-testid="tag-filter-chip"
+						data-key={tag.slug}
+					>
+						{tag.label}
+						<span className="text-muted-foreground text-xs">
+							({tagCounts.get(tag.slug) ?? 0})
+						</span>
+					</button>
+				))}
+			</div>
+		</section>
+	)
+}
+
+function NewTagButton() {
+	const [open, setOpen] = useState(false)
+	const [slug, setSlug] = useState('')
+	const [label, setLabel] = useState('')
+	const [description, setDescription] = useState('')
+	const slugId = useId()
+	const labelId = useId()
+	const descId = useId()
+
+	const submit = () => {
+		const cleanSlug = slug.trim()
+		const cleanLabel = label.trim()
+		if (!cleanSlug || !cleanLabel) {
+			toastError('Slug and label are required')
+			return
+		}
+		const tx = messageTagsCollection.insert({
+			slug: cleanSlug,
+			label: cleanLabel,
+			description: description.trim() || null,
+			sort_order: 999,
+			created_at: new Date().toISOString(),
+		})
+		tx.isPersisted.promise.then(
+			() => {
+				toastSuccess(`Created tag "${cleanLabel}"`)
+				setSlug('')
+				setLabel('')
+				setDescription('')
+				setOpen(false)
+			},
+			(err: unknown) => {
+				toastError('Failed to create tag')
+				console.error(err)
+			}
+		)
+	}
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button size="sm" variant="ghost" data-testid="new-tag-button">
+					<Plus className="me-1 h-3 w-3" /> New tag
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent align="end" className="w-80 space-y-3">
+				<div className="space-y-1">
+					<label htmlFor={slugId} className="text-muted-foreground text-xs">
+						Slug (immutable)
+					</label>
+					<Input
+						id={slugId}
+						value={slug}
+						onChange={(e) => setSlug(e.target.value)}
+						placeholder="kebab-case-slug"
+						data-testid="new-tag-slug"
+					/>
+				</div>
+				<div className="space-y-1">
+					<label htmlFor={labelId} className="text-muted-foreground text-xs">
+						Label
+					</label>
+					<Input
+						id={labelId}
+						value={label}
+						onChange={(e) => setLabel(e.target.value)}
+						placeholder="Display label"
+						data-testid="new-tag-label"
+					/>
+				</div>
+				<div className="space-y-1">
+					<label htmlFor={descId} className="text-muted-foreground text-xs">
+						Description (optional)
+					</label>
+					<Textarea
+						id={descId}
+						value={description}
+						onChange={(e) => setDescription(e.target.value)}
+						className="min-h-[60px]"
+						data-testid="new-tag-description"
+					/>
+				</div>
+				<div className="flex justify-end gap-2">
+					<Button size="sm" variant="neutral" onClick={() => setOpen(false)}>
+						Cancel
+					</Button>
+					<Button size="sm" onClick={submit} data-testid="new-tag-submit">
+						Create
+					</Button>
+				</div>
+			</PopoverContent>
+		</Popover>
+	)
+}
+
+function EditTagsDialog({ tagCounts }: { tagCounts: Map<string, number> }) {
+	const [open, setOpen] = useState(false)
+	const { data: tagsIncludingArchived } = useLiveQuery(
+		(q) =>
+			q
+				.from({ tag: messageTagsCollection })
+				.orderBy(({ tag }) => tag.archived, 'asc')
+				.orderBy(({ tag }) => tag.sort_order, 'asc'),
+		[]
+	)
+	const rows = tagsIncludingArchived ?? []
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<Button size="sm" variant="ghost" data-testid="edit-tags-button">
+					<Pencil className="me-1 h-3 w-3" /> Edit tags
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="max-w-lg">
+				<DialogHeader>
+					<DialogTitle>Edit tags</DialogTitle>
+					<DialogDescription>
+						Rename labels, edit descriptions, or archive retired tags. Archived
+						tags stay in the database but disappear from pickers and public
+						chips. Slugs are immutable.
+					</DialogDescription>
+				</DialogHeader>
+				{rows.length === 0 ? (
+					<p className="text-muted-foreground py-4 text-center text-sm italic">
+						No tags yet.
+					</p>
+				) : (
+					<ul className="divide-y" data-testid="edit-tags-list">
+						{rows.map((tag) => (
+							<TagAdminRow
+								key={tag.slug}
+								tag={tag}
+								count={tagCounts.get(tag.slug) ?? 0}
+							/>
+						))}
+					</ul>
+				)}
+			</DialogContent>
+		</Dialog>
+	)
+}
+
+function TagAdminRow({ tag, count }: { tag: MessageTagType; count: number }) {
+	const [isEditing, setIsEditing] = useState(false)
+	const [label, setLabel] = useState(tag.label)
+	const [description, setDescription] = useState(tag.description ?? '')
+	const [confirmingDelete, setConfirmingDelete] = useState(false)
+	const labelId = useId()
+	const descId = useId()
+
+	const save = () => {
+		const trimmedLabel = label.trim()
+		if (!trimmedLabel) {
+			toastError('Label is required')
+			return
+		}
+		const tx = messageTagsCollection.update(tag.slug, (draft) => {
+			draft.label = trimmedLabel
+			draft.description = description.trim() || null
+		})
+		tx.isPersisted.promise.then(
+			() => {
+				toastSuccess(`Updated ${tag.slug}`)
+				setIsEditing(false)
+			},
+			(err: unknown) => {
+				toastError('Failed to update tag')
+				console.error(err)
+			}
+		)
+	}
+
+	const cancel = () => {
+		setLabel(tag.label)
+		setDescription(tag.description ?? '')
+		setIsEditing(false)
+	}
+
+	const toggleArchive = () => {
+		const tx = messageTagsCollection.update(tag.slug, (draft) => {
+			draft.archived = !tag.archived
+		})
+		tx.isPersisted.promise.then(
+			() => {
+				toastSuccess(
+					tag.archived ? `Restored "${tag.slug}"` : `Archived "${tag.slug}"`
+				)
+				setConfirmingDelete(false)
+			},
+			(err: unknown) => {
+				toastError(
+					tag.archived ? 'Failed to restore tag' : 'Failed to archive tag'
+				)
+				console.error(err)
+			}
+		)
+	}
+
+	return (
+		<li
+			className={cn('py-3', tag.archived && 'opacity-60')}
+			data-testid="edit-tag-row"
+			data-key={tag.slug}
+		>
+			{isEditing ? (
+				<div className="space-y-2">
+					<p className="text-muted-foreground font-mono text-xs">{tag.slug}</p>
+					<div className="space-y-1">
+						<label htmlFor={labelId} className="text-muted-foreground text-xs">
+							Label
+						</label>
+						<Input
+							id={labelId}
+							value={label}
+							onChange={(e) => setLabel(e.target.value)}
+							data-testid="edit-tag-label"
+							onKeyDown={(e) => {
+								if (e.key === 'Enter') save()
+								if (e.key === 'Escape') cancel()
+							}}
+						/>
+					</div>
+					<div className="space-y-1">
+						<label htmlFor={descId} className="text-muted-foreground text-xs">
+							Description
+						</label>
+						<Textarea
+							id={descId}
+							value={description}
+							onChange={(e) => setDescription(e.target.value)}
+							className="min-h-[60px]"
+						/>
+					</div>
+					<div className="flex justify-end gap-2">
+						<Button
+							size="icon"
+							variant="ghost"
+							onClick={save}
+							aria-label="Save"
+							data-testid="edit-tag-save"
+						>
+							<Check className="h-4 w-4" />
+						</Button>
+						<Button
+							size="icon"
+							variant="ghost"
+							onClick={cancel}
+							aria-label="Cancel"
+						>
+							<X className="h-4 w-4" />
+						</Button>
+					</div>
+				</div>
+			) : (
+				<div className="flex items-start justify-between gap-3">
+					<div className="min-w-0 flex-1">
+						<div className="flex items-baseline gap-2">
+							<span className="font-semibold">{tag.label}</span>
+							<span className="text-muted-foreground text-xs">({count})</span>
+							{tag.archived ? (
+								<Badge variant="secondary" className="gap-1 text-xs">
+									<Archive className="size-3" /> Archived
+								</Badge>
+							) : null}
+						</div>
+						<p className="text-muted-foreground font-mono text-xs">
+							{tag.slug}
+						</p>
+						{tag.description ? (
+							<p className="text-muted-foreground mt-1 text-sm">
+								{tag.description}
+							</p>
+						) : null}
+					</div>
+					<div className="flex shrink-0 gap-1">
+						<Button
+							size="icon"
+							variant="ghost"
+							onClick={() => setIsEditing(true)}
+							aria-label={`Edit ${tag.label}`}
+							data-testid="edit-tag-pencil"
+						>
+							<Pencil className="size-3.5" />
+						</Button>
+						{tag.archived ? (
+							<Button
+								size="icon"
+								variant="ghost"
+								onClick={toggleArchive}
+								aria-label={`Restore ${tag.label}`}
+								data-testid="restore-tag-button"
+							>
+								<Undo2 className="size-3.5" />
+							</Button>
+						) : (
+							<AlertDialog
+								open={confirmingDelete}
+								onOpenChange={setConfirmingDelete}
+							>
+								<AlertDialogTrigger asChild>
+									<Button
+										size="icon"
+										variant="ghost"
+										aria-label={`Archive ${tag.label}`}
+										data-testid="archive-tag-button"
+									>
+										<Archive className="text-destructive size-3.5" />
+									</Button>
+								</AlertDialogTrigger>
+								<AlertDialogContent>
+									<AlertDialogHeader>
+										<AlertDialogTitle>
+											Archive tag &ldquo;{tag.label}&rdquo;?
+										</AlertDialogTitle>
+										<AlertDialogDescription>
+											{count > 0
+												? `This tag will disappear from filters, pickers, and public chips on ${count} message${count === 1 ? '' : 's'}. The link rows stay in the database — restore later to bring them back.`
+												: 'This tag is not in use. You can restore it later.'}
+										</AlertDialogDescription>
+									</AlertDialogHeader>
+									<AlertDialogFooter>
+										<AlertDialogCancel>Cancel</AlertDialogCancel>
+										<AlertDialogAction
+											onClick={toggleArchive}
+											data-testid="archive-tag-confirm"
+										>
+											Archive
+										</AlertDialogAction>
+									</AlertDialogFooter>
+								</AlertDialogContent>
+							</AlertDialog>
+						)}
+					</div>
+				</div>
+			)}
+		</li>
+	)
+}
+
+function BulkAddSection({
+	userId,
+	allTags,
+}: {
+	userId: string | null
+	allTags: MessageTagType[]
+}) {
+	const [open, setOpen] = useState(false)
+	const [text, setText] = useState('')
+	const [lang, setLang] = useState('')
+	const [tagSlug, setTagSlug] = useState<string | null>(null)
+	const [tagPickerOpen, setTagPickerOpen] = useState(false)
+
+	const prompts = useMemo(
+		() =>
+			text
+				.split(/\n\s*\n/)
+				.map((s) => s.trim())
+				.filter((s) => s.length > 0),
+		[text]
+	)
+
+	const selectedTag = allTags.find((t) => t.slug === tagSlug) ?? null
+
+	const bulkAdd = useMutation({
+		mutationFn: async () => {
+			if (!userId) throw new Error('Not authenticated')
+			if (!lang) throw new Error('Pick a language first')
+			if (prompts.length === 0) throw new Error('No prompts to add')
+			const { data: requests } = await supabase
+				.from('phrase_request')
+				.insert(
+					prompts.map((prompt) => ({
+						prompt,
+						lang,
+						requester_uid: userId,
+					}))
+				)
+				.select()
+				.throwOnError()
+			const insertedRequests = requests ?? []
+
+			let insertedLinks: { message_id: string; tag_slug: string }[] = []
+			if (tagSlug && insertedRequests.length > 0) {
+				const { data: links } = await supabase
+					.from('message_tag_link')
+					.insert(
+						insertedRequests
+							.filter((r) => r.message_id)
+							.map((r) => ({
+								message_id: r.message_id as string,
+								tag_slug: tagSlug,
+							}))
+					)
+					.select()
+					.throwOnError()
+				insertedLinks = links ?? []
+			}
+			return { requests: insertedRequests, links: insertedLinks }
+		},
+		onSuccess: ({ requests, links }) => {
+			for (const row of requests) {
+				const parsed = PhraseRequestSchema.parse(row)
+				phraseRequestsCollection.utils.writeInsert(parsed)
+				if (parsed.message_id) {
+					messagesCollection.utils.writeInsert({
+						id: parsed.message_id,
+						created_at: parsed.created_at,
+					})
+				}
+			}
+			for (const link of links) {
+				messageTagLinksCollection.utils.writeInsert(
+					MessageTagLinkSchema.parse(link)
+				)
+			}
+			toastSuccess(
+				`Added ${requests.length} message${requests.length === 1 ? '' : 's'}` +
+					(tagSlug ? ` tagged "${tagSlug}"` : '')
+			)
+			setText('')
+		},
+		onError: (err: unknown) => {
+			toastError(
+				err instanceof Error ? err.message : 'Failed to bulk-add messages'
+			)
+			console.error(err)
+		},
+	})
+
+	return (
+		<section
+			className="space-y-2 rounded border p-3"
+			data-testid="admin-messages-bulk-add"
+		>
+			<button
+				type="button"
+				className="flex w-full items-center justify-between"
+				onClick={() => setOpen((v) => !v)}
+			>
+				<span className="inline-flex items-center gap-2 text-sm font-semibold">
+					<Plus className="h-4 w-4" />
+					Bulk add ({prompts.length} parsed)
+				</span>
+				<ChevronsUpDown className="text-muted-foreground h-4 w-4" />
+			</button>
+			{open && (
+				<div className="space-y-3 pt-2">
+					<div className="flex flex-col gap-2 @md:flex-row @md:items-center">
+						<p className="text-muted-foreground text-xs">Language</p>
+						<div className="max-w-xs grow">
+							<SelectOneLanguage value={lang} setValue={setLang} />
+						</div>
+					</div>
+					<div className="flex flex-col gap-2 @md:flex-row @md:items-center">
+						<p className="text-muted-foreground text-xs">Tag (optional)</p>
+						<Popover open={tagPickerOpen} onOpenChange={setTagPickerOpen}>
+							<PopoverTrigger asChild>
+								<Button
+									size="sm"
+									variant="soft"
+									data-testid="bulk-add-tag-button"
+								>
+									{selectedTag ? selectedTag.label : 'No tag'}
+									<ChevronsUpDown className="ms-1 h-3 w-3" />
+								</Button>
+							</PopoverTrigger>
+							<PopoverContent align="start" className="w-64 p-1">
+								<button
+									type="button"
+									className={cn(
+										'hover:bg-1-lo-neutral block w-full rounded p-2 text-start text-sm',
+										tagSlug === null && 'bg-1-mlo-primary'
+									)}
+									onClick={() => {
+										setTagSlug(null)
+										setTagPickerOpen(false)
+									}}
+									data-testid="bulk-add-tag-none"
+								>
+									<span className="text-muted-foreground italic">No tag</span>
+								</button>
+								<ul className="max-h-64 overflow-y-auto">
+									{allTags.map((tag) => (
+										<li key={tag.slug}>
+											<button
+												type="button"
+												className={cn(
+													'hover:bg-1-lo-neutral block w-full rounded p-2 text-start text-sm',
+													tagSlug === tag.slug && 'bg-1-mlo-primary'
+												)}
+												onClick={() => {
+													setTagSlug(tag.slug)
+													setTagPickerOpen(false)
+												}}
+												data-testid="bulk-add-tag-option"
+												data-key={tag.slug}
+											>
+												{tag.label}
+											</button>
+										</li>
+									))}
+								</ul>
+							</PopoverContent>
+						</Popover>
+					</div>
+					<Textarea
+						value={text}
+						onChange={(e) => setText(e.target.value)}
+						placeholder="Paste messages here. Blank lines separate them."
+						className="min-h-[180px] font-mono text-sm"
+						data-testid="bulk-add-textarea"
+					/>
+					<div className="flex items-center justify-end gap-2">
+						<Button
+							size="sm"
+							onClick={() => bulkAdd.mutate()}
+							disabled={
+								bulkAdd.isPending || prompts.length === 0 || !lang || !userId
+							}
+							data-testid="bulk-add-submit"
+						>
+							Add {prompts.length} message{prompts.length === 1 ? '' : 's'}
+						</Button>
+					</div>
+				</div>
+			)}
+		</section>
+	)
+}
+
+function SelectionBar({
+	selected,
+	clear,
+	allTags,
+}: {
+	selected: Set<string>
+	clear: () => void
+	allTags: MessageTagType[]
+}) {
+	const [tagPickerOpen, setTagPickerOpen] = useState(false)
+
+	const applyTag = (slug: string) => {
+		const ids = Array.from(selected)
+		Promise.all(
+			ids.map(async (message_id) => {
+				try {
+					const tx = messageTagLinksCollection.insert({
+						message_id,
+						tag_slug: slug,
+						created_at: new Date().toISOString(),
+					})
+					await tx.isPersisted.promise
+				} catch (err) {
+					// Duplicate (already tagged) is fine; surface other errors.
+					if (
+						err instanceof Error &&
+						!err.message.toLowerCase().includes('duplicate')
+					) {
+						throw err
+					}
+				}
+			})
+		).then(
+			() => {
+				toastSuccess(`Applied "${slug}" to ${ids.length}`)
+				setTagPickerOpen(false)
+			},
+			(err: unknown) => {
+				toastError('Failed to apply tag to some messages')
+				console.error(err)
+			}
+		)
+	}
+
+	const removeTag = (slug: string) => {
+		const ids = Array.from(selected)
+		Promise.all(
+			ids.map(async (message_id) => {
+				try {
+					const tx = messageTagLinksCollection.delete(`${message_id}--${slug}`)
+					await tx.isPersisted.promise
+				} catch (err) {
+					if (
+						err instanceof Error &&
+						!err.message.toLowerCase().includes('not found')
+					) {
+						throw err
+					}
+				}
+			})
+		).then(
+			() => {
+				toastSuccess(`Removed "${slug}" from ${ids.length}`)
+				setTagPickerOpen(false)
+			},
+			(err: unknown) => {
+				toastError('Failed to remove tag from some messages')
+				console.error(err)
+			}
+		)
+	}
+
+	return (
+		<div
+			className="bg-1-mlo-primary flex flex-wrap items-center gap-3 rounded border p-3"
+			data-testid="admin-messages-selection-bar"
+		>
+			<span className="text-sm font-semibold">
+				{selected.size} message{selected.size === 1 ? '' : 's'} selected
+			</span>
+			<Popover open={tagPickerOpen} onOpenChange={setTagPickerOpen}>
+				<PopoverTrigger asChild>
+					<Button size="sm" data-testid="apply-tag-button">
+						<Tags className="me-1 h-3 w-3" />
+						Apply / remove tag
+					</Button>
+				</PopoverTrigger>
+				<PopoverContent align="start" className="w-72 space-y-2">
+					<p className="text-muted-foreground text-xs">
+						Pick a tag to add to all {selected.size} selected, or remove from
+						them.
+					</p>
+					<ul className="max-h-64 overflow-y-auto">
+						{allTags.map((tag) => (
+							<li
+								key={tag.slug}
+								className="flex items-center justify-between gap-2 py-1"
+							>
+								<span className="text-sm">{tag.label}</span>
+								<div className="flex gap-1">
+									<Button
+										size="sm"
+										variant="ghost"
+										onClick={() => applyTag(tag.slug)}
+										aria-label={`Apply ${tag.label}`}
+										data-testid="apply-tag-option"
+										data-key={tag.slug}
+									>
+										<Plus className="h-3 w-3" />
+									</Button>
+									<Button
+										size="sm"
+										variant="ghost"
+										onClick={() => removeTag(tag.slug)}
+										aria-label={`Remove ${tag.label}`}
+									>
+										<X className="h-3 w-3" />
+									</Button>
+								</div>
+							</li>
+						))}
+					</ul>
+				</PopoverContent>
+			</Popover>
+			<Button size="sm" variant="ghost" onClick={clear}>
+				Clear selection
+			</Button>
+		</div>
+	)
+}
+
+function MessagesTable({
+	rows,
+	selected,
+	toggleSelected,
+	toggleVisibleAll,
+	tagsByMessage,
+}: {
+	rows: MessageRow[]
+	selected: Set<string>
+	toggleSelected: (id: string) => void
+	toggleVisibleAll: () => void
+	tagsByMessage: Map<string, MessageTagType[]>
+}) {
+	const allVisibleSelected =
+		rows.length > 0 && rows.every((r) => selected.has(r.message_id))
+
+	if (rows.length === 0) {
+		return (
+			<p className="text-muted-foreground py-8 text-center">
+				No messages match.
+			</p>
+		)
+	}
+
+	return (
+		<div
+			className="rounded border"
+			data-testid="admin-messages-table"
+			data-name="message-row"
+		>
+			<div className="bg-1-lo-neutral flex items-center gap-2 border-b px-3 py-2 text-xs">
+				<Checkbox
+					checked={allVisibleSelected}
+					onCheckedChange={toggleVisibleAll}
+					aria-label="Select all visible"
+					data-testid="select-all-visible"
+				/>
+				<span className="text-muted-foreground font-semibold tracking-wide uppercase">
+					Select all visible
+				</span>
+			</div>
+			<ul className="divide-y">
+				{rows.map((row) => (
+					<MessageRowItem
+						key={row.message_id}
+						row={row}
+						isSelected={selected.has(row.message_id)}
+						onToggle={() => toggleSelected(row.message_id)}
+						tags={tagsByMessage.get(row.message_id) ?? []}
+					/>
+				))}
+			</ul>
+		</div>
+	)
+}
+
+function MessageRowItem({
+	row,
+	isSelected,
+	onToggle,
+	tags,
+}: {
+	row: MessageRow
+	isSelected: boolean
+	onToggle: () => void
+	tags: MessageTagType[]
+}) {
+	return (
+		<li
+			className={cn(
+				'flex items-start gap-3 p-3',
+				isSelected && 'bg-1-mlo-primary'
+			)}
+			data-testid="message-row"
+			data-key={row.message_id}
+		>
+			<Checkbox
+				checked={isSelected}
+				onCheckedChange={onToggle}
+				aria-label="Select message"
+				className="mt-1"
+				data-testid="message-row-checkbox"
+			/>
+			<div className="min-w-0 flex-1 space-y-1">
+				<div className="flex items-center gap-2">
+					<LangBadge lang={row.lang} />
+					<span className="text-muted-foreground text-xs">
+						{ago(row.created_at)}
+					</span>
+				</div>
+				<p className="text-sm">{row.prompt}</p>
+				{tags.length > 0 && (
+					<div className="flex flex-wrap gap-1">
+						{tags.map((tag) => (
+							<Badge
+								key={tag.slug}
+								variant="outline"
+								data-testid="row-tag-chip"
+								data-key={tag.slug}
+							>
+								{tag.label}
+								<button
+									type="button"
+									className="hover:text-c-hi ms-1 -me-1 inline-flex items-center"
+									onClick={() => detachTag(row.message_id, tag.slug)}
+									aria-label={`Remove ${tag.label}`}
+								>
+									<X className="h-3 w-3" />
+								</button>
+							</Badge>
+						))}
+					</div>
+				)}
+			</div>
+			<Link
+				to="/admin/$lang/requests/$id"
+				params={{ lang: row.lang, id: row.request_id }}
+				className={buttonVariants({ variant: 'ghost', size: 'sm' })}
+				aria-label="Open admin request page"
+				data-testid="row-open-request"
+			>
+				<ExternalLink className="h-3 w-3" />
+				Request
+			</Link>
+		</li>
+	)
+}
+
+function detachTag(messageId: string, slug: string) {
+	const tx = messageTagLinksCollection.delete(`${messageId}--${slug}`)
+	tx.isPersisted.promise.catch((err: unknown) => {
+		toastError('Failed to remove tag')
+		console.error(err)
+	})
+}

--- a/src/routes/_user/admin/messages.index.tsx
+++ b/src/routes/_user/admin/messages.index.tsx
@@ -1,0 +1,3 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_user/admin/messages/')({})

--- a/src/routes/_user/admin/messages.lazy.tsx
+++ b/src/routes/_user/admin/messages.lazy.tsx
@@ -1,0 +1,32 @@
+import { CSSProperties } from 'react'
+import { createLazyFileRoute, Outlet } from '@tanstack/react-router'
+import { ShieldAlert } from 'lucide-react'
+
+import Callout from '@/components/ui/callout'
+import { useAuth } from '@/lib/use-auth'
+
+export const Route = createLazyFileRoute('/_user/admin/messages')({
+	component: AdminMessagesLayout,
+})
+
+const style = { viewTransitionName: 'main-area' } as CSSProperties
+
+function AdminMessagesLayout() {
+	const { isAdmin, userEmail } = useAuth()
+
+	return (
+		<main style={style}>
+			{!isAdmin && (
+				<div data-testid="admin-not-authorized-warning" className="mb-6">
+					<Callout variant="problem" Icon={ShieldAlert}>
+						<p>
+							You are logged in as <strong>{userEmail}</strong> who is not an
+							admin user; mutations on this page will fail.
+						</p>
+					</Callout>
+				</div>
+			)}
+			<Outlet />
+		</main>
+	)
+}

--- a/src/routes/_user/admin/messages.tsx
+++ b/src/routes/_user/admin/messages.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { languagesCollection } from '@/features/languages/collections'
+import { publicProfilesCollection } from '@/features/profile/collections'
+import {
+	messageTagLinksCollection,
+	messageTagsCollection,
+	messagesCollection,
+	phraseRequestsCollection,
+} from '@/features/requests/collections'
+
+export const Route = createFileRoute('/_user/admin/messages')({
+	staticData: {
+		appnav: ['/admin/messages'],
+		titleBar: { title: 'Admin', subtitle: 'Messages & Tags' },
+	},
+	loader: async () => {
+		await Promise.all([
+			languagesCollection.preload(),
+			publicProfilesCollection.preload(),
+			messagesCollection.preload(),
+			phraseRequestsCollection.preload(),
+			messageTagsCollection.preload(),
+			messageTagLinksCollection.preload(),
+		])
+	},
+})

--- a/src/routes/_user/learn/$lang.requests.$id.tsx
+++ b/src/routes/_user/learn/$lang.requests.$id.tsx
@@ -10,14 +10,13 @@ import { Loader } from '@/components/ui/loader'
 import { ShowAndLogError } from '@/components/errors'
 import { useRequest } from '@/features/requests/hooks'
 import { Markdown } from '@/components/my-markdown'
-import { Badge } from '@/components/ui/badge'
 import { CardlikeRequest } from '@/components/ui/card-like'
 import { RequestHeader } from '@/components/requests/request-header'
+import { MessageTagsRow } from '@/components/requests/message-tags-row'
 import { buttonVariants } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { cn, mapArrays } from '@/lib/utils'
 import type { CommentPhraseLinkType } from '@/features/requests/schemas'
-import Flagged from '@/components/flagged'
 import { Collapsible } from '@/components/ui/collapsible'
 import languages from '@/lib/languages'
 import { RequestButtonsRow } from '@/components/requests/request-buttons-row'
@@ -113,12 +112,7 @@ function RequestThreadPage() {
 				<RequestHeader request={request} />
 
 				<CardContent className="flex flex-col gap-6">
-					<Flagged>
-						<div className="inline-flex flex-row gap-2">
-							<Badge variant="outline">Food</Badge>
-							<Badge variant="outline">Beginners</Badge>
-						</div>
-					</Flagged>
+					<MessageTagsRow messageId={request.message_id!} />
 					<div className="text-lg">
 						<Markdown>{request.prompt}</Markdown>
 					</div>

--- a/src/routes/_user/learn/$lang.tsx
+++ b/src/routes/_user/learn/$lang.tsx
@@ -17,6 +17,8 @@ import {
 	playlistPhraseLinksCollection,
 } from '@/features/playlists/collections'
 import {
+	messageTagLinksCollection,
+	messageTagsCollection,
 	phraseRequestsCollection,
 	phraseRequestUpvotesCollection,
 } from '@/features/requests/collections'
@@ -60,6 +62,8 @@ export const Route = createFileRoute('/_user/learn/$lang')({
 			phrasePlaylistsCollection.preload(),
 			playlistPhraseLinksCollection.preload(),
 			phraseRequestsCollection.preload(),
+			messageTagsCollection.preload(),
+			messageTagLinksCollection.preload(),
 		]
 		if (context.auth.isAuth) {
 			preloads.push(

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -479,6 +479,7 @@ export type Database = {
 			}
 			message_tag: {
 				Row: {
+					archived: boolean
 					created_at: string
 					description: string | null
 					label: string
@@ -486,6 +487,7 @@ export type Database = {
 					sort_order: number
 				}
 				Insert: {
+					archived?: boolean
 					created_at?: string
 					description?: string | null
 					label: string
@@ -493,6 +495,7 @@ export type Database = {
 					sort_order?: number
 				}
 				Update: {
+					archived?: boolean
 					created_at?: string
 					description?: string | null
 					label?: string

--- a/supabase/migrations/20260526120000_request_messages_and_tags.sql
+++ b/supabase/migrations/20260526120000_request_messages_and_tags.sql
@@ -152,36 +152,31 @@ alter column message_id
 set not null;
 
 -- ── 5. auto-create message on phrase_request insert ─────────────────
--- security definer so the trigger can write to public.message without
--- the inserting user needing a direct INSERT policy on it. The trigger
--- only fires when message_id is null on the incoming row, so a client
--- that wants to attach to an existing message can do so by passing the
--- message_id explicitly (used later for reposts / cross-posting).
-create or replace function public.ensure_phrase_request_message () returns trigger language plpgsql security definer as $$
+-- A column DEFAULT (rather than a trigger) so that:
+--   • supabase's type generator sees a non-null column_default and emits
+--     message_id as optional on Insert
+--   • defaults fire under session_replication_role = replica too, so
+--     seed loads that omit message_id still populate it (no ENABLE
+--     ALWAYS dance)
+-- security definer because public.message has no INSERT policy for
+-- authenticated users — the function writes the orphan message row on
+-- their behalf. Clients that want to attach to an existing message
+-- (used later for reposts / cross-posting) can still pass message_id
+-- explicitly; the default only fires when the column is omitted.
+create or replace function public.create_orphan_message () returns uuid language plpgsql security definer as $$
 declare
-  new_message_id uuid;
+  new_id uuid;
 begin
-  if new.message_id is null then
-    insert into public.message default values returning id into new_message_id;
-    new.message_id := new_message_id;
-  end if;
-  return new;
+  insert into public.message default values returning id into new_id;
+  return new_id;
 end;
 $$;
 
-alter function public.ensure_phrase_request_message () owner to postgres;
+alter function public.create_orphan_message () owner to postgres;
 
-drop trigger if exists ensure_phrase_request_message on public.phrase_request;
-
-create trigger ensure_phrase_request_message
-before insert on public.phrase_request for each row
-execute function public.ensure_phrase_request_message ();
-
--- The seed loader runs with `session_replication_role = replica` to skip
--- triggers for speed, but this trigger is the only thing populating the
--- new not-null message_id column. ENABLE ALWAYS makes it fire in replica
--- mode too, so seed inserts that omit message_id still get one.
-alter table public.phrase_request enable always trigger ensure_phrase_request_message;
+alter table public.phrase_request
+alter column message_id
+set default public.create_orphan_message ();
 
 -- ── 6. seed the initial tags ────────────────────────────────────────
 insert into

--- a/supabase/migrations/20260527120000_archive_message_tags.sql
+++ b/supabase/migrations/20260527120000_archive_message_tags.sql
@@ -1,0 +1,4 @@
+-- Soft-delete (archive) for message_tag.
+--
+alter table public.message_tag
+add column if not exists archived boolean not null default false;


### PR DESCRIPTION
## Summary

Builds the admin surface for tagging request messages, on top of the schema introduced in #696.

Tags don't attach to requests directly — they attach to the **message** (the cross-language thing a request expresses) so when cross-posting / reposting lands later, tags travel with all of a message's request variants for free.

The `/learn` side stays strictly read-only (tag chips + a Settings gear for admins); all editing happens under `/admin`.

## What's here

### Migrations

- `20260526120000` (edited from #696) — replaces the BEFORE INSERT trigger with a SECURITY DEFINER function set as the column DEFAULT on `phrase_request.message_id`. Defaults fire under `session_replication_role = replica` (no ENABLE ALWAYS dance) and surface in `information_schema.columns`, so `pnpm run types` correctly emits `message_id?: string` on Insert.
- `20260527120000` — adds `message_tag.archived` (bool, default false) so retiring a tag is a soft-delete. Link rows stay intact; archived tags are filtered out of pickers and public chips client-side; admins can restore.

### `/admin/messages` — consolidated CRUD page

- **Bulk-add**: textarea where blank lines split into separate prompts (one batch → N `phrase_request` inserts → N messages via the new column default). Single language picker + optional single tag applied to the whole batch.
- **Tag filter strip** with per-tag counts; **"+ New tag"** popover; **"Edit tags"** dialog that lists every tag with inline pencil/save edit mode (label + description; slug stays immutable), an Archive action (AlertDialog warns about how many messages will lose the chip), and an Undo to restore archived tags.
- **Filter-by-text** input + **multi-select** with selection that persists across filter changes. A selection bar exposes "Apply / remove tag" against the selected set.
- Per-row tag chips with X-to-detach and a link to the admin request page.

### `/admin/messages/$id`

Stub for now — message id, `created_at`, inline tag editor, and the list of all `phrase_request` rows pointing at this message. Becomes the natural home for the canonical-gloss editor and cross-language variants when cross-posting ships.

### `/admin/$lang/requests/$id` enhancements

- Inline tag editor (chips + add-tag popover) on the request's message — same handler as the consolidated page.
- "View this message" link to `/admin/messages/$id`.
- **Other requests on this message** — siblings sharing the same `message_id`, each with a link to its own admin page.
- **Phrases attached** — uses `useRequestLinksPhraseIds` + `WithPhrase` to render each suggested phrase with a link to its admin page.

### `/learn/$lang/requests/$id`

- Read-only tag chips for everyone (returns `null` when there are no tags so empty requests don't render a stray row).
- Admins see a Settings gear next to the LangBadge in `RequestHeader` that links to the admin request page. No inline editing on `/learn`.

### Collections / hooks

- `messageTagsCollection` gains `onInsert` / `onUpdate` / `onDelete` so new-tag, edit-tag, and archive flows all route through the collection with optimistic state.
- `useMessageTags` and `useMessageTagsForMessage` filter `archived = true` so pickers and public chips never surface retired tags. The Edit-tags dialog runs its own query that includes archived tags, sorted active-first, with an opacity treatment + "Archived" badge for restorable rows.

### Admin shell polish

- `/admin` top layout wraps content in a `bg-card/50` page card so every admin route renders on the same padded surface.
- `/admin/messages` is registered as a "Messages" tab (`Tags` icon, `inexact: true`) and added to the appnav on `$lang.phrases` / `$lang.requests`, so the strip consistently shows **Phrases | Requests | Messages** across the per-language admin views.
- Custom in-page `<BackLink>` ("All requests", "All phrases", "All messages") is gone from all three admin detail pages — the navbar back chevron + appnav already cover that nav, and the BackLink was the third affordance pointing at the same place.

## What's NOT in this PR

- A canonical `gloss` text column on `message` (deferred — admins seed messages by creating requests; per-message text editing comes later).
- A real ranking column on `message_tag_link` (deferred — display order within a tag is currently just sort_order on the tag itself).
- Server-side pagination on `/admin/messages` (naive `useLiveQuery` over the whole table works at current scale).
- Display of tag chips on request feed cards / filter-by-tag on the feed (additive UI, no DB changes — can ship to `main` once this lands).

## Local setup

1. Pull `next`, `supabase db reset` (applies both migrations), `pnpm run types` (regenerates `src/types/supabase.ts`; the hand-patch in this PR will be overwritten cleanly), `pnpm dev`.
2. Insert yourself into `admin_user` via Studio.
3. Browse to `/admin/messages` — bulk-add a few prompts, create a tag, apply it across messages, archive it, view a single message, jump to a request's admin page, see the chips on `/learn/$lang/requests/$id`.

## Test plan

- [ ] `supabase db reset` applies both migrations clean; existing seeded `phrase_request` rows each have a `message_id` after the backfill.
- [ ] `pnpm run types` regenerates types; `message_id` is optional on Insert and `archived` shows up on `message_tag`.
- [ ] Non-admin on `/admin/messages` sees the warning and mutations fail at the RLS layer (UI is permissive).
- [ ] Admin can bulk-add prompts with a language + optional tag; new rows appear in the list with the tag applied.
- [ ] Edit-tags dialog: rename a label, edit description, archive a tag (chips disappear from filters/pickers and from public chips on `/learn`), restore it (chips come back).
- [ ] Apply / remove tag via the selection bar over multiple messages; per-row X detaches.
- [ ] `/admin/$lang/requests/$id`: inline tag toggle works; the message section links to `/admin/messages/$id`; related-requests + attached-phrases sections render when populated.
- [ ] `/learn/$lang/requests/$id`: chips render for everyone, gear visible only to admins, navbar back chevron and appnav handle navigation (no in-page BackLink).
- [ ] `pnpm check`, `pnpm lint` clean.

https://claude.ai/code/session_01C5BBVxcdfKzyjtm89N1bm2