### PR TITLE
Add component showcase sections for pickers, social, and chat UI

### DIFF
--- a/src/routes/themes.index.lazy.tsx
+++ b/src/routes/themes.index.lazy.tsx
@@ -1,20 +1,37 @@
-import { useEffect, useState, type CSSProperties } from 'react'
+import {
+	useEffect,
+	useId,
+	useState,
+	type CSSProperties,
+	type ReactNode,
+} from 'react'
 import { useLiveQuery } from '@tanstack/react-db'
 import { createLazyFileRoute } from '@tanstack/react-router'
 import { gt } from '@tanstack/db'
 import {
 	Bookmark,
+	Check,
 	ChevronDown,
+	ChevronsUpDown,
+	HeartPlus,
 	Lightbulb,
+	ListFilter,
+	ListPlus,
 	Logs,
 	Mail,
+	MessageCircleHeart,
+	MessageCircleWarningIcon,
 	MessageSquare,
+	MessageSquareQuote,
 	MoreVertical,
 	Reply,
 	Rocket,
+	Settings,
 	Share2,
 	Star,
+	TableProperties,
 	ThumbsUp,
+	type LucideIcon,
 } from 'lucide-react'
 import { allLanguageOptions } from '@/lib/languages'
 import {
@@ -28,6 +45,31 @@ import { languagesCollection } from '@/features/languages/collections'
 import { Badge, LangBadge } from '@/components/ui/badge'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
+import Callout from '@/components/ui/callout'
+import { DestructiveOctagon } from '@/components/ui/destructive-octagon-badge'
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+	CommandSeparator,
+} from '@/components/ui/command'
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from '@/components/ui/popover'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
 	CardContent,
 	CardDescription,
@@ -594,6 +636,296 @@ function ShowcaseButtonsAndType() {
 	)
 }
 
