### PR TITLE
Add interactive FSRS forgetting curve visualization page

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -79,6 +79,7 @@ const ThemesLazyRouteImport = createFileRoute('/themes')()
 const RequestRemovalLazyRouteImport = createFileRoute('/request-removal')()
 const PrivacyPolicyLazyRouteImport = createFileRoute('/privacy-policy')()
 const MicrocopyLazyRouteImport = createFileRoute('/microcopy')()
+const FsrsLazyRouteImport = createFileRoute('/fsrs')()
 const ComponentsLazyRouteImport = createFileRoute('/components')()
 const ThemesIndexLazyRouteImport = createFileRoute('/themes/')()
 const ChatsIndexLazyRouteImport = createFileRoute('/chats/')()
@@ -127,6 +128,11 @@ const MicrocopyLazyRoute = MicrocopyLazyRouteImport.update({
   path: '/microcopy',
   getParentRoute: () => rootRouteImport,
 } as any).lazy(() => import('./routes/microcopy.lazy').then((d) => d.Route))
+const FsrsLazyRoute = FsrsLazyRouteImport.update({
+  id: '/fsrs',
+  path: '/fsrs',
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() => import('./routes/fsrs.lazy').then((d) => d.Route))
 const ComponentsLazyRoute = ComponentsLazyRouteImport.update({
   id: '/components',
   path: '/components',
@@ -563,6 +569,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/chats': typeof ChatsRouteWithChildren
   '/components': typeof ComponentsLazyRoute
+  '/fsrs': typeof FsrsLazyRoute
   '/microcopy': typeof MicrocopyLazyRoute
   '/privacy-policy': typeof PrivacyPolicyLazyRoute
   '/request-removal': typeof RequestRemovalLazyRoute
@@ -642,6 +649,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/components': typeof ComponentsLazyRoute
+  '/fsrs': typeof FsrsLazyRoute
   '/microcopy': typeof MicrocopyLazyRoute
   '/privacy-policy': typeof PrivacyPolicyLazyRoute
   '/request-removal': typeof RequestRemovalLazyRoute
@@ -710,6 +718,7 @@ export interface FileRoutesById {
   '/_user': typeof UserRouteWithChildren
   '/chats': typeof ChatsRouteWithChildren
   '/components': typeof ComponentsLazyRoute
+  '/fsrs': typeof FsrsLazyRoute
   '/microcopy': typeof MicrocopyLazyRoute
   '/privacy-policy': typeof PrivacyPolicyLazyRoute
   '/request-removal': typeof RequestRemovalLazyRoute
@@ -792,6 +801,7 @@ export interface FileRouteTypes {
     | '/'
     | '/chats'
     | '/components'
+    | '/fsrs'
     | '/microcopy'
     | '/privacy-policy'
     | '/request-removal'
@@ -871,6 +881,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/components'
+    | '/fsrs'
     | '/microcopy'
     | '/privacy-policy'
     | '/request-removal'
@@ -938,6 +949,7 @@ export interface FileRouteTypes {
     | '/_user'
     | '/chats'
     | '/components'
+    | '/fsrs'
     | '/microcopy'
     | '/privacy-policy'
     | '/request-removal'
@@ -1021,6 +1033,7 @@ export interface RootRouteChildren {
   UserRoute: typeof UserRouteWithChildren
   ChatsRoute: typeof ChatsRouteWithChildren
   ComponentsLazyRoute: typeof ComponentsLazyRoute
+  FsrsLazyRoute: typeof FsrsLazyRoute
   MicrocopyLazyRoute: typeof MicrocopyLazyRoute
   PrivacyPolicyLazyRoute: typeof PrivacyPolicyLazyRoute
   RequestRemovalLazyRoute: typeof RequestRemovalLazyRoute
@@ -1055,6 +1068,13 @@ declare module '@tanstack/react-router' {
       path: '/microcopy'
       fullPath: '/microcopy'
       preLoaderRoute: typeof MicrocopyLazyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/fsrs': {
+      id: '/fsrs'
+      path: '/fsrs'
+      fullPath: '/fsrs'
+      preLoaderRoute: typeof FsrsLazyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/components': {
@@ -1927,6 +1947,7 @@ const rootRouteChildren: RootRouteChildren = {
   UserRoute: UserRouteWithChildren,
   ChatsRoute: ChatsRouteWithChildren,
   ComponentsLazyRoute: ComponentsLazyRoute,
+  FsrsLazyRoute: FsrsLazyRoute,
   MicrocopyLazyRoute: MicrocopyLazyRoute,
   PrivacyPolicyLazyRoute: PrivacyPolicyLazyRoute,
   RequestRemovalLazyRoute: RequestRemovalLazyRoute,

--- a/src/routes/fsrs.lazy.tsx
+++ b/src/routes/fsrs.lazy.tsx
@@ -1,5 +1,6 @@
 import { createLazyFileRoute } from '@tanstack/react-router'
 import { useMemo, useState } from 'react'
+import { X } from 'lucide-react'
 import {
 	calculateFSRS,
 	calculateInterval,
@@ -7,6 +8,7 @@ import {
 	type Score,
 } from '@/features/review/fsrs'
 import { type CardReviewType } from '@/features/review/schemas'
+import { cn } from '@/lib/utils'
 import {
 	Card,
 	CardContent,
@@ -14,6 +16,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 
 export const Route = createLazyFileRoute('/fsrs')({
@@ -28,16 +31,53 @@ export const Route = createLazyFileRoute('/fsrs')({
 // ---------------------------------------------------------------------------
 
 const DEFAULTS = {
-	/** Self-assessment used for every simulated review: 1=Again 2=Hard 3=Good 4=Easy */
-	score: 3 as Score,
+	/** The grade of each review, in order. 1=Again 2=Hard 3=Good 4=Easy. The
+	 *  first entry is the initial learning grade. */
+	scores: [1, 3, 2, 3, 3] as Array<Score>,
 	/** Retention the scheduler aims for. The card "comes back around" the moment
 	 *  its recall probability decays to this value — 0.9 = 90%. */
 	desiredRetention: 0.9,
-	/** How many times we review the card in the simulation. */
-	numReviews: 5,
 	/** Bottom of the Y axis. 0.7 = the chart starts at 70% retention. */
 	yMin: 0.7,
 } as const
+
+const PRESETS: Array<{ label: string; scores: Array<Score> }> = [
+	{ label: 'All Good', scores: [3, 3, 3, 3, 3] },
+	{ label: 'Struggling', scores: [1, 3, 2, 3, 3] },
+	{ label: 'Mid-lapse', scores: [3, 3, 3, 1, 3] },
+	{ label: 'Quick learner', scores: [4, 4, 4, 4] },
+]
+
+// Per-score presentation. Full literal class strings so Tailwind picks them up.
+const SCORE_META: Record<
+	Score,
+	{ label: string; glyph: string; text: string; activeBtn: string }
+> = {
+	1: {
+		label: 'Again',
+		glyph: '✕',
+		text: 'text-5-hi-danger',
+		activeBtn: 'bg-2-mlo-danger border-4-mid-danger text-5-hi-danger',
+	},
+	2: {
+		label: 'Hard',
+		glyph: '○',
+		text: 'text-6-hi-warning',
+		activeBtn: 'bg-2-mlo-warning border-4-mid-warning text-6-hi-warning',
+	},
+	3: {
+		label: 'Good',
+		glyph: '●',
+		text: 'text-6-hi-accent',
+		activeBtn: 'bg-2-mlo-accent border-4-mid-accent text-6-hi-accent',
+	},
+	4: {
+		label: 'Easy',
+		glyph: '◆',
+		text: 'text-5-hi-success',
+		activeBtn: 'bg-2-mlo-success border-4-mid-success text-5-hi-success',
+	},
+}
 
 // SVG geometry (in viewBox units)
 const VB = { w: 820, h: 520 }
@@ -48,21 +88,17 @@ const PLOT = {
 }
 const SAMPLES_PER_SEGMENT = 80
 
-const SCORE_LABELS: Record<Score, string> = {
-	1: 'Again',
-	2: 'Hard',
-	3: 'Good',
-	4: 'Easy',
-}
-
 // ---------------------------------------------------------------------------
 // Simulation — drive the real FSRS functions through a sequence of reviews.
 // Each review fires exactly when retrievability decays to `desiredRetention`,
-// resetting recall to 100% and lengthening the next interval (rising stability).
+// resetting recall to 100% and re-shaping the next interval according to the
+// grade: a lapse (Again) collapses stability so the next curve is short and
+// steep; an Easy stretches it far out.
 // ---------------------------------------------------------------------------
 
 interface Segment {
 	index: number
+	score: Score
 	/** Day this review happened (curve = 100% here). */
 	startDay: number
 	/** Day the next review is scheduled (curve = desiredRetention here). */
@@ -72,9 +108,8 @@ interface Segment {
 }
 
 function simulateReviews(
-	score: Score,
-	desiredRetention: number,
-	numReviews: number
+	scores: Array<Score>,
+	desiredRetention: number
 ): Array<Segment> {
 	const BASE = new Date('2025-01-01T00:00:00Z')
 	const atDay = (d: number) => new Date(BASE.getTime() + d * 86_400_000)
@@ -83,7 +118,7 @@ function simulateReviews(
 	let previousReview: CardReviewType | undefined = undefined
 	let day = 0
 
-	for (let i = 0; i < numReviews; i++) {
+	scores.forEach((score, i) => {
 		const { difficulty, stability } = calculateFSRS({
 			score,
 			previousReview,
@@ -96,6 +131,7 @@ function simulateReviews(
 
 		segments.push({
 			index: i,
+			score,
 			startDay: day,
 			endDay: day + interval,
 			stability,
@@ -120,7 +156,7 @@ function simulateReviews(
 		}
 
 		day += interval
-	}
+	})
 
 	return segments
 }
@@ -135,23 +171,54 @@ function buildPath(points: Array<[number, number]>): string {
 		.join(' ')
 }
 
+/** A grade marker centered at (x, y). Color comes from the parent <g>. */
+function ScoreGlyph({ score, x, y }: { score: Score; x: number; y: number }) {
+	if (score === 1) {
+		const s = 5.5
+		return (
+			<g stroke="currentColor" strokeWidth={2.5} strokeLinecap="round">
+				<line x1={x - s} y1={y - s} x2={x + s} y2={y + s} />
+				<line x1={x - s} y1={y + s} x2={x + s} y2={y - s} />
+			</g>
+		)
+	}
+	if (score === 2)
+		return (
+			<circle
+				cx={x}
+				cy={y}
+				r={5}
+				fill="none"
+				stroke="currentColor"
+				strokeWidth={2.5}
+			/>
+		)
+	if (score === 4)
+		return (
+			<polygon
+				points={`${x},${y - 6} ${x + 6},${y} ${x},${y + 6} ${x - 6},${y}`}
+				fill="currentColor"
+			/>
+		)
+	// score 3 — Good
+	return <circle cx={x} cy={y} r={4.5} fill="currentColor" />
+}
+
 function ForgettingCurveChart({
-	score,
+	scores,
 	desiredRetention,
-	numReviews,
 	yMin,
 }: {
-	score: Score
+	scores: Array<Score>
 	desiredRetention: number
-	numReviews: number
 	yMin: number
 }) {
 	const { segments, dayMax } = useMemo(() => {
-		const segs = simulateReviews(score, desiredRetention, numReviews)
+		const segs = simulateReviews(scores, desiredRetention)
 		const lastEnd = segs.at(-1)?.endDay ?? 1
 		// A little headroom so the final reset isn't flush against the edge.
 		return { segments: segs, dayMax: Math.ceil(lastEnd * 1.08) }
-	}, [score, desiredRetention, numReviews])
+	}, [scores, desiredRetention])
 
 	// Coordinate mappers
 	const toX = (day: number) => PAD.left + (day / dayMax) * PLOT.w
@@ -165,7 +232,8 @@ function ForgettingCurveChart({
 
 	return (
 		<svg viewBox={`0 0 ${VB.w} ${VB.h}`} className="h-auto w-full">
-			<title>FSRS forgetting curve with reviews</title>
+			<title>FSRS forgetting curve for a sequence of reviews</title>
+
 			{/* Y gridlines + labels */}
 			{yTicks.map((r) => (
 				<g key={`y-${r}`}>
@@ -205,7 +273,7 @@ function ForgettingCurveChart({
 						x={toX(s.endDay)}
 						y={PAD.top + PLOT.h + 22}
 						textAnchor="middle"
-						className="fill-muted-foreground text-[13px]"
+						className="fill-muted-foreground text-[12px]"
 					>
 						{s.endDay.toFixed(1)}
 					</text>
@@ -258,49 +326,49 @@ function ForgettingCurveChart({
 				)
 			})}
 
-			{/* Dashed vertical "review" reset lines: target retention back up to 100% */}
-			{segments.slice(0, -1).map((s) => (
+			{/* Dashed vertical "review" reset lines, colored by the grade given */}
+			{segments.slice(1).map((s) => (
 				<line
 					key={`reset-${s.index}`}
-					x1={toX(s.endDay)}
-					x2={toX(s.endDay)}
+					x1={toX(s.startDay)}
+					x2={toX(s.startDay)}
 					y1={toY(desiredRetention)}
 					y2={toY(1)}
-					className="text-accent"
+					className={SCORE_META[s.score].text}
 					stroke="currentColor"
 					strokeWidth={2.5}
 					strokeDasharray="5 5"
 				/>
 			))}
 
-			{/* Review markers + arrows along the top */}
+			{/* Review markers + arrows + grade label along the top */}
 			{segments.map((s) => {
 				const x = toX(s.startDay)
+				const meta = SCORE_META[s.score]
 				return (
-					<g key={`marker-${s.index}`}>
+					<g key={`marker-${s.index}`} className={meta.text}>
 						<line
 							x1={x}
 							x2={x}
 							y1={PAD.top - 26}
-							y2={PAD.top - 4}
-							className="text-accent"
+							y2={PAD.top - 6}
 							stroke="currentColor"
 							strokeWidth={2}
 						/>
 						<path
-							d={`M${x - 4},${PAD.top - 9} L${x},${PAD.top - 2} L${x + 4},${PAD.top - 9} Z`}
-							className="fill-accent"
+							d={`M${x - 4},${PAD.top - 11} L${x},${PAD.top - 4} L${x + 4},${PAD.top - 11} Z`}
+							fill="currentColor"
 						/>
 						<text
 							x={x}
 							y={PAD.top - 32}
 							textAnchor="middle"
-							className="fill-accent-foreground text-[12px] font-medium"
+							className="text-[12px] font-medium"
+							fill="currentColor"
 						>
-							{s.index === 0 ? 'Learned' : `Review ${s.index}`}
+							{s.index === 0 ? `Learn · ${meta.label}` : meta.label}
 						</text>
-						{/* dot where this curve starts at 100% */}
-						<circle cx={x} cy={toY(1)} r={4} className="fill-accent" />
+						<ScoreGlyph score={s.score} x={x} y={toY(1)} />
 					</g>
 				)
 			})}
@@ -344,6 +412,18 @@ function ForgettingCurveChart({
 				Retention
 			</text>
 		</svg>
+	)
+}
+
+function ChartLegend() {
+	return (
+		<div className="text-muted-foreground mt-2 flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs">
+			{([1, 2, 3, 4] as Array<Score>).map((s) => (
+				<span key={s} className={SCORE_META[s].text}>
+					{SCORE_META[s].glyph} {SCORE_META[s].label}
+				</span>
+			))}
+		</div>
 	)
 }
 
@@ -397,40 +477,66 @@ function RangeControl({
 // Page
 // ---------------------------------------------------------------------------
 
+// Reviews carry a stable id so the editor rows have data-dependent keys
+// (positional index keys would re-key on add/remove).
+interface Review {
+	id: number
+	score: Score
+}
+let reviewIdCounter = 0
+const makeReview = (score: Score): Review => ({ id: reviewIdCounter++, score })
+const makeReviews = (scores: ReadonlyArray<Score>) => scores.map(makeReview)
+
 function FsrsPage() {
-	const [score, setScore] = useState<Score>(DEFAULTS.score)
+	const [reviews, setReviews] = useState<Array<Review>>(() =>
+		makeReviews(DEFAULTS.scores)
+	)
 	const [desiredRetention, setDesiredRetention] = useState<number>(
 		DEFAULTS.desiredRetention
 	)
-	const [numReviews, setNumReviews] = useState<number>(DEFAULTS.numReviews)
 	const [yMin, setYMin] = useState<number>(DEFAULTS.yMin)
 
+	const scores = useMemo(() => reviews.map((r) => r.score), [reviews])
 	const segments = useMemo(
-		() => simulateReviews(score, desiredRetention, numReviews),
-		[score, desiredRetention, numReviews]
+		() => simulateReviews(scores, desiredRetention),
+		[scores, desiredRetention]
 	)
+
+	const setScoreAt = (id: number, value: Score) =>
+		setReviews((prev) =>
+			prev.map((r) => (r.id === id ? { ...r, score: value } : r))
+		)
+	const addReview = () =>
+		setReviews((prev) => (prev.length >= 8 ? prev : [...prev, makeReview(3)]))
+	const removeReview = (id: number) =>
+		setReviews((prev) =>
+			prev.length <= 1 ? prev : prev.filter((r) => r.id !== id)
+		)
 
 	return (
 		<main className="@container mx-auto max-w-5xl space-y-6 p-4 pb-20">
 			<div className="space-y-1">
 				<h1 className="text-3xl font-bold">How FSRS Works</h1>
 				<p className="text-muted-foreground text-sm">
-					The forgetting curve, drawn from the real FSRS v5 functions in{' '}
+					The forgetting curve for a whole sequence of reviews, drawn from the
+					real FSRS v5 functions in{' '}
 					<code className="text-xs">src/features/review/fsrs.ts</code>. Each
-					time recall decays to your target retention the card comes back
-					around; a correct answer resets recall to 100% and stretches the next
-					interval.
+					time recall decays to your target retention the card comes back around
+					— and how you grade it reshapes what comes next. A lapse{' '}
+					<span className="text-5-hi-danger">(Again ✕)</span> still resets
+					recall when you re-study, but stability collapses, so the next curve
+					is short and steep.
 				</p>
 			</div>
 
 			<Card>
 				<CardContent className="pt-6">
 					<ForgettingCurveChart
-						score={score}
+						scores={scores}
 						desiredRetention={desiredRetention}
-						numReviews={numReviews}
 						yMin={yMin}
 					/>
+					<ChartLegend />
 				</CardContent>
 			</Card>
 
@@ -439,31 +545,78 @@ function FsrsPage() {
 					<CardHeader>
 						<CardTitle className="text-lg">Tweak it</CardTitle>
 						<CardDescription>
-							Adjust the simulation. Defaults live in the{' '}
+							Pick a preset or grade each review yourself. Defaults live in the{' '}
 							<code className="text-xs">DEFAULTS</code> object at the top of the
 							route file.
 						</CardDescription>
 					</CardHeader>
 					<CardContent className="space-y-5">
-						<div className="space-y-1">
-							<Label>Review score</Label>
-							<div className="flex gap-2">
-								{([1, 2, 3, 4] as Array<Score>).map((s) => (
-									<button
-										key={s}
-										type="button"
-										onClick={() => setScore(s)}
-										className={
-											'flex-1 rounded-2xl border px-2 py-1.5 text-sm transition-colors ' +
-											(score === s
-												? 'border-accent bg-2-mlo-accent text-accent-foreground font-medium'
-												: 'border-border text-muted-foreground hover:bg-1-lo-accent')
-										}
+						<div className="space-y-2">
+							<Label>Presets</Label>
+							<div className="flex flex-wrap gap-2">
+								{PRESETS.map((p) => (
+									<Button
+										key={p.label}
+										variant="soft"
+										size="sm"
+										onClick={() => setReviews(makeReviews(p.scores))}
 									>
-										{SCORE_LABELS[s]}
-									</button>
+										{p.label}
+									</Button>
 								))}
 							</div>
+						</div>
+
+						<div className="space-y-2">
+							<div className="flex items-center justify-between">
+								<Label>Review sequence</Label>
+								<span className="text-muted-foreground text-xs">
+									grade each review
+								</span>
+							</div>
+							<div className="space-y-1.5">
+								{reviews.map((r, i) => (
+									<div key={r.id} className="flex items-center gap-2">
+										<span className="text-muted-foreground w-16 shrink-0 text-xs">
+											{i === 0 ? 'Learn' : `Review ${i}`}
+										</span>
+										<div className="flex flex-1 gap-1">
+											{([1, 2, 3, 4] as Array<Score>).map((opt) => (
+												<button
+													key={opt}
+													type="button"
+													onClick={() => setScoreAt(r.id, opt)}
+													className={cn(
+														'flex-1 rounded-2xl border px-1 py-1 text-xs transition-colors',
+														r.score === opt
+															? `${SCORE_META[opt].activeBtn} font-medium`
+															: 'border-border text-muted-foreground hover:bg-1-lo-neutral'
+													)}
+												>
+													{SCORE_META[opt].label}
+												</button>
+											))}
+										</div>
+										<button
+											type="button"
+											onClick={() => removeReview(r.id)}
+											aria-label={`Remove review ${i}`}
+											disabled={reviews.length <= 1}
+											className="text-muted-foreground hover:text-5-hi-danger disabled:opacity-40"
+										>
+											<X className="size-4" />
+										</button>
+									</div>
+								))}
+							</div>
+							<Button
+								variant="soft"
+								size="sm"
+								onClick={addReview}
+								disabled={reviews.length >= 8}
+							>
+								Add review
+							</Button>
 						</div>
 
 						<RangeControl
@@ -475,17 +628,6 @@ function FsrsPage() {
 							step={0.01}
 							display={`${Math.round(desiredRetention * 100)}%`}
 							onChange={setDesiredRetention}
-						/>
-
-						<RangeControl
-							id="num-reviews"
-							label="Number of reviews"
-							value={numReviews}
-							min={2}
-							max={8}
-							step={1}
-							display={String(numReviews)}
-							onChange={(v) => setNumReviews(Math.round(v))}
 						/>
 
 						<RangeControl
@@ -506,7 +648,8 @@ function FsrsPage() {
 						<CardTitle className="text-lg">Schedule</CardTitle>
 						<CardDescription>
 							Stability is the interval (in days) at which recall hits the
-							target retention. Notice it grows with every successful review.
+							target retention. Watch it grow on success and collapse on a
+							lapse.
 						</CardDescription>
 					</CardHeader>
 					<CardContent>
@@ -514,10 +657,11 @@ function FsrsPage() {
 							<thead>
 								<tr className="text-muted-foreground border-b text-left text-xs">
 									<th className="py-1.5">#</th>
+									<th className="py-1.5">Grade</th>
 									<th className="py-1.5">Day</th>
 									<th className="py-1.5">Interval</th>
 									<th className="py-1.5">Stability</th>
-									<th className="py-1.5">Difficulty</th>
+									<th className="py-1.5">Diff.</th>
 								</tr>
 							</thead>
 							<tbody>
@@ -525,6 +669,14 @@ function FsrsPage() {
 									<tr key={s.index} className="border-b last:border-0">
 										<td className="py-1.5 font-medium">
 											{s.index === 0 ? 'Learn' : s.index}
+										</td>
+										<td
+											className={cn(
+												'py-1.5 font-medium',
+												SCORE_META[s.score].text
+											)}
+										>
+											{SCORE_META[s.score].label}
 										</td>
 										<td className="py-1.5 tabular-nums">
 											{s.startDay.toFixed(1)}

--- a/src/routes/fsrs.lazy.tsx
+++ b/src/routes/fsrs.lazy.tsx
@@ -140,22 +140,14 @@ function simulateReviews(
 			difficulty,
 		})
 
-		// Minimal review record to feed the next iteration's calculateFSRS.
+		// Minimal review record to feed the next iteration's calculateFSRS —
+		// it only reads created_at, difficulty, and stability off the previous
+		// review, so the rest of CardReviewType is irrelevant to the simulation.
 		previousReview = {
-			id: crypto.randomUUID(),
 			created_at: atDay(day).toISOString(),
-			uid: '00000000-0000-0000-0000-000000000000',
-			day_session: atDay(day).toISOString().slice(0, 10),
-			lang: 'eng',
-			phrase_id: '00000000-0000-0000-0000-000000000000',
-			direction: 'forward',
-			score,
-			day_first_review: i === 0,
 			difficulty,
-			review_time_retrievability: i === 0 ? null : desiredRetention,
 			stability,
-			updated_at: null,
-		}
+		} as CardReviewType
 
 		day += interval
 	})

--- a/src/routes/fsrs.lazy.tsx
+++ b/src/routes/fsrs.lazy.tsx
@@ -1,0 +1,550 @@
+import { createLazyFileRoute } from '@tanstack/react-router'
+import { useMemo, useState } from 'react'
+import {
+	calculateFSRS,
+	calculateInterval,
+	retrievability,
+	type Score,
+} from '@/features/review/fsrs'
+import { type CardReviewType } from '@/features/review/schemas'
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+
+export const Route = createLazyFileRoute('/fsrs')({
+	component: FsrsPage,
+})
+
+// ---------------------------------------------------------------------------
+// Tweakable defaults — change these to reshape the demo curve.
+// Everything below is derived from the real FSRS v5 functions in
+// src/features/review/fsrs.ts (retrievability + calculateFSRS), so the decay
+// you see here is exactly what the scheduler uses.
+// ---------------------------------------------------------------------------
+
+const DEFAULTS = {
+	/** Self-assessment used for every simulated review: 1=Again 2=Hard 3=Good 4=Easy */
+	score: 3 as Score,
+	/** Retention the scheduler aims for. The card "comes back around" the moment
+	 *  its recall probability decays to this value — 0.9 = 90%. */
+	desiredRetention: 0.9,
+	/** How many times we review the card in the simulation. */
+	numReviews: 5,
+	/** Bottom of the Y axis. 0.7 = the chart starts at 70% retention. */
+	yMin: 0.7,
+} as const
+
+// SVG geometry (in viewBox units)
+const VB = { w: 820, h: 520 }
+const PAD = { top: 56, right: 48, bottom: 64, left: 76 }
+const PLOT = {
+	w: VB.w - PAD.left - PAD.right,
+	h: VB.h - PAD.top - PAD.bottom,
+}
+const SAMPLES_PER_SEGMENT = 80
+
+const SCORE_LABELS: Record<Score, string> = {
+	1: 'Again',
+	2: 'Hard',
+	3: 'Good',
+	4: 'Easy',
+}
+
+// ---------------------------------------------------------------------------
+// Simulation — drive the real FSRS functions through a sequence of reviews.
+// Each review fires exactly when retrievability decays to `desiredRetention`,
+// resetting recall to 100% and lengthening the next interval (rising stability).
+// ---------------------------------------------------------------------------
+
+interface Segment {
+	index: number
+	/** Day this review happened (curve = 100% here). */
+	startDay: number
+	/** Day the next review is scheduled (curve = desiredRetention here). */
+	endDay: number
+	stability: number
+	difficulty: number
+}
+
+function simulateReviews(
+	score: Score,
+	desiredRetention: number,
+	numReviews: number
+): Array<Segment> {
+	const BASE = new Date('2025-01-01T00:00:00Z')
+	const atDay = (d: number) => new Date(BASE.getTime() + d * 86_400_000)
+
+	const segments: Array<Segment> = []
+	let previousReview: CardReviewType | undefined = undefined
+	let day = 0
+
+	for (let i = 0; i < numReviews; i++) {
+		const { difficulty, stability } = calculateFSRS({
+			score,
+			previousReview,
+			currentTime: atDay(day),
+			desiredRetention,
+		})
+
+		// Exact (fractional) time until recall decays to the target retention.
+		const interval = calculateInterval(desiredRetention, stability)
+
+		segments.push({
+			index: i,
+			startDay: day,
+			endDay: day + interval,
+			stability,
+			difficulty,
+		})
+
+		// Minimal review record to feed the next iteration's calculateFSRS.
+		previousReview = {
+			id: crypto.randomUUID(),
+			created_at: atDay(day).toISOString(),
+			uid: '00000000-0000-0000-0000-000000000000',
+			day_session: atDay(day).toISOString().slice(0, 10),
+			lang: 'eng',
+			phrase_id: '00000000-0000-0000-0000-000000000000',
+			direction: 'forward',
+			score,
+			day_first_review: i === 0,
+			difficulty,
+			review_time_retrievability: i === 0 ? null : desiredRetention,
+			stability,
+			updated_at: null,
+		}
+
+		day += interval
+	}
+
+	return segments
+}
+
+// ---------------------------------------------------------------------------
+// Chart
+// ---------------------------------------------------------------------------
+
+function buildPath(points: Array<[number, number]>): string {
+	return points
+		.map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(2)},${y.toFixed(2)}`)
+		.join(' ')
+}
+
+function ForgettingCurveChart({
+	score,
+	desiredRetention,
+	numReviews,
+	yMin,
+}: {
+	score: Score
+	desiredRetention: number
+	numReviews: number
+	yMin: number
+}) {
+	const { segments, dayMax } = useMemo(() => {
+		const segs = simulateReviews(score, desiredRetention, numReviews)
+		const lastEnd = segs.at(-1)?.endDay ?? 1
+		// A little headroom so the final reset isn't flush against the edge.
+		return { segments: segs, dayMax: Math.ceil(lastEnd * 1.08) }
+	}, [score, desiredRetention, numReviews])
+
+	// Coordinate mappers
+	const toX = (day: number) => PAD.left + (day / dayMax) * PLOT.w
+	const toY = (r: number) => PAD.top + (1 - (r - yMin) / (1 - yMin)) * PLOT.h
+
+	// Y gridlines / ticks: every 10% from yMin to 100%.
+	const yTicks: Array<number> = []
+	for (let r = Math.ceil(yMin * 10) / 10; r <= 1.0001; r += 0.1) {
+		yTicks.push(Math.round(r * 100) / 100)
+	}
+
+	return (
+		<svg viewBox={`0 0 ${VB.w} ${VB.h}`} className="h-auto w-full">
+			<title>FSRS forgetting curve with reviews</title>
+			{/* Y gridlines + labels */}
+			{yTicks.map((r) => (
+				<g key={`y-${r}`}>
+					<line
+						x1={PAD.left}
+						x2={PAD.left + PLOT.w}
+						y1={toY(r)}
+						y2={toY(r)}
+						className="text-2-lo-neutral"
+						stroke="currentColor"
+						strokeWidth={1}
+					/>
+					<text
+						x={PAD.left - 12}
+						y={toY(r) + 4}
+						textAnchor="end"
+						className="fill-muted-foreground text-[13px]"
+					>
+						{Math.round(r * 100)}%
+					</text>
+				</g>
+			))}
+
+			{/* X axis ticks at each review day */}
+			{segments.map((s) => (
+				<g key={`x-${s.index}`}>
+					<line
+						x1={toX(s.endDay)}
+						x2={toX(s.endDay)}
+						y1={PAD.top}
+						y2={PAD.top + PLOT.h}
+						className="text-1-lo-neutral"
+						stroke="currentColor"
+						strokeWidth={1}
+					/>
+					<text
+						x={toX(s.endDay)}
+						y={PAD.top + PLOT.h + 22}
+						textAnchor="middle"
+						className="fill-muted-foreground text-[13px]"
+					>
+						{s.endDay.toFixed(1)}
+					</text>
+				</g>
+			))}
+
+			{/* Faint "if you never reviewed" decay tails from each review point */}
+			{segments.map((s) => {
+				const pts: Array<[number, number]> = []
+				for (let k = 0; k <= SAMPLES_PER_SEGMENT * 3; k++) {
+					const day = s.startDay + (k / SAMPLES_PER_SEGMENT) * s.stability * 4
+					if (day > dayMax) break
+					const r = retrievability(day - s.startDay, s.stability)
+					if (r < yMin) {
+						pts.push([toX(day), toY(yMin)])
+						break
+					}
+					pts.push([toX(day), toY(r)])
+				}
+				return (
+					<path
+						key={`tail-${s.index}`}
+						d={buildPath(pts)}
+						fill="none"
+						className="text-3-mlo-accent"
+						stroke="currentColor"
+						strokeWidth={1.5}
+					/>
+				)
+			})}
+
+			{/* Main retention curves: 100% decaying to desiredRetention, per review */}
+			{segments.map((s) => {
+				const pts: Array<[number, number]> = []
+				for (let k = 0; k <= SAMPLES_PER_SEGMENT; k++) {
+					const t = (k / SAMPLES_PER_SEGMENT) * (s.endDay - s.startDay)
+					const r = retrievability(t, s.stability)
+					pts.push([toX(s.startDay + t), toY(r)])
+				}
+				return (
+					<path
+						key={`curve-${s.index}`}
+						d={buildPath(pts)}
+						fill="none"
+						className="text-accent"
+						stroke="currentColor"
+						strokeWidth={4}
+						strokeLinecap="round"
+					/>
+				)
+			})}
+
+			{/* Dashed vertical "review" reset lines: target retention back up to 100% */}
+			{segments.slice(0, -1).map((s) => (
+				<line
+					key={`reset-${s.index}`}
+					x1={toX(s.endDay)}
+					x2={toX(s.endDay)}
+					y1={toY(desiredRetention)}
+					y2={toY(1)}
+					className="text-accent"
+					stroke="currentColor"
+					strokeWidth={2.5}
+					strokeDasharray="5 5"
+				/>
+			))}
+
+			{/* Review markers + arrows along the top */}
+			{segments.map((s) => {
+				const x = toX(s.startDay)
+				return (
+					<g key={`marker-${s.index}`}>
+						<line
+							x1={x}
+							x2={x}
+							y1={PAD.top - 26}
+							y2={PAD.top - 4}
+							className="text-accent"
+							stroke="currentColor"
+							strokeWidth={2}
+						/>
+						<path
+							d={`M${x - 4},${PAD.top - 9} L${x},${PAD.top - 2} L${x + 4},${PAD.top - 9} Z`}
+							className="fill-accent"
+						/>
+						<text
+							x={x}
+							y={PAD.top - 32}
+							textAnchor="middle"
+							className="fill-accent-foreground text-[12px] font-medium"
+						>
+							{s.index === 0 ? 'Learned' : `Review ${s.index}`}
+						</text>
+						{/* dot where this curve starts at 100% */}
+						<circle cx={x} cy={toY(1)} r={4} className="fill-accent" />
+					</g>
+				)
+			})}
+
+			{/* Axes */}
+			<line
+				x1={PAD.left}
+				x2={PAD.left}
+				y1={PAD.top - 4}
+				y2={PAD.top + PLOT.h}
+				className="text-foreground"
+				stroke="currentColor"
+				strokeWidth={2.5}
+			/>
+			<line
+				x1={PAD.left}
+				x2={PAD.left + PLOT.w}
+				y1={PAD.top + PLOT.h}
+				y2={PAD.top + PLOT.h}
+				className="text-foreground"
+				stroke="currentColor"
+				strokeWidth={2.5}
+			/>
+
+			{/* Axis titles */}
+			<text
+				x={PAD.left + PLOT.w / 2}
+				y={VB.h - 12}
+				textAnchor="middle"
+				className="fill-foreground text-[15px] font-semibold"
+			>
+				Days
+			</text>
+			<text
+				x={-(PAD.top + PLOT.h / 2)}
+				y={22}
+				textAnchor="middle"
+				transform="rotate(-90)"
+				className="fill-foreground text-[15px] font-semibold"
+			>
+				Retention
+			</text>
+		</svg>
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Controls
+// ---------------------------------------------------------------------------
+
+function RangeControl({
+	id,
+	label,
+	value,
+	min,
+	max,
+	step,
+	display,
+	onChange,
+}: {
+	id: string
+	label: string
+	value: number
+	min: number
+	max: number
+	step: number
+	display: string
+	onChange: (v: number) => void
+}) {
+	return (
+		<div className="space-y-1">
+			<div className="flex items-center justify-between">
+				<Label htmlFor={id}>{label}</Label>
+				<span className="text-muted-foreground text-sm tabular-nums">
+					{display}
+				</span>
+			</div>
+			<input
+				id={id}
+				type="range"
+				aria-label={label}
+				min={min}
+				max={max}
+				step={step}
+				value={value}
+				onChange={(e) => onChange(Number(e.target.value))}
+				className="accent-accent w-full"
+			/>
+		</div>
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+function FsrsPage() {
+	const [score, setScore] = useState<Score>(DEFAULTS.score)
+	const [desiredRetention, setDesiredRetention] = useState<number>(
+		DEFAULTS.desiredRetention
+	)
+	const [numReviews, setNumReviews] = useState<number>(DEFAULTS.numReviews)
+	const [yMin, setYMin] = useState<number>(DEFAULTS.yMin)
+
+	const segments = useMemo(
+		() => simulateReviews(score, desiredRetention, numReviews),
+		[score, desiredRetention, numReviews]
+	)
+
+	return (
+		<main className="@container mx-auto max-w-5xl space-y-6 p-4 pb-20">
+			<div className="space-y-1">
+				<h1 className="text-3xl font-bold">How FSRS Works</h1>
+				<p className="text-muted-foreground text-sm">
+					The forgetting curve, drawn from the real FSRS v5 functions in{' '}
+					<code className="text-xs">src/features/review/fsrs.ts</code>. Each
+					time recall decays to your target retention the card comes back
+					around; a correct answer resets recall to 100% and stretches the next
+					interval.
+				</p>
+			</div>
+
+			<Card>
+				<CardContent className="pt-6">
+					<ForgettingCurveChart
+						score={score}
+						desiredRetention={desiredRetention}
+						numReviews={numReviews}
+						yMin={yMin}
+					/>
+				</CardContent>
+			</Card>
+
+			<div className="grid gap-6 @lg:grid-cols-2">
+				<Card>
+					<CardHeader>
+						<CardTitle className="text-lg">Tweak it</CardTitle>
+						<CardDescription>
+							Adjust the simulation. Defaults live in the{' '}
+							<code className="text-xs">DEFAULTS</code> object at the top of the
+							route file.
+						</CardDescription>
+					</CardHeader>
+					<CardContent className="space-y-5">
+						<div className="space-y-1">
+							<Label>Review score</Label>
+							<div className="flex gap-2">
+								{([1, 2, 3, 4] as Array<Score>).map((s) => (
+									<button
+										key={s}
+										type="button"
+										onClick={() => setScore(s)}
+										className={
+											'flex-1 rounded-2xl border px-2 py-1.5 text-sm transition-colors ' +
+											(score === s
+												? 'border-accent bg-2-mlo-accent text-accent-foreground font-medium'
+												: 'border-border text-muted-foreground hover:bg-1-lo-accent')
+										}
+									>
+										{SCORE_LABELS[s]}
+									</button>
+								))}
+							</div>
+						</div>
+
+						<RangeControl
+							id="retention"
+							label="Target retention (review trigger)"
+							value={desiredRetention}
+							min={0.75}
+							max={0.97}
+							step={0.01}
+							display={`${Math.round(desiredRetention * 100)}%`}
+							onChange={setDesiredRetention}
+						/>
+
+						<RangeControl
+							id="num-reviews"
+							label="Number of reviews"
+							value={numReviews}
+							min={2}
+							max={8}
+							step={1}
+							display={String(numReviews)}
+							onChange={(v) => setNumReviews(Math.round(v))}
+						/>
+
+						<RangeControl
+							id="y-min"
+							label="Y-axis floor"
+							value={yMin}
+							min={0.5}
+							max={Math.min(0.85, desiredRetention - 0.05)}
+							step={0.05}
+							display={`${Math.round(yMin * 100)}%`}
+							onChange={(v) => setYMin(Math.round(v * 20) / 20)}
+						/>
+					</CardContent>
+				</Card>
+
+				<Card>
+					<CardHeader>
+						<CardTitle className="text-lg">Schedule</CardTitle>
+						<CardDescription>
+							Stability is the interval (in days) at which recall hits the
+							target retention. Notice it grows with every successful review.
+						</CardDescription>
+					</CardHeader>
+					<CardContent>
+						<table className="w-full text-sm">
+							<thead>
+								<tr className="text-muted-foreground border-b text-left text-xs">
+									<th className="py-1.5">#</th>
+									<th className="py-1.5">Day</th>
+									<th className="py-1.5">Interval</th>
+									<th className="py-1.5">Stability</th>
+									<th className="py-1.5">Difficulty</th>
+								</tr>
+							</thead>
+							<tbody>
+								{segments.map((s) => (
+									<tr key={s.index} className="border-b last:border-0">
+										<td className="py-1.5 font-medium">
+											{s.index === 0 ? 'Learn' : s.index}
+										</td>
+										<td className="py-1.5 tabular-nums">
+											{s.startDay.toFixed(1)}
+										</td>
+										<td className="py-1.5 tabular-nums">
+											{(s.endDay - s.startDay).toFixed(1)}d
+										</td>
+										<td className="py-1.5 tabular-nums">
+											{s.stability.toFixed(2)}
+										</td>
+										<td className="py-1.5 tabular-nums">
+											{s.difficulty.toFixed(2)}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</CardContent>
+				</Card>
+			</div>
+		</main>
+	)
+}

--- a/src/routes/fsrs.lazy.tsx
+++ b/src/routes/fsrs.lazy.tsx
@@ -48,7 +48,9 @@ const PRESETS: Array<{ label: string; scores: Array<Score> }> = [
 	{ label: 'Quick learner', scores: [4, 4, 4, 4] },
 ]
 
-// Per-score presentation. Full literal class strings so Tailwind picks them up.
+// Per-score presentation, matching the review buttons' raw palette colors
+// (see review-single-card.tsx): Again=red, Hard=gray, Good=blue, Easy=green.
+// Full literal class strings so Tailwind picks them up.
 const SCORE_META: Record<
 	Score,
 	{ label: string; glyph: string; text: string; activeBtn: string }
@@ -56,26 +58,26 @@ const SCORE_META: Record<
 	1: {
 		label: 'Again',
 		glyph: '✕',
-		text: 'text-5-hi-danger',
-		activeBtn: 'bg-2-mlo-danger border-4-mid-danger text-5-hi-danger',
+		text: 'text-red-600',
+		activeBtn: 'bg-red-600 border-red-600 text-white',
 	},
 	2: {
 		label: 'Hard',
 		glyph: '○',
-		text: 'text-6-hi-warning',
-		activeBtn: 'bg-2-mlo-warning border-4-mid-warning text-6-hi-warning',
+		text: 'text-gray-400',
+		activeBtn: 'bg-gray-200 border-gray-300 text-gray-700',
 	},
 	3: {
 		label: 'Good',
 		glyph: '●',
-		text: 'text-6-hi-accent',
-		activeBtn: 'bg-2-mlo-accent border-4-mid-accent text-6-hi-accent',
+		text: 'text-blue-500',
+		activeBtn: 'bg-blue-500 border-blue-500 text-white',
 	},
 	4: {
 		label: 'Easy',
 		glyph: '◆',
-		text: 'text-5-hi-success',
-		activeBtn: 'bg-2-mlo-success border-4-mid-success text-5-hi-success',
+		text: 'text-green-500',
+		activeBtn: 'bg-green-500 border-green-500 text-white',
 	},
 }
 
@@ -230,6 +232,20 @@ function ForgettingCurveChart({
 		yTicks.push(Math.round(r * 100) / 100)
 	}
 
+	// When early reviews cluster (e.g. after a lapse), their top labels would
+	// overlap. Draw a grade label only when there's horizontal room since the
+	// last one; the colored arrow + glyph still mark every review.
+	const MIN_LABEL_GAP = 48
+	const labeledIndices = new Set<number>()
+	let lastLabelX = -Infinity
+	for (const s of segments) {
+		const x = toX(s.startDay)
+		if (x - lastLabelX >= MIN_LABEL_GAP) {
+			labeledIndices.add(s.index)
+			lastLabelX = x
+		}
+	}
+
 	return (
 		<svg viewBox={`0 0 ${VB.w} ${VB.h}`} className="h-auto w-full">
 			<title>FSRS forgetting curve for a sequence of reviews</title>
@@ -359,15 +375,17 @@ function ForgettingCurveChart({
 							d={`M${x - 4},${PAD.top - 11} L${x},${PAD.top - 4} L${x + 4},${PAD.top - 11} Z`}
 							fill="currentColor"
 						/>
-						<text
-							x={x}
-							y={PAD.top - 32}
-							textAnchor="middle"
-							className="text-[12px] font-medium"
-							fill="currentColor"
-						>
-							{s.index === 0 ? `Learn · ${meta.label}` : meta.label}
-						</text>
+						{labeledIndices.has(s.index) && (
+							<text
+								x={x}
+								y={PAD.top - 32}
+								textAnchor="middle"
+								className="text-[12px] font-medium"
+								fill="currentColor"
+							>
+								{s.index === 0 ? `Learn` : meta.label}
+							</text>
+						)}
 						<ScoreGlyph score={s.score} x={x} y={toY(1)} />
 					</g>
 				)
@@ -523,9 +541,9 @@ function FsrsPage() {
 					<code className="text-xs">src/features/review/fsrs.ts</code>. Each
 					time recall decays to your target retention the card comes back around
 					— and how you grade it reshapes what comes next. A lapse{' '}
-					<span className="text-5-hi-danger">(Again ✕)</span> still resets
-					recall when you re-study, but stability collapses, so the next curve
-					is short and steep.
+					<span className="text-red-600">(Again ✕)</span> still resets recall
+					when you re-study, but stability collapses, so the next curve is short
+					and steep.
 				</p>
 			</div>
 


### PR DESCRIPTION
## Summary

Adds a new `/fsrs` route with an interactive visualization of the FSRS v5 spaced repetition algorithm. The page demonstrates how the forgetting curve works by simulating a sequence of card reviews and rendering the decay of retention over time.

## Changes

- **New route**: `src/routes/fsrs.lazy.tsx` — Interactive FSRS visualization page with:
  - **Forgetting curve chart** — SVG visualization showing retention decay across multiple review cycles, with gridlines, axis labels, and review markers
  - **Review simulation** — Drives the real FSRS functions (`calculateFSRS`, `calculateInterval`, `retrievability`) through a sequence of reviews, each triggered when retention decays to the target threshold
  - **Interactive controls** — Adjustable parameters:
    - Review score (Again/Hard/Good/Easy buttons)
    - Target retention percentage (75–97%)
    - Number of reviews (2–8)
    - Y-axis floor (for chart zoom)
  - **Schedule table** — Displays computed stability, difficulty, and interval for each review in the simulation

- **Route registration**: Updated `src/routeTree.gen.ts` to register the new `/fsrs` lazy route

## Implementation Details

- The simulation uses the actual FSRS v5 functions from `src/features/review/fsrs.ts`, ensuring the visualization reflects the real scheduler behavior
- Each review is triggered exactly when retrievability decays to `desiredRetention`, resetting recall to 100% and increasing stability for the next interval
- The chart renders both the main retention curves (100% → target retention per review) and faint decay tails showing what would happen if reviews were skipped
- Coordinate mapping handles day-to-pixel and retention-to-pixel transformations with configurable Y-axis floor for zoom control
- All state is local to the page; no database queries or mutations

https://claude.ai/code/session_01TiMERXkVBT8gh5SpU5HJMM