### PR TITLE
Add message tagging system for cross-language request grouping

### DIFF
--- a/scenetest/scenes/admin-messages.spec.md
+++ b/scenetest/scenes/admin-messages.spec.md
@@ -1,0 +1,87 @@
+# admin sees /admin/messages page with the seeded tag filter strip
+
+// All nine starter tags are seeded by 20260526120000_request_messages_and_tags.sql,
+// so the strip should always have at least one chip and the "Day 1" tag in particular.
+
+setup: supabase.from('admin_user').upsert({ uid: '[learner.key]' })
+cleanup: supabase.from('admin_user').delete().eq('uid', '[learner.key]')
+
+learner:
+
+- login
+- openTo /admin/messages
+- up
+- see admin-messages-page
+- see admin-messages-tags-strip
+- see tag-filter-all
+- see admin-messages-tags-strip day-1
+- notSee admin-not-authorized-warning
+
+# non-admin sees the warning on /admin/messages
+
+friend:
+
+- login
+- openTo /admin/messages
+- up
+- see admin-messages-page
+- see admin-not-authorized-warning
+
+# admin sees the gear on a request page and lands on the admin request detail
+
+setup: supabase.from('admin_user').upsert({ uid: '[learner.key]' })
+cleanup: supabase.from('admin_user').delete().eq('uid', '[learner.key]')
+
+learner:
+
+- login
+- openTo /learn/[team.lang_full]/requests/[team.full_request_for_comments]
+- up
+- see request-detail-page
+- see admin-request-gear-link
+- click admin-request-gear-link
+- up
+- see admin-request-detail
+- see admin-request-message-section
+
+# non-admin does not see the request gear icon
+
+friend:
+
+- login
+- openTo /learn/[team.lang_full]/requests/[team.full_request_for_comments]
+- up
+- see request-detail-page
+- notSee admin-request-gear-link
+
+# admin opens the Edit tags dialog and sees the seeded vocabulary
+
+setup: supabase.from('admin_user').upsert({ uid: '[learner.key]' })
+cleanup: supabase.from('admin_user').delete().eq('uid', '[learner.key]')
+
+learner:
+
+- login
+- openTo /admin/messages
+- up
+- see admin-messages-page
+- click edit-tags-button
+- up
+- see edit-tags-list
+- see edit-tags-list day-1
+- see edit-tags-list introductions
+
+# admin appnav exposes the Messages tab from the per-language admin views
+
+setup: supabase.from('admin_user').upsert({ uid: '[learner.key]' })
+cleanup: supabase.from('admin_user').delete().eq('uid', '[learner.key]')
+
+learner:
+
+- login
+- openTo /admin/[team.lang_full]/requests
+- up
+- see appnav-messages
+- click appnav-messages
+- up
+- see admin-messages-page


### PR DESCRIPTION
## Summary

Introduces a message tagging infrastructure that enables admins to organize and categorize phrase requests across languages. Messages are the cross-language abstraction behind requests—today created 1:1 with each request via a database trigger, but designed to support future request reposting/cross-posting where multiple requests share a single message and its tags.

## Key Changes

**Database & Schema**
- Added three new tables: `message` (id, created_at), `message_tag` (slug PK, label, description, sort_order, archived), and `message_tag_link` (join table)
- Server-side trigger auto-creates message rows on phrase_request insert
- Added `message_id` field to PhraseRequestSchema (optional at insert time, always populated in synced rows)
- Implemented soft-delete (archive) for message tags to preserve historical links

**Admin UI Pages**
- `/admin/messages` — List all messages with search, tag filtering, and bulk-add functionality
  - Tag filter strip with counts and edit/new tag dialogs
  - Bulk-add section to create multiple requests with optional tag assignment
  - Selection bar for batch tag operations
  - Messages table with tag chips and request details
- `/admin/messages/$id` — Detail view for a single message showing tags and linked requests
- Enhanced `/admin/$lang/requests/$id` with message section linking to message detail page

**Tag Management**
- New tag creation via popover (slug, label, description)
- Edit tags dialog with rename, description updates, and archive/restore
- Tag counts displayed in filter chips
- Add/remove tags from messages via popover picker
- Archive functionality hides tags from filters/pickers while preserving database links

**Collections & Hooks**
- Created `messagesCollection`, `messageTagsCollection`, `messageTagLinksCollection` with full CRUD support
- Added hooks: `useMessageTags()`, `useMessageTagsForMessage()`, `useRequestLinksPhraseIds()`
- Integrated with TanStack DB for live queries and optimistic mutations

**Testing**
- Added scenetest specs for admin messages page, tag management, and request detail integration
- Registered new test IDs in TEST_IDS.md

## Implementation Details

- Tags are admin-curated (closed vocabulary, no per-user tags)—contrast with language-scoped phrase tags
- Message creation is automatic via database trigger; clients don't need to manage it
- Tag links cascade-delete when messages or tags are removed
- Archived tags remain in the database for historical integrity but disappear from UI pickers and public chips
- Bulk-add writes both phrase_request and message_tag_link rows, then syncs collections optimistically
- Admin authorization enforced via RLS policies and `is_admin()` checks

https://claude.ai/code/session_01C5BBVxcdfKzyjtm89N1bm2