### PR TITLE
Extract phrase translations into their own collection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,10 +202,16 @@ The version comes from the current `package.json` `version` (today `0.27.0`) and
 
 ### Decision rule
 
-> **Does this PR touch a migration file?**
+> **Two questions, in order:**
 >
-> - **No** → merge to `main`, deploy when ready.
-> - **Yes** → PR into the open `next-<version>` branch, hold for review, merge `next-<version>` → `main` when the batch is ready.
+> 1. **Was this branch created from `next-<version>`?**
+>    - **Yes** → PR into the open `next-<version>` branch, regardless of what your own changes touch. The base branch already carries unreleased migrations waiting for the next release cut; merging your branch into `main` would smuggle those past the migration-track QA + CI gate.
+>    - **No** → continue to question 2.
+> 2. **Does this PR touch a migration file?**
+>    - **No** → merge to `main`, deploy when ready.
+>    - **Yes** → PR into the open `next-<version>` branch, hold for review, merge `next-<version>` → `main` when the batch is ready.
+
+The point of the gate is that **migrations only ever reach `main` through a `next-<version>` → `main` release merge** — never as a side effect of a UI PR whose branch happened to start from `next-<version>`. If you're unsure where your branch started, `git merge-base HEAD origin/next-<version>` vs `git merge-base HEAD origin/main` will tell you.
 
 ### Workflow
 
@@ -217,6 +223,7 @@ The version comes from the current `package.json` `version` (today `0.27.0`) and
 
 - **Don't let the `next-<version>` branch get stale.** If it's been open >2 weeks, either ship it or break the migrations into smaller pieces.
 - **Tag `next-<version>` → `main` merges** even informally — `git tag` is cheap and makes the deployment log reconstructable.
