### PR TITLE
Refactor card status dropdown showcase to use static popup

### DIFF
--- a/src/routes/themes.index.lazy.tsx
+++ b/src/routes/themes.index.lazy.tsx
@@ -687,12 +687,10 @@ function CardStatusShowcaseTrigger({
 	choice,
 	dot,
 	soft,
-	defaultOpen,
 }: {
 	choice: ShowableActions
 	dot: string
 	soft?: boolean
-	defaultOpen?: boolean
 }) {
 	const { name } = statusStrings[choice]
 	// `nocard` collapses the menu to a single "Add to deck" item, matching
@@ -702,7 +700,7 @@ function CardStatusShowcaseTrigger({
 			? [choice]
 			: ['active', 'learned', 'skipped']
 	return (
-		<DropdownMenu defaultOpen={defaultOpen}>
+		<DropdownMenu>
 			<DropdownMenuTrigger
 				render={
 					<Button
@@ -728,18 +726,54 @@ function CardStatusShowcaseTrigger({
 	)
 }
 
+// Static, non-portal twin of DropdownMenuContent + DropdownMenuItem so we can
+// show the menu's open state in the showcase without mounting a real open
+// DropdownMenu (which would trap focus + scroll-lock the page on mount).
+// Styles mirror src/components/ui/dropdown-menu.tsx — keep in sync.
+function StaticCardStatusPopup({ items }: { items: Array<ShowableActions> }) {
+	return (
+		<div
+			aria-hidden="true"
+			className="bg-popover text-popover-foreground inline-block min-w-[8rem] overflow-hidden rounded-xl border p-1 shadow-md"
+		>
+			{items.map((choice) => {
+				const { Icon, iconClassName, action, actionSecond } =
+					statusStrings[choice]
+				return (
+					<div
+						key={choice}
+						className="relative flex cursor-default items-center gap-2 rounded-lg px-2 py-1.5 text-sm select-none"
+					>
+						<div className="flex flex-row items-center gap-2 py-1 pe-2">
+							<span className="h-5 w-5">
+								<Icon className={iconClassName} aria-hidden="true" />
+							</span>
+							<div>
+								<p className="font-bold">{action}</p>
+								<p className="text-opacity-80 text-sm">{actionSecond}</p>
+							</div>
+						</div>
+					</div>
+				)
+			})}
+		</div>
+	)
+}
+
 function ShowcaseCardStatusDropdown() {
 	return (
-		<div className="flex flex-wrap items-center gap-2">
-			{cardStatusShowcaseStates.map((s, i) => (
-				<CardStatusShowcaseTrigger
-					key={s.choice}
-					choice={s.choice}
-					dot={s.dot}
-					soft={s.soft}
-					defaultOpen={i === 0}
-				/>
-			))}
+		<div className="space-y-3">
+			<div className="flex flex-wrap items-center gap-2">
+				{cardStatusShowcaseStates.map((s) => (
+					<CardStatusShowcaseTrigger
+						key={s.choice}
+						choice={s.choice}
+						dot={s.dot}
+						soft={s.soft}
+					/>
+				))}
+			</div>
+			<StaticCardStatusPopup items={['active', 'learned', 'skipped']} />
 		</div>
 	)
 }

--- a/src/routes/themes.index.lazy.tsx
+++ b/src/routes/themes.index.lazy.tsx
@@ -1355,7 +1355,7 @@ function SmolShowcaseBlock({
 	children: ReactNode
 }) {
 	return (
-		<div className="space-y-2">
+		<div className="mb-6 break-inside-avoid space-y-2">
 			<h3 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
 				{label}
 			</h3>
@@ -1374,7 +1374,7 @@ function SmolShowcase() {
 					language picker, and the three callout variants.
 				</p>
 			</div>
-			<div className="grid gap-6 @2xl:grid-cols-2">
+			<div className="gap-x-6 @2xl:columns-2">
 				<SmolShowcaseBlock label="Card status dropdown">
 					<ShowcaseCardStatusDropdown />
 				</SmolShowcaseBlock>
@@ -1415,7 +1415,7 @@ function SocialShowcase() {
 					inline intro callout — each shown across the states the app uses.
 				</p>
 			</div>
-			<div className="grid gap-6 @2xl:grid-cols-2">
+			<div className="gap-x-6 @2xl:columns-2">
 				<SmolShowcaseBlock label="Choice tile group">
 					<ShowcaseChoiceTileGroup />
 				</SmolShowcaseBlock>

--- a/src/routes/themes.index.lazy.tsx
+++ b/src/routes/themes.index.lazy.tsx
@@ -1355,7 +1355,7 @@ function SmolShowcaseBlock({
 	children: ReactNode
 }) {
 	return (
-		<div className="mb-6 break-inside-avoid space-y-2">
+		<div className="space-y-2">
 			<h3 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
 				{label}
 			</h3>
@@ -1374,7 +1374,7 @@ function SmolShowcase() {
 					language picker, and the three callout variants.
 				</p>
 			</div>
-			<div className="gap-x-6 @2xl:columns-2">
+			<div className="grid gap-6 @2xl:grid-cols-2">
 				<SmolShowcaseBlock label="Card status dropdown">
 					<ShowcaseCardStatusDropdown />
 				</SmolShowcaseBlock>
@@ -1415,7 +1415,7 @@ function SocialShowcase() {
 					inline intro callout — each shown across the states the app uses.
 				</p>
 			</div>
-			<div className="gap-x-6 @2xl:columns-2">
+			<div className="grid gap-6 @2xl:grid-cols-2">
 				<SmolShowcaseBlock label="Choice tile group">
 					<ShowcaseChoiceTileGroup />
 				</SmolShowcaseBlock>

--- a/src/routes/themes.index.lazy.tsx
+++ b/src/routes/themes.index.lazy.tsx
@@ -1135,37 +1135,39 @@ function ShowcaseChatBubbles() {
 					<p className="text-muted-foreground text-xs">Friends</p>
 				</div>
 			</div>
-			<div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
-				<ChatBubble
-					isMine={false}
-					username="Priya L."
-					initials="PL"
-					seed="priya"
-					label="Sent a phrase recommendation"
-					time="2m ago"
-				>
-					<ChatPhrasePreview
+			<div className="flex-1 overflow-y-auto p-4">
+				<div className="space-y-4">
+					<ChatBubble
 						isMine={false}
-						text="selamat sonja"
-						translation="good evening"
-						lang={SHOWCASE_LANG}
-					/>
-				</ChatBubble>
-				<ChatBubble
-					isMine
-					username="You"
-					initials="Yo"
-					seed="self"
-					label="Added this to your deck"
-					time="just now"
-				>
-					<ChatPhrasePreview
+						username="Priya L."
+						initials="PL"
+						seed="priya"
+						label="Sent a phrase recommendation"
+						time="2m ago"
+					>
+						<ChatPhrasePreview
+							isMine={false}
+							text="selamat sonja"
+							translation="good evening"
+							lang={SHOWCASE_LANG}
+						/>
+					</ChatBubble>
+					<ChatBubble
 						isMine
-						text="selamat sonja"
-						translation="good evening"
-						lang={SHOWCASE_LANG}
-					/>
-				</ChatBubble>
+						username="You"
+						initials="Yo"
+						seed="self"
+						label="Added this to your deck"
+						time="just now"
+					>
+						<ChatPhrasePreview
+							isMine
+							text="selamat sonja"
+							translation="good evening"
+							lang={SHOWCASE_LANG}
+						/>
+					</ChatBubble>
+				</div>
 			</div>
 			<div className="border-t p-3">
 				<div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
Refactored the card status dropdown showcase to display a static, non-interactive popup alongside the trigger buttons, eliminating the need for the `defaultOpen` prop and providing a clearer visual representation of the menu's open state.

## Changes
- **Removed `defaultOpen` prop** from `CardStatusShowcaseTrigger` component and its `DropdownMenu` usage, simplifying the component API
- **Created `StaticCardStatusPopup` component** — a new static, non-portal twin of `DropdownMenuContent` + `DropdownMenuItem` that mirrors the styles from `src/components/ui/dropdown-menu.tsx`
  - Uses `aria-hidden="true"` to keep it out of the accessibility tree
  - Renders menu items without mounting a real `DropdownMenu` (avoiding focus trapping and scroll-locking)
- **Updated `ShowcaseCardStatusDropdown`** layout to display both the trigger buttons and the static popup in a vertical stack (`space-y-3`)
- **Removed index-based logic** that was opening only the first dropdown (`defaultOpen={i === 0}`)

## Implementation Details
The static popup component replicates the visual styling of the actual dropdown menu to provide an accurate preview of how the menu appears when open, without the side effects of mounting an interactive dropdown in the showcase context.

https://claude.ai/code/session_012k5EtWMf3MhftXPf7wJqTD