+// Static showcase of the CardStatusDropdown trigger across its visual states.
+// The real component (src/components/card-pieces/card-status-dropdown.tsx)
+// depends on auth + deck data, so we render a stripped-down twin here.
+const cardStatusShowcaseStates: Array<{
+	choice: 'active' | 'learned' | 'skipped' | 'nocard' | 'nodeck'
+	dot: string
+	label: string
+	active?: boolean
+}> = [
+	{ choice: 'active', dot: 'bg-primary', label: 'Active', active: true },
+	{ choice: 'learned', dot: 'bg-5-hi-success', label: 'Learned' },
+	{ choice: 'skipped', dot: 'bg-4-lo-neutral', label: 'Skipped' },
+	{ choice: 'nocard', dot: 'bg-3-lo-neutral', label: 'Not in deck' },
+	{ choice: 'nodeck', dot: 'bg-3-lo-neutral', label: 'Start deck' },
+]
+
+function ShowcaseCardStatusDropdown() {
+	return (
+		<div className="flex flex-wrap items-center gap-2">
+			{cardStatusShowcaseStates.map((s) => (
+				<Button
+					key={s.choice}
+					variant={s.active ? 'soft' : 'ghost'}
+					size="sm"
+					aria-label={`Card status: ${s.label}`}
+				>
+					<span
+						aria-hidden="true"
+						className={`size-2 shrink-0 rounded-full ${s.dot}`}
+					/>
+					<span>{s.label}</span>
+					<ChevronDown className="opacity-60" />
+				</Button>
+			))}
+		</div>
+	)
+}
+
+function ShowcaseTabsList() {
+	const tabs = [
+		{ value: 'requests', label: 'Requests', Icon: MessageCircleHeart },
+		{ value: 'phrases', label: 'Phrases', Icon: MessageSquareQuote },
+		{ value: 'playlists', label: 'Playlists', Icon: Logs },
+		{ value: 'comments', label: 'Comments', Icon: MessageSquare },
+	]
+	return (
+		<Tabs defaultValue="requests">
+			<TabsList>
+				{tabs.map(({ value, label, Icon }) => (
+					<TabsTrigger key={value} value={value}>
+						<Icon className="me-1 size-4" />
+						{label}
+					</TabsTrigger>
+				))}
+			</TabsList>
+		</Tabs>
+	)
+}
+
+const deckContextMenuItems: Array<{ label: string; Icon: LucideIcon }> = [
+	{ label: 'Manage Deck', Icon: TableProperties },
+	{ label: 'Request a Phrase', Icon: MessageCircleHeart },
+	{ label: 'Add a Phrase', Icon: MessageSquareQuote },
+	{ label: 'New Playlist', Icon: ListPlus },
+	{ label: 'Deck Settings', Icon: Settings },
+]
+
+function ShowcaseContextMenu() {
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger
+				render={<Button variant="ghost" size="icon" aria-label="Open menu" />}
+			>
+				<MoreVertical />
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="w-56">
+				{deckContextMenuItems.map(({ label, Icon }) => (
+					<DropdownMenuItem key={label}>
+						<Icon className="size-5" />
+						{label}
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	)
+}
+
+const feedFilterShowcaseOptions = [
+	['all', 'All types'],
+	['request', 'Requests'],
+	['playlist', 'Playlists'],
+	['phrase', 'New Phrases'],
+] as const
+
+function ShowcaseFilterMenu() {
+	const [active, setActive] = useState<string>('all')
+	const activeLabel =
+		feedFilterShowcaseOptions.find(([v]) => v === active)?.[1] ?? 'All types'
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger
+				render={
+					<Button
+						variant="ghost"
+						size="sm"
+						aria-label="Filter feed content"
+						className="text-muted-foreground gap-1 text-xs"
+					/>
+				}
+			>
+				<ListFilter className="size-3.5" />
+				{activeLabel}
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuLabel>Show content type</DropdownMenuLabel>
+				<DropdownMenuSeparator />
+				{feedFilterShowcaseOptions.map(([value, label]) => (
+					<DropdownMenuItem key={value} onClick={() => setActive(value)}>
+						<Check className={active === value ? 'opacity-100' : 'opacity-0'} />
+						{label}
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	)
+}
+
+function ShowcaseCallouts() {
+	return (
+		<div className="space-y-3">
+			<Callout variant="default" size="sm" Icon={HeartPlus}>
+				<p className="font-medium">Default callout</p>
+				<p className="text-sm">
+					Tinted in the primary hue — for guidance, tips, and friendly nudges.
+				</p>
+			</Callout>
+			<Callout variant="problem" size="sm" alert Icon={DestructiveOctagon}>
+				<p className="font-medium">Problem callout</p>
+				<p className="text-sm">
+					Carries the danger hue and an alert role — for errors and blocked
+					actions.
+				</p>
+			</Callout>
+			<Callout variant="ghost" size="sm" Icon={MessageCircleWarningIcon}>
+				<p className="font-medium">Ghost callout</p>
+				<p className="text-sm">
+					Quiet muted surface — for context the reader can take or leave.
+				</p>
+			</Callout>
+		</div>
+	)
+}
+
+// Mocked language picker — mirrors SelectOneOfYourLanguages without depending
+// on auth/profile state. Two "your languages" up top, the rest below.
+const showcaseKnownLangs = ['hin', 'tam'] as const
+
+function ShowcaseLanguagePicker() {
+	const [value, setValue] = useState<string>('hin')
+	const [open, setOpen] = useState(false)
+	const id = useId()
+
+	const otherLanguages = allLanguageOptions.filter(
+		(opt) => !showcaseKnownLangs.includes(opt.value as never)
+	)
+
+	const onSelect = (next: string) => {
+		setValue(next === value ? '' : next)
+		setOpen(false)
+	}
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild className="w-full">
+				<Button
+					variant="soft"
+					role="combobox"
+					aria-controls={id}
+					aria-expanded={open}
+					className="bg-card/50 text-foreground justify-between font-normal"
+				>
+					{value
+						? (allLanguageOptions.find((l) => l.value === value)?.label ??
+							value)
+						: 'Select language...'}
+					<ChevronsUpDown className="ms-2 size-4 shrink-0 opacity-50" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent id={id} className="p-0">
+				<Command>
+					<CommandInput placeholder="Search language..." className="my-1" />
+					<CommandList>
+						<CommandEmpty>No language found.</CommandEmpty>
+						<CommandGroup>
+							{showcaseKnownLangs.map((lang) => (
+								<CommandItem key={lang} value={lang} onSelect={onSelect}>
+									<Check
+										className={cn(
+											'me-2 size-4',
+											value === lang ? 'opacity-100' : 'opacity-0'
+										)}
+									/>
+									{allLanguageOptions.find((l) => l.value === lang)?.label} (
+									{lang})
+								</CommandItem>
+							))}
+						</CommandGroup>
+						<CommandSeparator />
+						<CommandGroup>
+							{otherLanguages.slice(0, 50).map((language) => (
+								<CommandItem
+									key={language.value}
+									value={language.value}
+									onSelect={onSelect}
+								>
+									<Check
+										className={cn(
+											'me-2 size-4',
+											value === language.value ? 'opacity-100' : 'opacity-0'
+										)}
+									/>
+									{language.label} ({language.value})
+								</CommandItem>
+							))}
+						</CommandGroup>
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	)
+}
+
+function SmolShowcaseBlock({
+	label,
+	children,
+}: {
+	label: string
+	children: ReactNode
+}) {
+	return (
+		<div className="space-y-2">
+			<h3 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+				{label}
+			</h3>
+			{children}
+		</div>
+	)
+}
+
+function SmolShowcase() {
+	return (
+		<section className="@container space-y-6">
+			<div className="space-y-1">
+				<h2 className="text-lg font-semibold">Pickers, menus & callouts</h2>
+				<p className="text-muted-foreground text-sm">
+					Smaller building blocks shown in isolation — dropdowns, tabs, the
+					language picker, and the three callout variants.
+				</p>
+			</div>
+			<div className="grid gap-6 @2xl:grid-cols-2">
+				<SmolShowcaseBlock label="Card status dropdown">
+					<ShowcaseCardStatusDropdown />
+				</SmolShowcaseBlock>
+				<SmolShowcaseBlock label="Tabs list picker">
+					<ShowcaseTabsList />
+				</SmolShowcaseBlock>
+				<SmolShowcaseBlock label="Context menu">
+					<div className="flex items-center gap-2">
+						<ShowcaseContextMenu />
+						<span className="text-muted-foreground text-sm">
+							Click for menu items
+						</span>
+					</div>
+				</SmolShowcaseBlock>
+				<SmolShowcaseBlock label="Filter dropdown">
+					<ShowcaseFilterMenu />
+				</SmolShowcaseBlock>
+				<SmolShowcaseBlock label="Select one of your languages">
+					<div className="max-w-xs">
+						<ShowcaseLanguagePicker />
+					</div>
+				</SmolShowcaseBlock>
+				<SmolShowcaseBlock label="Callouts">
+					<ShowcaseCallouts />
+				</SmolShowcaseBlock>
+			</div>
+		</section>
+	)
+}
+
 function ComponentShowcase() {
 	return (
 		<section className="@container space-y-6">
@@ -695,6 +1027,8 @@ function ThemesPage() {
 	return (
 		<div className="@container mx-auto max-w-5xl space-y-8 p-6">
 			<ComponentShowcase />
+
+			<SmolShowcase />
 
 			<header className="space-y-2">
 				<h1 className="text-2xl font-bold">Per-language palette</h1>

--- a/src/routes/themes.index.lazy.tsx
+++ b/src/routes/themes.index.lazy.tsx
@@ -43,6 +43,7 @@ import {
 import { cn } from '@/lib/utils'
 import { languagesCollection } from '@/features/languages/collections'
 import { Badge, LangBadge } from '@/components/ui/badge'
+import { statusStrings } from '@/components/card-pieces/card-status-dropdown'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
 import Callout from '@/components/ui/callout'
@@ -636,39 +637,97 @@ function ShowcaseButtonsAndType() {
 	)
 }
 
-// Static showcase of the CardStatusDropdown trigger across its visual states.
-// The real component (src/components/card-pieces/card-status-dropdown.tsx)
-// depends on auth + deck data, so we render a stripped-down twin here.
+// Showcase twin of CardStatusDropdown — the real component
+// (src/components/card-pieces/card-status-dropdown.tsx) depends on auth + deck
+// data, so we render the trigger across its visual states and reuse the
+// exported `statusStrings` map for the menu copy.
+type ShowableActions = 'active' | 'learned' | 'skipped' | 'nocard' | 'nodeck'
+
 const cardStatusShowcaseStates: Array<{
-	choice: 'active' | 'learned' | 'skipped' | 'nocard' | 'nodeck'
+	choice: ShowableActions
 	dot: string
-	label: string
-	active?: boolean
+	soft?: boolean
 }> = [
-	{ choice: 'active', dot: 'bg-primary', label: 'Active', active: true },
-	{ choice: 'learned', dot: 'bg-5-hi-success', label: 'Learned' },
-	{ choice: 'skipped', dot: 'bg-4-lo-neutral', label: 'Skipped' },
-	{ choice: 'nocard', dot: 'bg-3-lo-neutral', label: 'Not in deck' },
-	{ choice: 'nodeck', dot: 'bg-3-lo-neutral', label: 'Start deck' },
+	{ choice: 'active', dot: 'bg-primary', soft: true },
+	{ choice: 'learned', dot: 'bg-5-hi-success' },
+	{ choice: 'skipped', dot: 'bg-4-lo-neutral' },
+	{ choice: 'nocard', dot: 'bg-3-lo-neutral' },
+	{ choice: 'nodeck', dot: 'bg-3-lo-neutral' },
 ]
+
+function CardStatusMenuItem({ choice }: { choice: ShowableActions }) {
+	const { Icon, iconClassName, action, actionSecond } = statusStrings[choice]
+	return (
+		<DropdownMenuItem>
+			<div className="flex flex-row items-center gap-2 py-1 pe-2">
+				<span className="h-5 w-5">
+					<Icon className={iconClassName} aria-hidden="true" />
+				</span>
+				<div>
+					<p className="font-bold">{action}</p>
+					<p className="text-opacity-80 text-sm">{actionSecond}</p>
+				</div>
+			</div>
+		</DropdownMenuItem>
+	)
+}
+
+function CardStatusShowcaseTrigger({
+	choice,
+	dot,
+	soft,
+	defaultOpen,
+}: {
+	choice: ShowableActions
+	dot: string
+	soft?: boolean
+	defaultOpen?: boolean
+}) {
+	const { name } = statusStrings[choice]
+	// `nocard` collapses the menu to a single "Add to deck" item, matching
+	// the real CardStatusDropdown behaviour.
+	const items: ShowableActions[] =
+		choice === 'nocard' || choice === 'nodeck'
+			? [choice]
+			: ['active', 'learned', 'skipped']
+	return (
+		<DropdownMenu defaultOpen={defaultOpen}>
+			<DropdownMenuTrigger
+				render={
+					<Button
+						variant={soft ? 'soft' : 'ghost'}
+						size="sm"
+						aria-label={`Card status: ${name}`}
+					/>
+				}
+			>
+				<span
+					aria-hidden="true"
+					className={`size-2 shrink-0 rounded-full ${dot}`}
+				/>
+				<span>{name}</span>
+				<ChevronDown className="opacity-60" />
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="start">
+				{items.map((c) => (
+					<CardStatusMenuItem key={c} choice={c} />
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	)
+}
 
 function ShowcaseCardStatusDropdown() {
 	return (
 		<div className="flex flex-wrap items-center gap-2">
-			{cardStatusShowcaseStates.map((s) => (
-				<Button
+			{cardStatusShowcaseStates.map((s, i) => (
+				<CardStatusShowcaseTrigger
 					key={s.choice}
-					variant={s.active ? 'soft' : 'ghost'}
-					size="sm"
-					aria-label={`Card status: ${s.label}`}
-				>
-					<span
-						aria-hidden="true"
-						className={`size-2 shrink-0 rounded-full ${s.dot}`}
-					/>
-					<span>{s.label}</span>
-					<ChevronDown className="opacity-60" />
-				</Button>
+					choice={s.choice}
+					dot={s.dot}
+					soft={s.soft}
+					defaultOpen={i === 0}
+				/>
 			))}
 		</div>
 	)
@@ -876,7 +935,7 @@ function SmolShowcaseBlock({
 	children: ReactNode
 }) {
 	return (
-		<div className="space-y-2">
+		<div className="mb-6 break-inside-avoid space-y-2">
 			<h3 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
 				{label}
 			</h3>
@@ -895,7 +954,7 @@ function SmolShowcase() {
 					language picker, and the three callout variants.
 				</p>
 			</div>
-			<div className="grid gap-6 @2xl:grid-cols-2">
+			<div className="gap-x-6 @2xl:columns-2">
 				<SmolShowcaseBlock label="Card status dropdown">
 					<ShowcaseCardStatusDropdown />
 				</SmolShowcaseBlock>

--- a/src/routes/themes.index.lazy.tsx
+++ b/src/routes/themes.index.lazy.tsx
@@ -9,11 +9,13 @@ import { useLiveQuery } from '@tanstack/react-db'
 import { createLazyFileRoute } from '@tanstack/react-router'
 import { gt } from '@tanstack/db'
 import {
+	BookA,
 	Bookmark,
 	Check,
 	ChevronDown,
 	ChevronsUpDown,
 	HeartPlus,
+	Info,
 	Lightbulb,
 	ListFilter,
 	ListPlus,
@@ -23,14 +25,20 @@ import {
 	MessageCircleWarningIcon,
 	MessageSquare,
 	MessageSquareQuote,
+	MonitorCog,
+	Moon,
 	MoreVertical,
 	Reply,
 	Rocket,
+	Send,
 	Settings,
 	Share2,
 	Star,
+	Sun,
 	TableProperties,
 	ThumbsUp,
+	UserCheck,
+	X,
 	type LucideIcon,
 } from 'lucide-react'
 import { allLanguageOptions } from '@/lib/languages'
@@ -47,6 +55,7 @@ import { statusStrings } from '@/components/card-pieces/card-status-dropdown'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
 import Callout from '@/components/ui/callout'
+import { ChoiceTile } from '@/components/ui/choice-tile'
 import { DestructiveOctagon } from '@/components/ui/destructive-octagon-badge'
 import {
 	Command,
@@ -927,6 +936,284 @@ function ShowcaseLanguagePicker() {
 	)
 }
 
+function ShowcaseChoiceTileGroup() {
+	const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('system')
+	const [font, setFont] = useState<'default' | 'dyslexic'>('default')
+	return (
+		<div className="space-y-4">
+			<div className="space-y-1">
+				<p className="text-sm font-medium">Appearance</p>
+				<div className="flex gap-2">
+					{(
+						[
+							['light', 'Light', Sun],
+							['dark', 'Dark', Moon],
+							['system', 'System', MonitorCog],
+						] as const
+					).map(([value, label, Icon]) => (
+						<ChoiceTile
+							key={value}
+							selected={theme === value}
+							onClick={() => setTheme(value)}
+							className="flex flex-1 items-center gap-3 px-4 py-3 text-start"
+						>
+							<Icon className="size-5 shrink-0" />
+							<span className="font-medium">{label}</span>
+						</ChoiceTile>
+					))}
+				</div>
+			</div>
+			<div className="space-y-1">
+				<p className="text-sm font-medium">Font style</p>
+				<div className="flex gap-2">
+					{(
+						[
+							['default', 'Default', 'Atkinson Hyperlegible'],
+							['dyslexic', 'Dyslexic', 'OpenDyslexic'],
+						] as const
+					).map(([value, label, sub]) => (
+						<ChoiceTile
+							key={value}
+							selected={font === value}
+							onClick={() => setFont(value)}
+							className="flex flex-1 items-center gap-3 px-4 py-3 text-start"
+						>
+							<BookA className="size-5 shrink-0" />
+							<div>
+								<span className="block font-medium">{label}</span>
+								<span className="text-muted-foreground text-sm">{sub}</span>
+							</div>
+						</ChoiceTile>
+					))}
+				</div>
+			</div>
+		</div>
+	)
+}
+
+// Twin of the friend-chat bubble (src/routes/_user/friends/chats.$friendUid.tsx).
+// `isMine` flips alignment + drops the avatar, matching the live component.
+function ChatBubble({
+	isMine,
+	username,
+	initials,
+	seed,
+	label,
+	time,
+	body,
+}: {
+	isMine: boolean
+	username: string
+	initials: string
+	seed: string
+	label: string
+	time: string
+	body: string
+}) {
+	return (
+		<div
+			className={cn(
+				'max-w-[80%] items-start gap-2',
+				isMine
+					? 'align-end ms-auto justify-end ps-[10%]'
+					: 'align-start me-auto justify-start pe-[10%]'
+			)}
+		>
+			<div>
+				<div className="mb-1 flex items-center gap-2">
+					{!isMine && (
+						<Avatar className="h-8 w-8 shrink-0">
+							<AvatarFallback seed={seed} className="text-xs font-bold">
+								{initials}
+							</AvatarFallback>
+						</Avatar>
+					)}
+					<p
+						className={cn(
+							'text-muted-foreground grow text-xs',
+							isMine && 'text-end'
+						)}
+					>
+						{isMine ? (
+							<>
+								{label} &middot; {time}
+							</>
+						) : (
+							<>
+								{time} &middot; {label}
+							</>
+						)}
+					</p>
+				</div>
+				<div
+					className={cn(
+						'rounded-2xl border px-3 py-2 text-sm',
+						isMine
+							? 'bg-1-mlo-primary border-2-mlo-primary'
+							: 'bg-card border-border'
+					)}
+				>
+					{body}
+				</div>
+			</div>
+			<span className="sr-only">{isMine ? 'You' : username}</span>
+		</div>
+	)
+}
+
+function ShowcaseChatBubbles() {
+	return (
+		<div className="bg-base-lo-neutral flex flex-col gap-4 rounded border p-4">
+			<ChatBubble
+				isMine={false}
+				username="Priya L."
+				initials="PL"
+				seed="priya"
+				label="Sent a phrase recommendation"
+				time="2m ago"
+				body="Here's the polite-greeting one we talked about — perfect for grandparents."
+			/>
+			<ChatBubble
+				isMine
+				username="You"
+				initials="Yo"
+				seed="self"
+				label="Added this to your deck"
+				time="just now"
+				body="Got it — adding to my deck now, thanks!"
+			/>
+		</div>
+	)
+}
+
+// Twin of ProfileWithRelationship + AvatarIconRow. Renders the four states
+// (unconnected, pending-from-them, pending-from-me, friends) side by side
+// without depending on real profile data or the router.
+function ProfilePill({
+	username,
+	seed,
+	children,
+}: {
+	username: string
+	seed: string
+	children: ReactNode
+}) {
+	return (
+		<div className="flex w-full flex-row items-center gap-4">
+			<div className="hover:bg-1-mlo-primary hover:border-2-mlo-primary flex grow flex-row items-center justify-start gap-4 rounded-2xl border border-transparent p-2">
+				<Avatar className="size-8">
+					<AvatarFallback seed={seed} className="text-xs font-bold">
+						{username.slice(0, 2).toUpperCase()}
+					</AvatarFallback>
+				</Avatar>
+				<span>{username}</span>
+			</div>
+			<div className="flex flex-row gap-2">{children}</div>
+		</div>
+	)
+}
+
+function ShowcaseProfilePills() {
+	return (
+		<div className="divide-y rounded border">
+			<ProfilePill username="Priya L." seed="priya">
+				<Button
+					variant="default"
+					size="icon"
+					className="size-8"
+					aria-label="Send friend request"
+				>
+					<Send className="me-[0.1rem] mt-[0.1rem] size-6" />
+				</Button>
+			</ProfilePill>
+			<ProfilePill username="Marco R." seed="marco">
+				<Button
+					variant="default"
+					size="icon"
+					className="size-8"
+					aria-label="Accept invitation"
+				>
+					<ThumbsUp />
+				</Button>
+				<Button
+					variant="neutral"
+					size="icon"
+					className="size-8"
+					aria-label="Decline invitation"
+				>
+					<X className="size-6 p-0" />
+				</Button>
+			</ProfilePill>
+			<ProfilePill username="Theo K." seed="theo">
+				<Button
+					variant="neutral"
+					size="icon"
+					className="size-8"
+					aria-label="Cancel friend request"
+				>
+					<X className="size-6 p-0" />
+				</Button>
+			</ProfilePill>
+			<ProfilePill username="Sofía M." seed="sofia">
+				<UserCheck className="size-6 p-0" />
+			</ProfilePill>
+		</div>
+	)
+}
+
+function ShowcaseIntroCallout() {
+	return (
+		<div className="space-y-2">
+			<div className="border-3-mlo-primary bg-1-mlo-primary flex items-start gap-2 rounded border px-3 py-2 text-sm">
+				<Info className="text-primary mt-0.5 size-4 shrink-0" />
+				<div className="flex-1">
+					<span className="text-foreground/80">
+						Quick reminder: reviews use a 4 am cutoff, so cards due "today" stay
+						available until tomorrow morning.
+					</span>{' '}
+					<button className="text-primary underline hover:no-underline">
+						Learn more
+					</button>
+				</div>
+			</div>
+			<div className="border-3-mlo-primary bg-1-mlo-primary flex items-start gap-2 rounded border px-3 py-2 text-sm">
+				<Info className="text-primary mt-0.5 size-4 shrink-0" />
+				<div className="flex-1">
+					<span className="text-foreground/80">
+						No "show more" link when the callout stands on its own.
+					</span>
+				</div>
+			</div>
+		</div>
+	)
+}
+
+function ShowcaseAvatarSizes() {
+	const sizes: Array<{ cls: string; label: string }> = [
+		{ cls: 'size-6', label: '6' },
+		{ cls: 'size-8', label: '8' },
+		{ cls: 'size-10', label: '10 (default)' },
+		{ cls: 'size-14', label: '14' },
+		{ cls: 'size-20', label: '20' },
+	]
+	const seeds = ['priya', 'marco', 'theo', 'sofia', 'kenji']
+	const initials = ['PL', 'MR', 'TK', 'SM', 'KO']
+	return (
+		<div className="flex flex-wrap items-end gap-4">
+			{sizes.map((s, i) => (
+				<div key={s.label} className="flex flex-col items-center gap-2">
+					<Avatar className={s.cls}>
+						<AvatarFallback seed={seeds[i]} className="font-bold">
+							{initials[i]}
+						</AvatarFallback>
+					</Avatar>
+					<span className="text-muted-foreground text-xs">{s.label}</span>
+				</div>
+			))}
+		</div>
+	)
+}
+
 function SmolShowcaseBlock({
 	label,
 	children,
@@ -979,6 +1266,37 @@ function SmolShowcase() {
 				</SmolShowcaseBlock>
 				<SmolShowcaseBlock label="Callouts">
 					<ShowcaseCallouts />
+				</SmolShowcaseBlock>
+			</div>
+		</section>
+	)
+}
+
+function SocialShowcase() {
+	return (
+		<section className="@container space-y-6">
+			<div className="space-y-1">
+				<h2 className="text-lg font-semibold">Profiles, chat & onboarding</h2>
+				<p className="text-muted-foreground text-sm">
+					Avatar sizes, friend-relationship pills, the chat bubble pair, and the
+					inline intro callout — each shown across the states the app uses.
+				</p>
+			</div>
+			<div className="gap-x-6 @2xl:columns-2">
+				<SmolShowcaseBlock label="Choice tile group">
+					<ShowcaseChoiceTileGroup />
+				</SmolShowcaseBlock>
+				<SmolShowcaseBlock label="Avatar sizes">
+					<ShowcaseAvatarSizes />
+				</SmolShowcaseBlock>
+				<SmolShowcaseBlock label="Profile pill (relationship states)">
+					<ShowcaseProfilePills />
+				</SmolShowcaseBlock>
+				<SmolShowcaseBlock label="Intro callout">
+					<ShowcaseIntroCallout />
+				</SmolShowcaseBlock>
+				<SmolShowcaseBlock label="Chat bubbles (theirs + yours)">
+					<ShowcaseChatBubbles />
 				</SmolShowcaseBlock>
 			</div>
 		</section>
@@ -1088,6 +1406,8 @@ function ThemesPage() {
 			<ComponentShowcase />
 
 			<SmolShowcase />
+
+			<SocialShowcase />
 
 			<header className="space-y-2">
 				<h1 className="text-2xl font-bold">Per-language palette</h1>


### PR DESCRIPTION
## Summary

Expands the themes showcase page with new component demonstration sections covering dropdowns, tabs, language pickers, callouts, chat bubbles, profile pills, and avatar sizes. These additions provide visual reference for UI patterns used throughout the app without depending on auth or real data.

## Changes

- **Card Status Dropdown showcase**: Renders all five card status states (active, learned, skipped, nocard, nodeck) with their respective menu items, reusing the `statusStrings` map from the real component
- **Tabs, context menu, and filter dropdown**: Demonstrates tab navigation, deck context menu items, and feed filter states
- **Language picker**: Mocked version of `SelectOneOfYourLanguages` showing the combobox pattern with "your languages" section and searchable full list
- **Callouts**: Three variants (default, problem, ghost) with appropriate icons and messaging
- **Choice tiles**: Appearance and font style selection UI
- **Chat bubbles**: Twin of the friend-chat component showing both incoming and outgoing message states with avatars, timestamps, and labels
- **Profile pills**: Four relationship states (unconnected, pending-from-them, pending-from-me, friends) with appropriate action buttons
- **Avatar sizes**: Reference grid showing five size variants (6, 8, 10, 14, 20)
- **Intro callout**: Inline callout pattern with optional "Learn more" link

New sections `SmolShowcase()` and `SocialShowcase()` organize these components into two themed groups with descriptive headers and use a `SmolShowcaseBlock` wrapper for consistent labeling.

## Implementation Details

- Added 20+ new icon imports from lucide-react
- Imported UI components: `Callout`, `ChoiceTile`, `DestructiveOctagon`, `Command`, `DropdownMenu`, `Popover`, `Tabs`
- Used `useId()` for accessible combobox controls in the language picker
- Leveraged `cn()` utility for conditional styling in chat bubbles and profile pills
- All showcase components are self-contained and don't depend on auth, router, or live data

https://claude.ai/code/session_01V9cZnNJ4bkiSKrVKttZ5qr