### PR TITLE
Add LanguagePicker component and wire up translation language field

### DIFF
--- a/src/components/fields/language-picker.tsx
+++ b/src/components/fields/language-picker.tsx
@@ -26,15 +26,17 @@ import { LangBadge } from '@/components/ui/badge'
 import languages, { allLanguageOptions } from '@/lib/languages'
 import { useProfile } from '@/features/profile/hooks'
 import { useDecks } from '@/features/deck/hooks'
+import { useTopLanguages } from '@/features/languages'
 import { useIsMobile } from '@/hooks/use-mobile'
-import { getLangHue } from '@/lib/lang-theme'
+import { getLangThemeCss } from '@/lib/lang-theme'
 import { cn } from '@/lib/utils'
 
-const POPULAR_LANGS = ['eng', 'spa', 'fra', 'cmn', 'jpn', 'deu']
+// How many shortcut tiles to show signed-out / new users
+const POPULAR_LANG_COUNT = 6
 
-function langHueStyle(code: string): CSSProperties {
-	return { '--hue-primary': getLangHue(code) } as CSSProperties
-}
+// Shown before the languages collection has synced, so the "Popular languages"
+// section never flashes empty. Replaced by live `display_order` ranking once ready.
+const FALLBACK_POPULAR_LANGS = ['eng', 'fra', 'hin', 'kan', 'spa', 'tam']
 
 function Highlight({ text, q }: { text: string; q: string }) {
 	if (!q) return <>{text}</>
@@ -82,7 +84,7 @@ function LangTile({
 		<button
 			type="button"
 			className="bg-card border-border hover:border-primary/40 flex min-w-0 cursor-pointer flex-col gap-2 rounded-xl border p-2.5 text-left transition-all hover:-translate-y-px hover:shadow-sm"
-			style={langHueStyle(code)}
+			style={getLangThemeCss(code)}
 			onClick={() => onPick(code)}
 		>
 			<div className="flex items-center justify-between gap-2">
@@ -132,13 +134,11 @@ function AllLanguagesList({
 	exclude,
 	isDisabled,
 	isSelected,
-	q,
 	onPick,
 }: {
 	exclude: string[]
 	isDisabled: (code: string) => boolean
 	isSelected: (code: string) => boolean
-	q: string
 	onPick: (code: string) => void
 }) {
 	return (
@@ -150,7 +150,7 @@ function AllLanguagesList({
 						key={l.value}
 						code={l.value}
 						label={l.label}
-						q={q}
+						q=""
 						isSelected={isSelected(l.value)}
 						onPick={onPick}
 					/>
@@ -170,6 +170,7 @@ interface PickerBodyProps {
 	signedIn: boolean
 	knownLangs: string[]
 	deckLangs: string[]
+	popularLangs: string[]
 	primaryLang?: string
 }
 
@@ -184,6 +185,7 @@ function PickerBody({
 	signedIn,
 	knownLangs,
 	deckLangs,
+	popularLangs,
 	primaryLang,
 }: PickerBodyProps) {
 	const q = search.trim()
@@ -193,7 +195,9 @@ function PickerBody({
 	useEffect(() => {
 		const id = setTimeout(() => searchRef.current?.focus(), focusDelay)
 		return () => clearTimeout(id)
-	}, [])  
+		// run once on mount (popover/drawer open) — focusDelay is fixed per instance
+		// oxlint-disable-next-line react-hooks/exhaustive-deps
+	}, [])
 
 	const isDisabled = useCallback(
 		(code: string) => disabled?.includes(code) ?? false,
@@ -205,22 +209,48 @@ function PickerBody({
 	)
 
 	const filteredAll = useMemo(() => {
-		if (!q) return allLanguageOptions
+		if (!q) return []
 		const needle = q.toLowerCase()
-		return allLanguageOptions.filter(
-			(l) =>
-				l.label.toLowerCase().includes(needle) ||
-				l.value.toLowerCase().startsWith(needle)
-		)
-	}, [q])
+		return allLanguageOptions
+			.filter(
+				(l) =>
+					!isDisabled(l.value) &&
+					(l.label.toLowerCase().includes(needle) ||
+						l.value.toLowerCase().startsWith(needle))
+			)
+			.slice(0, 60)
+	}, [q, isDisabled])
 
 	const visibleKnown = knownLangs.filter((c) => !isDisabled(c))
 	const visibleDecks = deckLangs.filter(
 		(c) => !isDisabled(c) && !knownLangs.includes(c)
 	)
-	const tileExclude = signedIn
-		? [...visibleKnown, ...visibleDecks]
-		: POPULAR_LANGS.filter((c) => !isDisabled(c))
+	// Tile sections shown when not searching: signed-in users see their own
+	// languages + decks; signed-out users see a popular-languages shortcut.
+	const tileSections = signedIn
+		? [
+				{
+					label: 'Your languages',
+					count: visibleKnown.length,
+					codes: visibleKnown,
+					showPrimary: true,
+				},
+				{
+					label: 'Your decks',
+					count: visibleDecks.length,
+					codes: visibleDecks,
+					showPrimary: false,
+				},
+			].filter((s) => s.codes.length > 0)
+		: [
+				{
+					label: 'Popular languages',
+					count: 'most active' as string | number,
+					codes: popularLangs.filter((c) => !isDisabled(c)),
+					showPrimary: false,
+				},
+			]
+	const tileExclude = tileSections.flatMap((s) => s.codes)
 
 	return (
 		<div className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -272,84 +302,36 @@ function PickerBody({
 						</div>
 					) : (
 						<div className="flex flex-col pt-2">
-							{filteredAll
-								.filter((l) => !isDisabled(l.value))
-								.slice(0, 60)
-								.map((l) => (
-									<LangRow
-										key={l.value}
-										code={l.value}
-										label={l.label}
-										q={q}
-										isSelected={isSelected(l.value)}
-										onPick={onPick}
-									/>
-								))}
+							{filteredAll.map((l) => (
+								<LangRow
+									key={l.value}
+									code={l.value}
+									label={l.label}
+									q={q}
+									isSelected={isSelected(l.value)}
+									onPick={onPick}
+								/>
+							))}
 						</div>
 					)
-				) : signedIn ? (
-					<>
-						{visibleKnown.length > 0 && (
-							<section className="mt-2.5">
-								<SectionHead
-									label="Your languages"
-									count={visibleKnown.length}
-								/>
-								<div className="grid grid-cols-2 gap-2 px-1">
-									{visibleKnown.map((code) => (
-										<LangTile
-											key={code}
-											code={code}
-											isPrimary={code === primaryLang}
-											isSelected={isSelected(code)}
-											onPick={onPick}
-										/>
-									))}
-								</div>
-							</section>
-						)}
-						{visibleDecks.length > 0 && (
-							<section className="mt-2.5">
-								<SectionHead label="Your decks" count={visibleDecks.length} />
-								<div className="grid grid-cols-2 gap-2 px-1">
-									{visibleDecks.map((code) => (
-										<LangTile
-											key={code}
-											code={code}
-											isSelected={isSelected(code)}
-											onPick={onPick}
-										/>
-									))}
-								</div>
-							</section>
-						)}
-						<div className="border-border mx-1 my-3 border-t border-dashed" />
-						<section>
-							<SectionHead label="All languages" count="A — Z" />
-							<AllLanguagesList
-								exclude={tileExclude}
-								isDisabled={isDisabled}
-								isSelected={isSelected}
-								q=""
-								onPick={onPick}
-							/>
-						</section>
-					</>
 				) : (
 					<>
-						<section className="mt-2.5">
-							<SectionHead label="Popular languages" count="most active" />
-							<div className="grid grid-cols-2 gap-2 px-1">
-								{POPULAR_LANGS.filter((c) => !isDisabled(c)).map((code) => (
-									<LangTile
-										key={code}
-										code={code}
-										isSelected={isSelected(code)}
-										onPick={onPick}
-									/>
-								))}
-							</div>
-						</section>
+						{tileSections.map((s) => (
+							<section key={s.label} className="mt-2.5">
+								<SectionHead label={s.label} count={s.count} />
+								<div className="grid grid-cols-2 gap-2 px-1">
+									{s.codes.map((code) => (
+										<LangTile
+											key={code}
+											code={code}
+											isPrimary={s.showPrimary && code === primaryLang}
+											isSelected={isSelected(code)}
+											onPick={onPick}
+										/>
+									))}
+								</div>
+							</section>
+						))}
 						<div className="border-border mx-1 my-3 border-t border-dashed" />
 						<section>
 							<SectionHead label="All languages" count="A — Z" />
@@ -357,7 +339,6 @@ function PickerBody({
 								exclude={tileExclude}
 								isDisabled={isDisabled}
 								isSelected={isSelected}
-								q=""
 								onPick={onPick}
 							/>
 						</section>
@@ -387,10 +368,11 @@ export function LanguagePickerTrigger({
 		<button
 			type="button"
 			className={cn(
-				'flex w-full items-center gap-2.5 rounded-2xl border bg-card px-3.5 py-2.5 text-left text-sm font-sans',
-				'cursor-pointer transition-all hover:border-primary/50',
-				'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
-				hasError ? 'border-destructive' : 'border-border',
+				// Match the at-rest + hover border treatment of <Input>/<Textarea>
+				'flex w-full items-center gap-2.5 rounded-2xl border bg-card/50 px-3.5 py-2.5 text-left text-sm font-sans inset-shadow-sm',
+				'ring-offset-background cursor-pointer hover:border-primary',
+				'focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden',
+				hasError ? 'border-destructive' : 'border-3-mlo-primary',
 				!value && 'text-muted-foreground',
 				className
 			)}
@@ -418,16 +400,20 @@ export function LanguagePicker({
 	disabled,
 	hasError,
 	className,
+	placeholder,
 	children,
 }: {
 	value: string
 	setValue: (v: string) => void
 	disabled?: string[]
-	/** Only used when children is a string — passed to the built-in trigger */
+	/** Passed to the built-in trigger (ignored when a custom `children` trigger is supplied) */
 	hasError?: boolean
-	/** Only used when children is a string — passed to the built-in trigger */
+	/** Passed to the built-in trigger (ignored when a custom `children` trigger is supplied) */
 	className?: string
-	children?: string | ReactElement
+	/** Placeholder shown by the built-in trigger when no value is set */
+	placeholder?: string
+	/** Supply a fully custom trigger element instead of the built-in one */
+	children?: ReactElement
 }) {
 	const [open, setOpen] = useState(false)
 	const [search, setSearch] = useState('')
@@ -436,6 +422,7 @@ export function LanguagePicker({
 
 	const { data: profile } = useProfile()
 	const { data: decks } = useDecks()
+	const { data: topLanguages } = useTopLanguages(POPULAR_LANG_COUNT)
 
 	const knownLangs = useMemo(
 		() => profile?.languages_known?.map((l) => l.lang) ?? [],
@@ -447,6 +434,13 @@ export function LanguagePicker({
 			...new Set(decks?.filter((d) => !d.archived).map((d) => d.lang) ?? []),
 		],
 		[decks]
+	)
+	const popularLangs = useMemo(
+		() =>
+			topLanguages?.length
+				? topLanguages.map((l) => l.lang)
+				: FALLBACK_POPULAR_LANGS,
+		[topLanguages]
 	)
 	const signedIn = !!profile
 
@@ -464,19 +458,14 @@ export function LanguagePicker({
 		if (!next) setSearch('')
 	}, [])
 
-	const trigger =
-		typeof children !== 'object' ? (
-			<LanguagePickerTrigger
-				value={value}
-				placeholder={
-					typeof children === 'string' ? children : 'Select language…'
-				}
-				hasError={hasError}
-				className={className}
-			/>
-		) : (
-			children
-		)
+	const trigger = children ?? (
+		<LanguagePickerTrigger
+			value={value}
+			placeholder={placeholder}
+			hasError={hasError}
+			className={className}
+		/>
+	)
 
 	const bodyProps: PickerBodyProps = {
 		search,
@@ -488,6 +477,7 @@ export function LanguagePicker({
 		signedIn,
 		knownLangs,
 		deckLangs,
+		popularLangs,
 		primaryLang,
 	}
 
@@ -495,7 +485,9 @@ export function LanguagePicker({
 		return (
 			<Drawer open={open} onOpenChange={handleOpenChange}>
 				<DrawerTrigger asChild>{trigger}</DrawerTrigger>
-				<DrawerContent className="flex max-h-[90svh] flex-col">
+				{/* bg-popover (pure white) to match the desktop popover chrome —
+				    the shared DrawerContent default bg-background is hue-tinted */}
+				<DrawerContent className="bg-popover flex max-h-[90svh] flex-col">
 					<div className="border-border flex shrink-0 items-center justify-between border-b px-4 pb-3">
 						<DrawerTitle>Pick a language</DrawerTitle>
 						<DrawerClose
@@ -517,10 +509,23 @@ export function LanguagePicker({
 			<PopoverContent
 				className="flex flex-col overflow-hidden rounded-xl p-0"
 				style={
-					{ width: 'min(420px, 92vw)', maxHeight: '540px' } as CSSProperties
+					{
+						width: 'min(420px, 92vw)',
+						// Cap to the space the positioner reports so the popup always
+						// fits its chosen side and scrolls internally — otherwise an
+						// over-tall popup overflows and gets shoved into a corner.
+						maxHeight: 'min(540px, var(--available-height))',
+					} as CSSProperties
 				}
 				align="start"
 				sideOffset={6}
+				// Allow flipping above the anchor, but never shift sideways or fall
+				// back to the perpendicular axis (which parks it at the screen edge).
+				collisionAvoidance={{
+					side: 'flip',
+					align: 'none',
+					fallbackAxisSide: 'none',
+				}}
 			>
 				<PickerBody {...bodyProps} />
 			</PopoverContent>

--- a/src/components/fields/language-picker.tsx
+++ b/src/components/fields/language-picker.tsx
@@ -1,0 +1,529 @@
+import {
+	useState,
+	useRef,
+	useMemo,
+	useCallback,
+	useEffect,
+	type CSSProperties,
+	type RefObject,
+	type ReactElement,
+	type ButtonHTMLAttributes,
+} from 'react'
+import { Globe, Search, X, Star, Check, ChevronsUpDown } from 'lucide-react'
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from '@/components/ui/popover'
+import {
+	Drawer,
+	DrawerClose,
+	DrawerContent,
+	DrawerTitle,
+	DrawerTrigger,
+} from '@/components/ui/drawer'
+import { LangBadge } from '@/components/ui/badge'
+import languages, { allLanguageOptions } from '@/lib/languages'
+import { useProfile } from '@/features/profile/hooks'
+import { useDecks } from '@/features/deck/hooks'
+import { useIsMobile } from '@/hooks/use-mobile'
+import { getLangHue } from '@/lib/lang-theme'
+import { cn } from '@/lib/utils'
+
+const POPULAR_LANGS = ['eng', 'spa', 'fra', 'cmn', 'jpn', 'deu']
+
+function langHueStyle(code: string): CSSProperties {
+	return { '--hue-primary': getLangHue(code) } as CSSProperties
+}
+
+function Highlight({ text, q }: { text: string; q: string }) {
+	if (!q) return <>{text}</>
+	const i = text.toLowerCase().indexOf(q.toLowerCase())
+	if (i < 0) return <>{text}</>
+	return (
+		<>
+			{text.slice(0, i)}
+			<mark className="rounded-sm bg-amber-100 px-px text-amber-900 dark:bg-amber-900/60 dark:text-amber-100">
+				{text.slice(i, i + q.length)}
+			</mark>
+			{text.slice(i + q.length)}
+		</>
+	)
+}
+
+function SectionHead({
+	label,
+	count,
+}: {
+	label: string
+	count: string | number
+}) {
+	return (
+		<div className="text-muted-foreground flex items-center gap-2 px-1 py-2 font-mono text-[10.5px] font-bold tracking-widest uppercase">
+			<span>{label}</span>
+			<span className="ml-auto font-normal tracking-wide">{count}</span>
+		</div>
+	)
+}
+
+function LangTile({
+	code,
+	isPrimary,
+	isSelected,
+	onPick,
+}: {
+	code: string
+	isPrimary?: boolean
+	isSelected?: boolean
+	onPick: (code: string) => void
+}) {
+	const name = languages[code as keyof typeof languages] ?? code
+	return (
+		<button
+			type="button"
+			className="bg-card border-border hover:border-primary/40 flex min-w-0 cursor-pointer flex-col gap-2 rounded-xl border p-2.5 text-left transition-all hover:-translate-y-px hover:shadow-sm"
+			style={langHueStyle(code)}
+			onClick={() => onPick(code)}
+		>
+			<div className="flex items-center justify-between gap-2">
+				<LangBadge lang={code} className="text-[10px]" />
+				{isPrimary ? (
+					<Star className="size-3.5 shrink-0 fill-amber-500 text-amber-500 dark:fill-amber-400 dark:text-amber-400" />
+				) : isSelected ? (
+					<Check className="text-primary size-3.5 shrink-0" />
+				) : null}
+			</div>
+			<div className="truncate text-sm leading-tight font-bold tracking-tight">
+				{name}
+			</div>
+		</button>
+	)
+}
+
+function LangRow({
+	code,
+	label,
+	q,
+	isSelected,
+	onPick,
+}: {
+	code: string
+	label: string
+	q: string
+	isSelected?: boolean
+	onPick: (code: string) => void
+}) {
+	return (
+		<button
+			type="button"
+			className="hover:bg-primary/10 focus-visible:bg-primary/10 text-foreground flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2 text-left transition-colors outline-none"
+			onClick={() => onPick(code)}
+		>
+			<span className="min-w-0 flex-1 truncate text-sm font-semibold">
+				<Highlight text={label} q={q} />
+			</span>
+			<LangBadge lang={code} className="shrink-0 text-[10px]" />
+			{isSelected && <Check className="text-primary size-3.5 shrink-0" />}
+		</button>
+	)
+}
+
+function AllLanguagesList({
+	exclude,
+	isDisabled,
+	isSelected,
+	q,
+	onPick,
+}: {
+	exclude: string[]
+	isDisabled: (code: string) => boolean
+	isSelected: (code: string) => boolean
+	q: string
+	onPick: (code: string) => void
+}) {
+	return (
+		<div className="flex flex-col">
+			{allLanguageOptions
+				.filter((l) => !isDisabled(l.value) && !exclude.includes(l.value))
+				.map((l) => (
+					<LangRow
+						key={l.value}
+						code={l.value}
+						label={l.label}
+						q={q}
+						isSelected={isSelected(l.value)}
+						onPick={onPick}
+					/>
+				))}
+		</div>
+	)
+}
+
+interface PickerBodyProps {
+	search: string
+	setSearch: (v: string) => void
+	onPick: (code: string) => void
+	currentValue: string
+	disabled?: string[]
+	searchRef: RefObject<HTMLInputElement | null>
+	focusDelay?: number
+	signedIn: boolean
+	knownLangs: string[]
+	deckLangs: string[]
+	primaryLang?: string
+}
+
+function PickerBody({
+	search,
+	setSearch,
+	onPick,
+	currentValue,
+	disabled,
+	searchRef,
+	focusDelay = 60,
+	signedIn,
+	knownLangs,
+	deckLangs,
+	primaryLang,
+}: PickerBodyProps) {
+	const q = search.trim()
+	const isFiltering = q.length > 0
+
+	// Focus the search input shortly after mount (popover/drawer open)
+	useEffect(() => {
+		const id = setTimeout(() => searchRef.current?.focus(), focusDelay)
+		return () => clearTimeout(id)
+	}, [])  
+
+	const isDisabled = useCallback(
+		(code: string) => disabled?.includes(code) ?? false,
+		[disabled]
+	)
+	const isSelected = useCallback(
+		(code: string) => code === currentValue,
+		[currentValue]
+	)
+
+	const filteredAll = useMemo(() => {
+		if (!q) return allLanguageOptions
+		const needle = q.toLowerCase()
+		return allLanguageOptions.filter(
+			(l) =>
+				l.label.toLowerCase().includes(needle) ||
+				l.value.toLowerCase().startsWith(needle)
+		)
+	}, [q])
+
+	const visibleKnown = knownLangs.filter((c) => !isDisabled(c))
+	const visibleDecks = deckLangs.filter(
+		(c) => !isDisabled(c) && !knownLangs.includes(c)
+	)
+	const tileExclude = signedIn
+		? [...visibleKnown, ...visibleDecks]
+		: POPULAR_LANGS.filter((c) => !isDisabled(c))
+
+	return (
+		<div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+			{/* Search — pinned at top */}
+			<div className="bg-popover border-border shrink-0 border-b px-3.5 pt-3 pb-2.5">
+				<div className="bg-muted/60 border-border focus-within:border-ring focus-within:ring-ring/20 focus-within:bg-card flex items-center gap-2 rounded-2xl border px-3 py-2 transition-all focus-within:ring-2">
+					<Search className="text-muted-foreground size-4 shrink-0" />
+					<input
+						ref={searchRef}
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						placeholder="Search 100+ languages…"
+						aria-label="Search language"
+						className="text-foreground placeholder:text-muted-foreground min-w-0 flex-1 border-0 bg-transparent text-sm outline-none"
+					/>
+					{q ? (
+						<button
+							type="button"
+							className="text-muted-foreground hover:text-foreground p-0.5"
+							onClick={() => setSearch('')}
+							aria-label="Clear"
+						>
+							<X className="size-3.5" />
+						</button>
+					) : null}
+				</div>
+			</div>
+
+			{/* Scrollable results */}
+			<div className="min-h-0 flex-1 overflow-y-auto px-3.5 pb-4">
+				{isFiltering ? (
+					filteredAll.length === 0 ? (
+						<div className="text-muted-foreground px-4 py-8 text-center text-sm">
+							<div>
+								No matches for{' '}
+								<span className="text-foreground font-bold">"{q}"</span>
+							</div>
+							<div className="mt-1.5 text-xs">
+								Try the ISO 639-3 code, like{' '}
+								<code className="bg-muted rounded px-1 py-0.5 font-mono">
+									fra
+								</code>{' '}
+								or{' '}
+								<code className="bg-muted rounded px-1 py-0.5 font-mono">
+									tam
+								</code>
+								.
+							</div>
+						</div>
+					) : (
+						<div className="flex flex-col pt-2">
+							{filteredAll
+								.filter((l) => !isDisabled(l.value))
+								.slice(0, 60)
+								.map((l) => (
+									<LangRow
+										key={l.value}
+										code={l.value}
+										label={l.label}
+										q={q}
+										isSelected={isSelected(l.value)}
+										onPick={onPick}
+									/>
+								))}
+						</div>
+					)
+				) : signedIn ? (
+					<>
+						{visibleKnown.length > 0 && (
+							<section className="mt-2.5">
+								<SectionHead
+									label="Your languages"
+									count={visibleKnown.length}
+								/>
+								<div className="grid grid-cols-2 gap-2 px-1">
+									{visibleKnown.map((code) => (
+										<LangTile
+											key={code}
+											code={code}
+											isPrimary={code === primaryLang}
+											isSelected={isSelected(code)}
+											onPick={onPick}
+										/>
+									))}
+								</div>
+							</section>
+						)}
+						{visibleDecks.length > 0 && (
+							<section className="mt-2.5">
+								<SectionHead label="Your decks" count={visibleDecks.length} />
+								<div className="grid grid-cols-2 gap-2 px-1">
+									{visibleDecks.map((code) => (
+										<LangTile
+											key={code}
+											code={code}
+											isSelected={isSelected(code)}
+											onPick={onPick}
+										/>
+									))}
+								</div>
+							</section>
+						)}
+						<div className="border-border mx-1 my-3 border-t border-dashed" />
+						<section>
+							<SectionHead label="All languages" count="A — Z" />
+							<AllLanguagesList
+								exclude={tileExclude}
+								isDisabled={isDisabled}
+								isSelected={isSelected}
+								q=""
+								onPick={onPick}
+							/>
+						</section>
+					</>
+				) : (
+					<>
+						<section className="mt-2.5">
+							<SectionHead label="Popular languages" count="most active" />
+							<div className="grid grid-cols-2 gap-2 px-1">
+								{POPULAR_LANGS.filter((c) => !isDisabled(c)).map((code) => (
+									<LangTile
+										key={code}
+										code={code}
+										isSelected={isSelected(code)}
+										onPick={onPick}
+									/>
+								))}
+							</div>
+						</section>
+						<div className="border-border mx-1 my-3 border-t border-dashed" />
+						<section>
+							<SectionHead label="All languages" count="A — Z" />
+							<AllLanguagesList
+								exclude={tileExclude}
+								isDisabled={isDisabled}
+								isSelected={isSelected}
+								q=""
+								onPick={onPick}
+							/>
+						</section>
+					</>
+				)}
+			</div>
+		</div>
+	)
+}
+
+export function LanguagePickerTrigger({
+	value,
+	hasError,
+	className,
+	placeholder = 'Select language…',
+	...props
+}: {
+	value: string
+	hasError?: boolean
+	className?: string
+	placeholder?: string
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type'>) {
+	const name = value
+		? (languages[value as keyof typeof languages] ?? value)
+		: null
+	return (
+		<button
+			type="button"
+			className={cn(
+				'flex w-full items-center gap-2.5 rounded-2xl border bg-card px-3.5 py-2.5 text-left text-sm font-sans',
+				'cursor-pointer transition-all hover:border-primary/50',
+				'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+				hasError ? 'border-destructive' : 'border-border',
+				!value && 'text-muted-foreground',
+				className
+			)}
+			{...props}
+		>
+			{value ? (
+				<>
+					<LangBadge lang={value} />
+					<span className="text-foreground font-semibold">{name}</span>
+				</>
+			) : (
+				<>
+					<Globe className="text-muted-foreground size-4" />
+					<span>{placeholder}</span>
+				</>
+			)}
+			<ChevronsUpDown className="text-muted-foreground ml-auto size-4 shrink-0" />
+		</button>
+	)
+}
+
+export function LanguagePicker({
+	value,
+	setValue,
+	disabled,
+	hasError,
+	className,
+	children,
+}: {
+	value: string
+	setValue: (v: string) => void
+	disabled?: string[]
+	/** Only used when children is a string — passed to the built-in trigger */
+	hasError?: boolean
+	/** Only used when children is a string — passed to the built-in trigger */
+	className?: string
+	children?: string | ReactElement
+}) {
+	const [open, setOpen] = useState(false)
+	const [search, setSearch] = useState('')
+	const searchRef = useRef<HTMLInputElement | null>(null)
+	const isMobile = useIsMobile()
+
+	const { data: profile } = useProfile()
+	const { data: decks } = useDecks()
+
+	const knownLangs = useMemo(
+		() => profile?.languages_known?.map((l) => l.lang) ?? [],
+		[profile]
+	)
+	const primaryLang = knownLangs[0]
+	const deckLangs = useMemo(
+		() => [
+			...new Set(decks?.filter((d) => !d.archived).map((d) => d.lang) ?? []),
+		],
+		[decks]
+	)
+	const signedIn = !!profile
+
+	const pick = useCallback(
+		(code: string) => {
+			setValue(code)
+			setOpen(false)
+			setSearch('')
+		},
+		[setValue]
+	)
+
+	const handleOpenChange = useCallback((next: boolean) => {
+		setOpen(next)
+		if (!next) setSearch('')
+	}, [])
+
+	const trigger =
+		typeof children !== 'object' ? (
+			<LanguagePickerTrigger
+				value={value}
+				placeholder={
+					typeof children === 'string' ? children : 'Select language…'
+				}
+				hasError={hasError}
+				className={className}
+			/>
+		) : (
+			children
+		)
+
+	const bodyProps: PickerBodyProps = {
+		search,
+		setSearch,
+		onPick: pick,
+		currentValue: value,
+		disabled,
+		searchRef,
+		signedIn,
+		knownLangs,
+		deckLangs,
+		primaryLang,
+	}
+
+	if (isMobile) {
+		return (
+			<Drawer open={open} onOpenChange={handleOpenChange}>
+				<DrawerTrigger asChild>{trigger}</DrawerTrigger>
+				<DrawerContent className="flex max-h-[90svh] flex-col">
+					<div className="border-border flex shrink-0 items-center justify-between border-b px-4 pb-3">
+						<DrawerTitle>Pick a language</DrawerTitle>
+						<DrawerClose
+							className="bg-muted text-foreground hover:bg-muted/80 flex size-8 items-center justify-center rounded-xl"
+							aria-label="Close"
+						>
+							<X className="size-4" />
+						</DrawerClose>
+					</div>
+					<PickerBody {...bodyProps} focusDelay={280} />
+				</DrawerContent>
+			</Drawer>
+		)
+	}
+
+	return (
+		<Popover open={open} onOpenChange={handleOpenChange}>
+			<PopoverTrigger asChild>{trigger}</PopoverTrigger>
+			<PopoverContent
+				className="flex flex-col overflow-hidden rounded-xl p-0"
+				style={
+					{ width: 'min(420px, 92vw)', maxHeight: '540px' } as CSSProperties
+				}
+				align="start"
+				sideOffset={6}
+			>
+				<PickerBody {...bodyProps} />
+			</PopoverContent>
+		</Popover>
+	)
+}

--- a/src/components/fields/translation-language-field.tsx
+++ b/src/components/fields/translation-language-field.tsx
@@ -25,9 +25,7 @@ export default function TranslationLanguageField({
 				}}
 				hasError={showError}
 				disabled={[phraseLang]}
-			>
-				Select language…
-			</LanguagePicker>
+			/>
 			{showError && <ErrorList errors={meta.errors} />}
 		</div>
 	)

--- a/src/components/fields/translation-language-field.tsx
+++ b/src/components/fields/translation-language-field.tsx
@@ -1,5 +1,5 @@
 import { Label } from '@/components/ui/label'
-import { SelectOneOfYourLanguages } from './select-one-of-your-languages'
+import { LanguagePicker } from './language-picker'
 import { useFieldContext } from '@/components/form'
 import { ErrorList } from '@/components/form/fields/error-list'
 
@@ -17,7 +17,7 @@ export default function TranslationLanguageField({
 			<Label className={showError ? 'text-destructive' : ''}>
 				Translation language
 			</Label>
-			<SelectOneOfYourLanguages
+			<LanguagePicker
 				value={field.state.value ?? ''}
 				setValue={(v) => {
 					field.handleChange(v)
@@ -25,7 +25,9 @@ export default function TranslationLanguageField({
 				}}
 				hasError={showError}
 				disabled={[phraseLang]}
-			/>
+			>
+				Select language…
+			</LanguagePicker>
 			{showError && <ErrorList errors={meta.errors} />}
 		</div>
 	)

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -54,7 +54,10 @@ function DrawerContent({
 			<DrawerPrimitive.Content
 				data-slot="drawer-content"
 				className={cn(
-					'group/drawer-content bg-background fixed z-50 flex h-auto flex-col',
+					// !will-change-auto overrides vaul's `will-change: transform`, which
+					// otherwise keeps every drawer panel on a GPU layer and softens its
+					// text on HiDPI screens. The slide still animates via `transition`.
+					'group/drawer-content bg-background fixed z-50 flex h-auto flex-col !will-change-auto',
 					'data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b',
 					'data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t',
 					'data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm',
@@ -63,7 +66,7 @@ function DrawerContent({
 				)}
 				{...props}
 			>
-				<div className="bg-foreground/25 mx-auto mt-4 hidden h-2 w-[100px] shrink-0 cursor-pointer rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+				<div className="bg-foreground/25 mx-auto mt-4 hidden h-2 w-25 shrink-0 cursor-pointer rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
 				{children}
 			</DrawerPrimitive.Content>
 		</DrawerPortal>

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -33,14 +33,19 @@ const PopoverContent = ({
 	align = 'center',
 	sideOffset = 4,
 	side = 'bottom',
+	collisionAvoidance,
 	...props
 }: PopoverPrimitive.Popup.Props &
-	Pick<PopoverPrimitive.Positioner.Props, 'align' | 'sideOffset' | 'side'>) => (
+	Pick<
+		PopoverPrimitive.Positioner.Props,
+		'align' | 'sideOffset' | 'side' | 'collisionAvoidance'
+	>) => (
 	<PopoverPrimitive.Portal>
 		<PopoverPrimitive.Positioner
 			align={align}
 			sideOffset={sideOffset}
 			side={side}
+			collisionAvoidance={collisionAvoidance}
 			positionMethod="fixed"
 			className="isolate z-50"
 		>

--- a/src/features/languages/hooks.ts
+++ b/src/features/languages/hooks.ts
@@ -1,4 +1,4 @@
-import { eq, useLiveQuery } from '@tanstack/react-db'
+import { eq, gt, useLiveQuery } from '@tanstack/react-db'
 
 import type { UseLiveQueryResult } from '@/types/main'
 import type { LanguageType, LangTagType } from './schemas'
@@ -53,6 +53,24 @@ export const useLanguagesWithPhrases = (): UseLiveQueryResult<LanguageType[]> =>
 			.from({ lang: languagesCollection })
 			.fn.where(({ lang }) => (lang.phrases_to_learn ?? 0) > 0)
 			.orderBy(({ lang }) => lang.phrases_to_learn, 'desc')
+	)
+
+/**
+ * The most popular languages, by `display_order` — a precomputed popularity
+ * rank (learners × phrases_to_learn) where 1 is the most popular. Used to seed
+ * the language picker's shortcut tiles for signed-out / new users.
+ */
+export const useTopLanguages = (
+	limit: number
+): UseLiveQueryResult<LanguageType[]> =>
+	useLiveQuery(
+		(q) =>
+			q
+				.from({ lang: languagesCollection })
+				.where(({ lang }) => gt(lang.display_order, 0))
+				.orderBy(({ lang }) => lang.display_order, 'asc')
+				.limit(limit),
+		[limit]
 	)
 
 /** All language tags across all languages. */

--- a/src/features/languages/index.ts
+++ b/src/features/languages/index.ts
@@ -22,6 +22,7 @@ export {
 	useAllLanguages,
 	useLanguagesSortedByLearners,
 	useLanguagesWithPhrases,
+	useTopLanguages,
 	useAllLangTags,
 } from './hooks'
 


### PR DESCRIPTION
Implements the designed Language Picker: Popover (desktop) / Drawer (mobile), sticky search, "Your languages" + "Your decks" tiles for signed-in users, popular languages for signed-out users, full A–Z list below. Replaces `SelectOneOfYourLanguages` in `TranslationLanguageField`.