+- **Check the PR base before merging, not after.** Auto-created PRs (from the Claude Code UI, `gh pr create` without `--base`, etc.) default to the repo's default branch — usually `main`. If your branch was based on `next-<version>`, the PR will silently target the wrong branch until you change it. Check `base:` in the PR header.
 - **Changelog has two modes**: a running "Recent changes" section for fast-track items, and named/versioned release entries (`v0.28`) for migration-track batches.
 - **Ship UI, architect the database.** UI changes should flow fast; schema changes deserve ceremony.
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -171,7 +171,7 @@ async function fetchOGData(
 		try {
 			if (route.type === 'phrase') {
 				const { data } = await supabase
-					.from('phrase_meta')
+					.from('phrase')
 					.select('text, translations:phrase_translation(text, lang)')
 					.eq('id', id)
 					.single()
@@ -197,9 +197,9 @@ async function fetchOGData(
 					// Construct cover image URL from Supabase storage
 					const supabaseUrl = process.env.VITE_SUPABASE_URL
 					const imageUrl =
-						data.cover_image_path && supabaseUrl ?
-							`${supabaseUrl}/storage/v1/object/public/avatars/${data.cover_image_path}`
-						:	undefined
+						data.cover_image_path && supabaseUrl
+							? `${supabaseUrl}/storage/v1/object/public/avatars/${data.cover_image_path}`
+							: undefined
 
 					return {
 						title: `${data.title} - ${langName} Playlist`,
@@ -236,9 +236,11 @@ async function fetchOGData(
 
 				const learnerCount = count || 0
 				const learnerText =
-					learnerCount === 0 ? 'Start learning'
-					: learnerCount === 1 ? 'Join 1 learner'
-					: `Join ${learnerCount} learners`
+					learnerCount === 0
+						? 'Start learning'
+						: learnerCount === 1
+							? 'Join 1 learner'
+							: `Join ${learnerCount} learners`
 
 				return {
 					title: `Learn ${langName} on Sunlo`,

--- a/src/components/card-pieces/add-translations.tsx
+++ b/src/components/card-pieces/add-translations.tsx
@@ -21,7 +21,7 @@ import {
 import { AuthenticatedDialogContent } from '@/components/ui/authenticated-dialog'
 import { Button, ButtonProps } from '@/components/ui/button'
 import TranslationLanguageField from '@/components/fields/translation-language-field'
-import { phrasesCollection } from '@/features/phrases/collections'
+import { phraseTranslationsCollection } from '@/features/phrases/collections'
 import { usePreferredTranslationLang } from '@/features/deck/hooks'
 import { useUserId } from '@/lib/use-auth'
 import { Input } from '@/components/ui/input'
@@ -75,10 +75,9 @@ export function AddTranslationsDialog({
 			return data[0]
 		},
 		onSuccess: (data) => {
-			phrasesCollection.utils.writeUpdate({
-				id: phrase.id,
-				translations: [TranslationSchema.parse(data), ...phrase.translations],
-			})
+			phraseTranslationsCollection.utils.writeInsert(
+				TranslationSchema.parse(data)
+			)
 			close()
 			form.reset()
 			toastSuccess(`Translation added for ${phrase.text}`)
@@ -137,11 +136,7 @@ export function AddTranslationsDialog({
 					<p>Please check to make sure you're not entering a duplicate.</p>
 					<ol className="space-y-2">
 						{phrase.translations.map((trans) => (
-							<TranslationListItem
-								key={trans.id}
-								trans={trans}
-								phrase={phrase}
-							/>
+							<TranslationListItem key={trans.id} trans={trans} />
 						))}
 					</ol>
 				</div>
@@ -184,13 +179,7 @@ export function AddTranslationsDialog({
 }
 
 // Component for displaying a translation with edit/delete options
-function TranslationListItem({
-	trans,
-	phrase,
-}: {
-	trans: TranslationType
-	phrase: PhraseFullType
-}) {
+function TranslationListItem({ trans }: { trans: TranslationType }) {
 	const userId = useUserId()
 	const isOwner = trans.added_by === userId
 	const [isEditing, setIsEditing] = useState(false)
@@ -209,12 +198,9 @@ function TranslationListItem({
 			return data[0]
 		},
 		onSuccess: (data) => {
-			phrasesCollection.utils.writeUpdate({
-				id: phrase.id,
-				translations: phrase.translations.map((t) =>
-					t.id === trans.id ? TranslationSchema.parse(data) : t
-				),
-			})
+			phraseTranslationsCollection.utils.writeUpdate(
+				TranslationSchema.parse(data)
+			)
 			setIsEditing(false)
 			toastSuccess('Translation updated')
 		},
@@ -237,11 +223,9 @@ function TranslationListItem({
 				.throwOnError()
 		},
 		onSuccess: () => {
-			phrasesCollection.utils.writeUpdate({
-				id: phrase.id,
-				translations: phrase.translations.map((t) =>
-					t.id !== trans.id ? t : { ...t, archived: !trans.archived }
-				),
+			phraseTranslationsCollection.utils.writeUpdate({
+				...trans,
+				archived: !trans.archived,
 			})
 			toastSuccess(`Translation ${trans.archived ? 'un' : ''}archived`)
 		},

--- a/src/components/card-pieces/add-translations.tsx
+++ b/src/components/card-pieces/add-translations.tsx
@@ -135,7 +135,7 @@ export function AddTranslationsDialog({
 				<div className="text-muted-foreground space-y-2 text-sm">
 					<p>Please check to make sure you're not entering a duplicate.</p>
 					<ol className="space-y-2">
-						{phrase.translations.map((trans) => (
+						{(phrase.translations ?? []).map((trans) => (
 							<TranslationListItem key={trans.id} trans={trans} />
 						))}
 					</ol>

--- a/src/components/cards/phrase-tiny-card.tsx
+++ b/src/components/cards/phrase-tiny-card.tsx
@@ -39,9 +39,9 @@ export const PhraseTinyCard = ({
 				<div className="line-clamp-3">
 					<p className="font-semibold">{phrase.text}</p>{' '}
 					<p className="text-muted-foreground text-sm">
-						{phrase.translations_mine?.[0]?.text.length ?
-							phrase.translations_mine[0].text
-						:	phrase.translations[0]?.text}
+						{phrase.translations_mine?.[0]?.text.length
+							? phrase.translations_mine[0].text
+							: phrase.translations?.[0]?.text}
 					</p>
 				</div>
 				<div className="mt-auto flex w-full flex-row justify-between self-end pt-2">
@@ -63,9 +63,9 @@ export const PhraseTinyCard = ({
 				<div className="line-clamp-3">
 					<p className="font-semibold">{phrase.text}</p>{' '}
 					<p className="text-muted-foreground text-sm">
-						{phrase.translations_mine?.[0]?.text.length ?
-							phrase.translations_mine[0].text
-						:	phrase.translations[0]?.text}
+						{phrase.translations_mine?.[0]?.text.length
+							? phrase.translations_mine[0].text
+							: phrase.translations?.[0]?.text}
 					</p>
 				</div>
 				<div className="mt-auto flex w-full flex-row justify-between self-end pt-2">

--- a/src/components/cards/tap-to-select.tsx
+++ b/src/components/cards/tap-to-select.tsx
@@ -34,7 +34,7 @@ export function TapCardToSelect({
 		>
 			<CardHeader className="p-3 pb-0">
 				<CardTitle className="text-base">{phrase.text}</CardTitle>
-				<CardDescription>{phrase.translations[0].text}</CardDescription>
+				<CardDescription>{phrase.translations?.[0]?.text}</CardDescription>
 			</CardHeader>
 			<CardFooter className="flex justify-end p-3 pt-0">
 				<Badge

--- a/src/components/feed/feed-phrase-group-item.tsx
+++ b/src/components/feed/feed-phrase-group-item.tsx
@@ -20,7 +20,7 @@ export function PhraseSummaryLine({
 
 	// Count translations in languages the user knows
 	const userLanguages = profile?.languages_known ?? []
-	const knownLangTranslations = phrase.translations.filter((t) =>
+	const knownLangTranslations = (phrase.translations ?? []).filter((t) =>
 		userLanguages.some((ul) => ul.lang === t.lang)
 	)
 	const translationCount = knownLangTranslations.length

--- a/src/components/library-charts.tsx
+++ b/src/components/library-charts.tsx
@@ -27,7 +27,10 @@ import {
 	useLanguagesSortedByLearners,
 	useLanguagesWithPhrases,
 } from '@/features/languages/hooks'
-import { phrasesCollection } from '@/features/phrases/collections'
+import {
+	phrasesCollection,
+	phraseTranslationsCollection,
+} from '@/features/phrases/collections'
 import { useLangPhrasesRaw } from '@/features/phrases/hooks'
 import { phraseRequestsCollection } from '@/features/requests/collections'
 import { phrasePlaylistsActive } from '@/features/playlists/live'
@@ -543,6 +546,9 @@ export function LibrarySummaryStats() {
 	const { data: allPhrases } = useLiveQuery((q) =>
 		q.from({ phrase: phrasesCollection })
 	)
+	const { data: allTranslations } = useLiveQuery((q) =>
+		q.from({ t: phraseTranslationsCollection })
+	)
 	const { data: allRequests } = useLiveQuery((q) =>
 		q.from({ req: phraseRequestsCollection })
 	)
@@ -556,12 +562,7 @@ export function LibrarySummaryStats() {
 		[allPhrases]
 	)
 
-	const totalTranslations = useMemo(
-		() =>
-			allPhrases?.reduce((sum, p) => sum + (p.translations?.length ?? 0), 0) ??
-			0,
-		[allPhrases]
-	)
+	const totalTranslations = allTranslations?.length ?? 0
 
 	const stats = [
 		{ label: 'Languages', value: allLanguages?.length ?? 0 },

--- a/src/components/phrases/inline-phrase-creator.tsx
+++ b/src/components/phrases/inline-phrase-creator.tsx
@@ -12,9 +12,12 @@ import { Label } from '@/components/ui/label'
 import supabase from '@/lib/supabase-client'
 import languages from '@/lib/languages'
 import TranslationLanguageField from '@/components/fields/translation-language-field'
-import { PhraseFullSchema, TranslationSchema } from '@/features/phrases/schemas'
+import { PhraseSchema, TranslationSchema } from '@/features/phrases/schemas'
 import { CardMetaSchema } from '@/features/deck/schemas'
-import { phrasesCollection } from '@/features/phrases/collections'
+import {
+	phrasesCollection,
+	phraseTranslationsCollection,
+} from '@/features/phrases/collections'
 import { cardsCollection } from '@/features/deck/collections'
 import { useInvalidateFeed } from '@/features/feed/hooks'
 import { usePreferredTranslationLang, useDecks } from '@/features/deck/hooks'
@@ -144,14 +147,13 @@ function InlinePhraseForm({
 			// re-spins it up if it was cleaned up after gcTime expired.
 			await Promise.all([
 				phrasesCollection.preload(),
+				phraseTranslationsCollection.preload(),
 				cardsCollection.preload(),
 			])
 
-			phrasesCollection.utils.writeInsert(
-				PhraseFullSchema.parse({
-					...data.phrase,
-					translations: [TranslationSchema.parse(data.translation)],
-				})
+			phrasesCollection.utils.writeInsert(PhraseSchema.parse(data.phrase))
+			phraseTranslationsCollection.utils.writeInsert(
+				TranslationSchema.parse(data.translation)
 			)
 			if (data.card) {
 				cardsCollection.utils.writeInsert(CardMetaSchema.parse(data.card))

--- a/src/features/phrases/collections.ts
+++ b/src/features/phrases/collections.ts
@@ -1,25 +1,49 @@
 import { createCollection } from '@tanstack/react-db'
 import { queryCollectionOptions } from '@tanstack/query-db-collection'
 import { BasicIndex } from '@tanstack/db'
-import { PhraseFullSchema, type PhraseFullType } from './schemas'
+import {
+	PhraseSchema,
+	type PhraseType,
+	TranslationSchema,
+	type TranslationType,
+} from './schemas'
 import { queryClient } from '@/lib/query-client'
 import supabase from '@/lib/supabase-client'
 
 export const phrasesCollection = createCollection(
 	queryCollectionOptions({
 		id: 'phrases',
-		queryKey: ['public', 'phrase_full'],
-		getKey: (item: PhraseFullType) => item.id,
+		queryKey: ['public', 'phrase_meta'],
+		getKey: (item: PhraseType) => item.id,
 		queryFn: async () => {
 			console.log(`Loading phrasesCollection`)
-
 			const { data } = await supabase
 				.from('phrase_meta')
-				.select('*, translations:phrase_translation(*)')
+				.select('*')
 				.throwOnError()
-			return data?.map((p) => PhraseFullSchema.parse(p)) ?? []
+			return data?.map((p) => PhraseSchema.parse(p)) ?? []
 		},
-		schema: PhraseFullSchema,
+		schema: PhraseSchema,
+		queryClient,
+		autoIndex: 'eager',
+		defaultIndexType: BasicIndex,
+	})
+)
+
+export const phraseTranslationsCollection = createCollection(
+	queryCollectionOptions({
+		id: 'phrase_translations',
+		queryKey: ['public', 'phrase_translation'],
+		getKey: (item: TranslationType) => item.id,
+		queryFn: async () => {
+			console.log(`Loading phraseTranslationsCollection`)
+			const { data } = await supabase
+				.from('phrase_translation')
+				.select('*')
+				.throwOnError()
+			return data?.map((t) => TranslationSchema.parse(t)) ?? []
+		},
+		schema: TranslationSchema,
 		queryClient,
 		autoIndex: 'eager',
 		defaultIndexType: BasicIndex,

--- a/src/features/phrases/hooks.ts
+++ b/src/features/phrases/hooks.ts
@@ -8,9 +8,9 @@ import type {
 	PhraseFullFullType,
 	PhraseFullType,
 } from './schemas'
-import { phrasesCollection } from './collections'
 import {
 	phrasesFull,
+	phrasesWithTranslations,
 	usePhrasePlaylists,
 	usePhraseComments,
 	type PhraseProvenanceItem,
@@ -31,8 +31,9 @@ export const useLanguagePhrases = (
 	)
 
 /**
- * Phrases for a language, straight off `phrasesCollection` (no profile/card join).
- * Use this when you only need raw phrase metadata — charts, manage-deck, etc.
+ * Phrases for a language with translations composed in. No profile join —
+ * use this when you don't need the author's public profile (charts,
+ * manage-deck, etc).
  */
 export const useLangPhrasesRaw = (
 	lang: string
@@ -40,12 +41,12 @@ export const useLangPhrasesRaw = (
 	useLiveQuery(
 		(q) =>
 			q
-				.from({ phrase: phrasesCollection })
+				.from({ phrase: phrasesWithTranslations })
 				.where(({ phrase }) => eq(phrase.lang, lang)),
 		[lang]
 	)
 
-/** A single phrase by id from the raw `phrasesCollection`. */
+/** A single phrase by id with its translations composed in. */
 export const useOnePhrase = (
 	pid: uuid | undefined | null
 ): UseLiveQueryResult<PhraseFullType> =>
@@ -54,7 +55,7 @@ export const useOnePhrase = (
 			!pid
 				? undefined
 				: q
-						.from({ phrase: phrasesCollection })
+						.from({ phrase: phrasesWithTranslations })
 						.where(({ phrase }) => eq(phrase.id, pid))
 						.findOne(),
 		[pid]

--- a/src/features/phrases/index.ts
+++ b/src/features/phrases/index.ts
@@ -3,6 +3,8 @@
 
 // Schemas & types
 export {
+	PhraseSchema,
+	type PhraseType,
 	PhraseFullSchema,
 	type PhraseFullType,
 	type PhraseFullFullType,
@@ -15,11 +17,12 @@ export {
 } from './schemas'
 
 // Collections
-export { phrasesCollection } from './collections'
+export { phrasesCollection, phraseTranslationsCollection } from './collections'
 
 // Live collections
 export {
 	phrasesFull,
+	phrasesWithTranslations,
 	usePhrasePlaylists,
 	usePhraseComments,
 	useRelatedCards,

--- a/src/features/phrases/live.ts
+++ b/src/features/phrases/live.ts
@@ -4,11 +4,12 @@ import {
 	createLiveQueryCollection,
 	eq,
 	inArray,
+	toArray,
 } from '@tanstack/db'
 import { useLiveQuery } from '@tanstack/react-db'
 
 import type { UseLiveQueryResult, uuid } from '@/types/main'
-import { phrasesCollection } from './collections'
+import { phrasesCollection, phraseTranslationsCollection } from './collections'
 import { publicProfilesCollection } from '@/features/profile/collections'
 import {
 	playlistPhraseLinksCollection,
@@ -20,11 +21,31 @@ import {
 	phraseRequestsCollection,
 } from '@/features/requests/collections'
 
+// Phrase row with its translations aggregated via toArray(). Used by
+// `useOnePhrase` / `useLangPhrasesRaw` and as the base for `phrasesFull`.
+// Keeping it as a derived collection means the aggregation runs once and
+// is reused across consumers.
+export const phrasesWithTranslations = createLiveQueryCollection({
+	id: 'phrases_with_translations',
+	query: (q) =>
+		q.from({ phrase: phrasesCollection }).select(({ phrase }) => ({
+			...phrase,
+			translations: toArray(
+				q
+					.from({ t: phraseTranslationsCollection })
+					.where(({ t }) => eq(t.phrase_id, phrase.id))
+					.select(({ t }) => t)
+			),
+		})),
+})
+
+phrasesWithTranslations.createIndex((row) => row.id, { indexType: BasicIndex })
+
 export const phrasesFull = createLiveQueryCollection({
 	id: 'phrases_full',
 	query: (q) =>
 		q
-			.from({ phrase: phrasesCollection })
+			.from({ phrase: phrasesWithTranslations })
 			.join(
 				{ profile: publicProfilesCollection },
 				({ phrase, profile }) => eq(phrase.added_by, profile.uid),

--- a/src/features/phrases/live.ts
+++ b/src/features/phrases/live.ts
@@ -51,15 +51,19 @@ export const phrasesFull = createLiveQueryCollection({
 				({ phrase, profile }) => eq(phrase.added_by, profile.uid),
 				'inner'
 			)
-			.fn.select(({ phrase, profile }) => ({
-				...phrase,
-				profile,
-				searchableText: [
-					phrase.text,
-					...(phrase.translations?.map((t) => t.text) ?? []),
-					...(phrase.tags ?? []).map((t) => t.name),
-				].join(', '),
-			})),
+			.fn.select(({ phrase, profile }) => {
+				const translations = phrase.translations ?? []
+				return {
+					...phrase,
+					translations,
+					profile,
+					searchableText: [
+						phrase.text,
+						...translations.map((t) => t.text),
+						...(phrase.tags ?? []).map((t) => t.name),
+					].join(', '),
+				}
+			}),
 })
 
 phrasesFull.createIndex((row) => row.id, { indexType: BasicIndex })

--- a/src/features/phrases/schemas.ts
+++ b/src/features/phrases/schemas.ts
@@ -36,7 +36,11 @@ export const TranslationSchema = z.object({
 
 export type TranslationType = z.infer<typeof TranslationSchema>
 
-export const PhraseFullSchema = z.object({
+// PhraseSchema — the row shape held by `phrasesCollection`. Mirrors what
+// `phrase_meta` returns. Translations live in their own collection now
+// (`phraseTranslationsCollection`) and are composed onto rows by the live
+// queries in `live.ts`.
+export const PhraseSchema = z.object({
 	id: z.string().uuid(),
 	created_at: z.string(),
 	text: z.string(),
@@ -48,10 +52,22 @@ export const PhraseFullSchema = z.object({
 	avg_stability: z.number().nullable().default(null),
 	count_learners: z.number().nullable().default(0),
 	tags: z.preprocess((val) => val ?? [], z.array(PhraseTagSchema)),
-	translations: z.preprocess((val) => val ?? [], z.array(TranslationSchema)),
 })
 
-export type PhraseFullType = z.infer<typeof PhraseFullSchema>
+export type PhraseType = z.infer<typeof PhraseSchema>
+
+// PhraseFullType — derived shape produced by `phrasesWithTranslations` /
+// `phrasesFull` live queries. `translations` is aggregated from
+// `phraseTranslationsCollection` via toArray() at query time.
+export type PhraseFullType = PhraseType & {
+	translations: Array<TranslationType>
+}
+
+// Parser for places (RPC responses, write paths) that need to validate a
+// composed phrase+translations payload.
+export const PhraseFullSchema = PhraseSchema.extend({
+	translations: z.preprocess((val) => val ?? [], z.array(TranslationSchema)),
+})
 
 export type PhraseFullFullType = PhraseFullType & {
 	profile: PublicProfileType

--- a/src/hooks/composite-phrase.ts
+++ b/src/hooks/composite-phrase.ts
@@ -26,18 +26,19 @@ export const usePhrase = (pid: uuid): CompositePhraseQueryResults => {
 
 	if (isLoading2) return { status: 'pending', data: undefined }
 	if (!phrase) return { data: null, status: 'not-found' }
+	const translations = phrase.translations ?? []
 	const partial = {
 		...phrase,
-		translations_mine: phrase.translations,
+		translations,
+		translations_mine: translations,
 		translations_other: [] as Array<TranslationType>,
 	}
 	if (isLoading1) return { data: partial, status: 'partial' }
 	if (!languagesToShow.length) return { data: partial, status: 'complete' }
 
-	const orderedLangs =
-		languagesToShow.includes(preferredLang) ?
-			[preferredLang, ...languagesToShow.filter((l) => l !== preferredLang)]
-		:	languagesToShow
+	const orderedLangs = languagesToShow.includes(preferredLang)
+		? [preferredLang, ...languagesToShow.filter((l) => l !== preferredLang)]
+		: languagesToShow
 
 	const phraseFiltered = splitPhraseTranslations(phrase, orderedLangs)
 
@@ -54,9 +55,9 @@ function splitTranslations(
 	const translations_mine = translations_incoming
 		.filter((t) => translationLangs.includes(t.lang))
 		.toSorted((a, b) => {
-			return a.lang === b.lang ?
-					0
-				:	translationLangs.indexOf(a.lang) - translationLangs.indexOf(b.lang)
+			return a.lang === b.lang
+				? 0
+				: translationLangs.indexOf(a.lang) - translationLangs.indexOf(b.lang)
 		})
 	const translations_other = translations_incoming.filter(
 		(t) => !translationLangs.includes(t.lang)
@@ -75,10 +76,11 @@ export function splitPhraseTranslations<T extends PhraseFullType>(
 	translations_mine: Array<TranslationType>
 	translations_other: Array<TranslationType>
 } {
+	const translations = phrase.translations ?? []
 	const { translations_mine, translations_other } = splitTranslations(
 		languagesToShow,
-		phrase.translations ?? []
+		translations
 	)
 
-	return { ...phrase, translations_mine, translations_other }
+	return { ...phrase, translations, translations_mine, translations_other }
 }

--- a/src/routes/_user/admin/$lang.phrases.$id.lazy.tsx
+++ b/src/routes/_user/admin/$lang.phrases.$id.lazy.tsx
@@ -33,7 +33,10 @@ import { AddTranslationsDialog } from '@/components/card-pieces/add-translations
 import { AddTags } from '@/components/card-pieces/add-tags'
 import { UidPermalink } from '@/components/card-pieces/user-permalink'
 import { useOnePhrase } from '@/features/phrases/hooks'
-import { phrasesCollection } from '@/features/phrases/collections'
+import {
+	phrasesCollection,
+	phraseTranslationsCollection,
+} from '@/features/phrases/collections'
 import { useAuth } from '@/lib/use-auth'
 import supabase from '@/lib/supabase-client'
 import { ago } from '@/lib/dayjs'
@@ -207,7 +210,6 @@ function AdminPhraseDetail() {
 							<AdminTranslationRow
 								key={trans.id}
 								translation={trans}
-								phrase={phrase}
 								isAdmin={isAdmin}
 							/>
 						))}
@@ -312,11 +314,9 @@ function EditablePhraseText({
 
 function AdminTranslationRow({
 	translation,
-	phrase,
 	isAdmin,
 }: {
 	translation: TranslationType
-	phrase: PhraseFullType
 	isAdmin: boolean
 }) {
 	const [isEditing, setIsEditing] = useState(false)
@@ -334,12 +334,9 @@ function AdminTranslationRow({
 			return data[0]
 		},
 		onSuccess: (data) => {
-			phrasesCollection.utils.writeUpdate({
-				id: phrase.id,
-				translations: phrase.translations.map((t) =>
-					t.id === translation.id ? TranslationSchema.parse(data) : t
-				),
-			})
+			phraseTranslationsCollection.utils.writeUpdate(
+				TranslationSchema.parse(data)
+			)
 			setIsEditing(false)
 			toastSuccess('Translation updated')
 		},
@@ -358,13 +355,9 @@ function AdminTranslationRow({
 				.throwOnError()
 		},
 		onSuccess: () => {
-			phrasesCollection.utils.writeUpdate({
-				id: phrase.id,
-				translations: phrase.translations.map((t) =>
-					t.id !== translation.id
-						? t
-						: { ...t, archived: !translation.archived }
-				),
+			phraseTranslationsCollection.utils.writeUpdate({
+				...translation,
+				archived: !translation.archived,
 			})
 			toastSuccess(
 				`Translation ${translation.archived ? 'restored' : 'archived'}`

--- a/src/routes/_user/admin/$lang.tsx
+++ b/src/routes/_user/admin/$lang.tsx
@@ -1,5 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { phrasesCollection } from '@/features/phrases/collections'
+import {
+	phrasesCollection,
+	phraseTranslationsCollection,
+} from '@/features/phrases/collections'
 import { phraseRequestsCollection } from '@/features/requests/collections'
 import { langTagsCollection } from '@/features/languages/collections'
 import { publicProfilesCollection } from '@/features/profile/collections'
@@ -8,6 +11,7 @@ export const Route = createFileRoute('/_user/admin/$lang')({
 	loader: async () => {
 		await Promise.all([
 			phrasesCollection.preload(),
+			phraseTranslationsCollection.preload(),
 			phraseRequestsCollection.preload(),
 			langTagsCollection.preload(),
 			publicProfilesCollection.preload(),

--- a/src/routes/_user/browse.tsx
+++ b/src/routes/_user/browse.tsx
@@ -4,7 +4,10 @@ import {
 	languagesCollection,
 	langTagsCollection,
 } from '@/features/languages/collections'
-import { phrasesCollection } from '@/features/phrases/collections'
+import {
+	phrasesCollection,
+	phraseTranslationsCollection,
+} from '@/features/phrases/collections'
 import { phraseRequestsCollection } from '@/features/requests/collections'
 import {
 	phrasePlaylistsCollection,
@@ -31,6 +34,7 @@ export const Route = createFileRoute('/_user/browse')({
 			phraseRequestsCollection.preload(),
 			phrasePlaylistsCollection.preload(),
 			phrasesCollection.preload(),
+			phraseTranslationsCollection.preload(),
 			playlistPhraseLinksCollection.preload(),
 		])
 	},

--- a/src/routes/_user/friends/-card-preview.tsx
+++ b/src/routes/_user/friends/-card-preview.tsx
@@ -10,7 +10,7 @@ import { LangBadge } from '@/components/ui/badge'
 
 export function CardPreview({ pid, isMine }: { pid: uuid; isMine: boolean }) {
 	const { data: phrase, status } = usePhrase(pid)
-	const chosenTranslation = phrase?.translations[0]
+	const chosenTranslation = phrase?.translations?.[0]
 
 	if (status === 'pending') return <Loader className="my-6" />
 	if (status === 'not-found' || !phrase)
@@ -30,12 +30,13 @@ export function CardPreview({ pid, isMine }: { pid: uuid; isMine: boolean }) {
 						<CardTitle className="text-lg">{phrase.text}</CardTitle>
 						<LangBadge lang={phrase.lang} />
 					</div>
-					{chosenTranslation ?
+					{chosenTranslation ? (
 						<p className="text-muted-foreground">{chosenTranslation.text}</p>
-					:	<p className="text-muted-foreground text-sm italic">
+					) : (
+						<p className="text-muted-foreground text-sm italic">
 							No translations yet
 						</p>
-					}
+					)}
 				</CardContent>
 			</CardlikeFlashcard>
 		</Link>

--- a/src/routes/_user/friends/chats.$friendUid.recommend.tsx
+++ b/src/routes/_user/friends/chats.$friendUid.recommend.tsx
@@ -16,7 +16,7 @@ import {
 import type { TablesInsert } from '@/types/supabase'
 import supabase from '@/lib/supabase-client'
 import { useUserId } from '@/lib/use-auth'
-import { phrasesCollection } from '@/features/phrases/collections'
+import { phrasesWithTranslations } from '@/features/phrases/live'
 import { phraseRequestsActive } from '@/features/requests/live'
 import { phrasePlaylistsActive } from '@/features/playlists/live'
 
@@ -91,7 +91,7 @@ function RouteComponent() {
 	// path returns nothing without a real query, so this preserves the
 	// "filter by lang/type, see all in-lang items" UX.
 	const { data: allPhrases } = useLiveQuery((q) =>
-		q.from({ phrase: phrasesCollection })
+		q.from({ phrase: phrasesWithTranslations })
 	)
 	const { data: allRequests } = useLiveQuery((q) =>
 		q.from({ req: phraseRequestsActive })

--- a/src/routes/_user/learn/$lang.bulk-add.tsx
+++ b/src/routes/_user/learn/$lang.bulk-add.tsx
@@ -24,12 +24,15 @@ import { usePreferredTranslationLang } from '@/features/deck/hooks'
 import { Separator } from '@/components/ui/separator'
 import { LanguagePicker } from '@/components/fields/language-picker'
 import { CardResultSimple } from '@/components/cards/card-result-simple'
-import { PhraseFullSchema } from '@/features/phrases/schemas'
+import { PhraseSchema, TranslationSchema } from '@/features/phrases/schemas'
 import { CardMetaSchema, DeckMetaSchema } from '@/features/deck/schemas'
 import { directionsForPhrase } from '@/features/deck/card-directions'
 import { LangTagSchema } from '@/features/languages/schemas'
 import { langTagsCollection } from '@/features/languages/collections'
-import { phrasesCollection } from '@/features/phrases/collections'
+import {
+	phrasesCollection,
+	phraseTranslationsCollection,
+} from '@/features/phrases/collections'
 import { cardsCollection, decksCollection } from '@/features/deck/collections'
 import { Tables } from '@/types/supabase'
 import { uuid } from '@/types/main'
@@ -302,16 +305,15 @@ function BulkAddPhrasesPage() {
 						.filter((t): t is { id: string; name: string } => t !== null)
 				}
 
-				return PhraseFullSchema.parse({
-					...p,
-					translations: rpcResult.translations.filter(
-						(t) => t.phrase_id === p.id
-					),
-					tags,
-				})
+				return PhraseSchema.parse({ ...p, tags })
 			})
 
 			phrasesToInsert.forEach((p) => phrasesCollection.utils.writeInsert(p))
+			rpcResult.translations.forEach((t) =>
+				phraseTranslationsCollection.utils.writeInsert(
+					TranslationSchema.parse(t)
+				)
+			)
 
 			should(
 				'bulk add wrote every submitted phrase into phrasesCollection',

--- a/src/routes/_user/learn/$lang.phrases.$id.tsx
+++ b/src/routes/_user/learn/$lang.phrases.$id.tsx
@@ -1,7 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { BigPhraseCard } from '@/components/cards/big-phrase-card'
 import { CSSProperties } from 'react'
-import { phrasesCollection } from '@/features/phrases/collections'
+import {
+	phrasesCollection,
+	phraseTranslationsCollection,
+} from '@/features/phrases/collections'
 import { cardsCollection } from '@/features/deck/collections'
 import { publicProfilesCollection } from '@/features/profile/collections'
 
@@ -13,6 +16,7 @@ export const Route = createFileRoute('/_user/learn/$lang/phrases/$id')({
 	loader: async ({ context }) => {
 		const preloads: Promise<unknown>[] = [
 			phrasesCollection.preload(),
+			phraseTranslationsCollection.preload(),
 			publicProfilesCollection.preload(),
 		]
 		if (context.auth.isAuth) {

--- a/src/routes/_user/learn/$lang.phrases.new.tsx
+++ b/src/routes/_user/learn/$lang.phrases.new.tsx
@@ -22,9 +22,12 @@ import languages from '@/lib/languages'
 import supabase from '@/lib/supabase-client'
 import TranslationLanguageField from '@/components/fields/translation-language-field'
 import { buttonVariants } from '@/components/ui/button'
-import { PhraseFullSchema, TranslationSchema } from '@/features/phrases/schemas'
+import { PhraseSchema, TranslationSchema } from '@/features/phrases/schemas'
 import { CardMetaSchema, DeckMetaSchema } from '@/features/deck/schemas'
-import { phrasesCollection } from '@/features/phrases/collections'
+import {
+	phrasesCollection,
+	phraseTranslationsCollection,
+} from '@/features/phrases/collections'
 import { cardsCollection, decksCollection } from '@/features/deck/collections'
 import { useInvalidateFeed } from '@/features/feed/hooks'
 import { WithPhrase } from '@/components/with-phrase'
@@ -159,11 +162,9 @@ function AddPhraseTab() {
 			if (!rpcResult)
 				throw new Error('No data returned from add_phrase_translation_card')
 
-			phrasesCollection.utils.writeInsert(
-				PhraseFullSchema.parse({
-					...rpcResult.phrase,
-					translations: [TranslationSchema.parse(rpcResult.translation)],
-				})
+			phrasesCollection.utils.writeInsert(PhraseSchema.parse(rpcResult.phrase))
+			phraseTranslationsCollection.utils.writeInsert(
+				TranslationSchema.parse(rpcResult.translation)
 			)
 			if (rpcResult.card)
 				phrasesCollection.utils.writeUpdate({

--- a/src/routes/_user/learn/$lang.tsx
+++ b/src/routes/_user/learn/$lang.tsx
@@ -5,7 +5,10 @@ import languages from '@/lib/languages'
 import { setLangTheme, useLangPopularityReady } from '@/lib/lang-theme'
 import { todayString } from '@/lib/utils'
 import { langTagsCollection } from '@/features/languages/collections'
-import { phrasesCollection } from '@/features/phrases/collections'
+import {
+	phrasesCollection,
+	phraseTranslationsCollection,
+} from '@/features/phrases/collections'
 import { cardsCollection, decksCollection } from '@/features/deck/collections'
 import { publicProfilesCollection } from '@/features/profile/collections'
 import {
@@ -58,6 +61,7 @@ export const Route = createFileRoute('/_user/learn/$lang')({
 		const preloads: Promise<unknown>[] = [
 			langTagsCollection.preload(),
 			phrasesCollection.preload(),
+			phraseTranslationsCollection.preload(),
 			publicProfilesCollection.preload(),
 			phrasePlaylistsCollection.preload(),
 			playlistPhraseLinksCollection.preload(),


### PR DESCRIPTION
## Summary

Phase 1 of splitting the denormalized `phrase_meta` shape into flat collections. This PR moves **translations** off the phrase row and into a dedicated `phraseTranslationsCollection`, with live queries composing them back onto each phrase via TanStack DB's `toArray()` aggregator so the consumer surface (`phrase.translations` as an array) is preserved.

Tags and `phrase_stats` will follow in their own PRs.

## Why

Today, `phrasesCollection` fetches from the `phrase_meta` view with a nested `translations:phrase_translation(*)` PostgREST embed. That couples translations to the phrase row, so:

- Adding/editing/archiving one translation forces splicing the denormalized array on the phrase row (or refetching the whole phrase).
- Translations share a cache lifetime with phrases — a translation change invalidates a phrase row that didn't really change.
- Public-facing pieces of the OG/middleware fetcher only need translations, but go through the heavier view.

Flattening makes each axis independently fetchable, cacheable, and mutable.

## Producer changes

- **`PhraseSchema`** (new, slim): the row shape held by `phrasesCollection`. `PhraseFullType` is now a *derived* shape (`PhraseType & { translations: TranslationType[] }`) produced by the live queries, not a fetched shape.
- **`phraseTranslationsCollection`**: reads `phrase_translation` directly, with `BasicIndex` for fast lookups by `phrase_id`.
- **`phrasesCollection`**: queryFn drops the nested translations embed; still reads from `phrase_meta` for now since tags + stats still live there.
- **`phrasesWithTranslations`** (new derived live collection): joins translations onto each phrase row via `toArray()`. Used by `useOnePhrase` / `useLangPhrasesRaw`.
- **`phrasesFull`**: rebased on `phrasesWithTranslations` so its existing `searchableText` composition keeps working.
- **`middleware.ts`** (OG meta fetcher): embeds against `phrase` directly — `phrase_meta` is no longer the only way to grab phrase + translations.

## Consumer changes

- Mutation handlers (`add-translations`, `inline-phrase-creator`, `$lang.phrases.new`, `bulk-add`, admin phrase detail) write to `phraseTranslationsCollection.utils.writeInsert / writeUpdate` instead of splicing the translations array on a phrase row.
- Routes that preload `phrasesCollection` also preload `phraseTranslationsCollection` (`browse`, `$lang`, `admin/$lang`, `$lang.phrases.$id`).
- `library-charts` counts the translations collection directly instead of summing `p.translations.length`.
- `chats.$friendUid.recommend` routes its browse-mode list through `phrasesWithTranslations` so it still gets translation subtitles.

## Defensive normalization

When `phrase_meta` shipped translations via Zod's `z.preprocess((val) => val ?? [], …)`, undefined/null inputs always became `[]` before any consumer saw them. The new live-query path skips Zod, so `toArray()` results can be transiently nullish before the subquery materializes — and that nullishness rode through every `{...phrase}` spread, crashing consumers reading `phrase.translations.map / [0]`.

Fixed in three layers:

1. `phrasesFull.fn.select` explicitly normalizes `translations` to `[]` before spreading.
2. `usePhrase` (both partial + complete branches) and `splitPhraseTranslations` carry a guaranteed array.
3. Defensive `?.` on the five read sites still reaching `phrase.translations.map / [0]` without a guard (`phrase-tiny-card`, `add-translations`, `feed-phrase-group-item`, `tap-to-select`, `-card-preview`).

## CLAUDE.md update

Also includes a clarification to the Deployment Strategy section: the "does this PR touch a migration?" rule alone is insufficient. A branch based off `next` carries unreleased migrations from `next` along with it — merging that branch into `main` would smuggle them past the migration-track QA gate regardless of the PR's own diff. The Decision rule is now two sequential checks (branch base first, then content) with an explicit note to verify the PR base before merging, since auto-created PRs default to the repo's default branch.

## History

Originally opened as #699 (closed). That PR's auto-generated description had drifted because it was created when the branch was based off the old `next` carrying unreleased migrations. The branch has been rebased cleanly onto `next-0.28` — 3 commits, no conflicts. The defensive null fixes already include scenetest repro coverage from cycle-card-status and create-phrase-from-chat-request failures.

## Test plan

- [ ] `pnpm check` clean
- [ ] `pnpm lint` clean (16 pre-existing warnings, none from this diff)
- [ ] Scenetest: cycle card status, create phrase from chat request, add/archive translation, bulk add with translations, admin phrase detail editing

https://claude.ai/code/session_0171QHSEQC4TiGFL4vq76uLq

---
_Generated by [Claude Code](https://claude.ai/code/session_0171QHSEQC4TiGFL4vq76uLq)_