### PR TITLE
Extract phrase tags + drop phrase-creation RPCs for direct collection actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v0.28 - LanguagePicker, Sharing Redesign, Translations Split
+## v0.28 - LanguagePicker, Sharing Redesign, Translations & Tags Split
 
 _5 June, 2026_
 
@@ -17,7 +17,8 @@ _5 June, 2026_
 
 ### Refactors
 
-- **Translations split off the phrase row.** New `phraseTranslationsCollection` reads `phrase_translation` directly; live queries compose translations back onto each phrase via TanStack DB's `toArray()` aggregator, so `phrase.translations` is still an array everywhere it's read. Adding or editing one translation now writes a single row to its own collection instead of splicing the denormalized array on the phrase. First step in dismantling `phrase_meta`; tags and stats can follow on their own schedule.
+- **Translations split off the phrase row.** New `phraseTranslationsCollection` reads `phrase_translation` directly; live queries compose translations back onto each phrase via TanStack DB's `toArray()` aggregator, so `phrase.translations` is still an array everywhere it's read. Adding or editing one translation now writes a single row to its own collection instead of splicing the denormalized array on the phrase.
+- **Phrase tags split off the phrase row** in the same shape: new `phraseTagLinksCollection` reads the `phrase_tag` join table, and the live queries compose `tags` onto each phrase via `toArray()` + an inner join to `langTagsCollection`. Adding or removing a tag writes a single link row to its own collection instead of splicing the denormalized JSON array on the phrase. The `phrase_meta` view's tag aggregation CTE is now unused by the client — only `phrase_stats` remains on the row.
 - **`UserAvatar`** extracted as a general component.
 - Drop the full-table refetch on new request creation; preload `messagesCollection` before the write.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.28 - LanguagePicker, Sharing Redesign, Translations & Tags Split
 
-_5 June, 2026_
+_6 June, 2026_
 
 ### Features
 
@@ -17,10 +17,15 @@ _5 June, 2026_
 
 ### Refactors
 
-- **Translations split off the phrase row.** New `phraseTranslationsCollection` reads `phrase_translation` directly; live queries compose translations back onto each phrase via TanStack DB's `toArray()` aggregator, so `phrase.translations` is still an array everywhere it's read. Adding or editing one translation now writes a single row to its own collection instead of splicing the denormalized array on the phrase.
-- **Phrase tags split off the phrase row** in the same shape: new `phraseTagLinksCollection` reads the `phrase_tag` join table, and the live queries compose `tags` onto each phrase via `toArray()` + an inner join to `langTagsCollection`. Adding or removing a tag writes a single link row to its own collection instead of splicing the denormalized JSON array on the phrase. The `phrase_meta` view's tag aggregation CTE is now unused by the client — only `phrase_stats` remains on the row.
+- **Translations split off the phrase row.** New `phraseTranslationsCollection` reads `phrase_translation` directly; live queries compose translations back onto each phrase via TanStack DB's `toArray()` aggregator, so `phrase.translations` is still an array everywhere it's read.
+- **Phrase tags split off the phrase row** in the same shape: new `phraseTagLinksCollection` reads the `phrase_tag` join table, and the live queries compose `tags` onto each phrase via `toArray()` + an inner join to `langTagsCollection`. After this, `phrase_meta` is just a slim phrase projection plus `phrase_stats` columns — both of those will get the same treatment in v0.29.
+- **Direct collection actions replace the phrase-creation RPCs.** Adding a phrase + translation (with or without cards), bulk-adding many phrases, adding tags, removing tags, editing or archiving a translation, and editing phrase text now all go through `collection.insert / update / delete` (with `onInsert / onUpdate / onDelete` handlers on the collection itself) or `createOptimisticAction` for multi-collection flows. No more `useMutation` + manual `writeInsert` in `onSuccess`, no more misleading "Failed to X" toasts when a post-success local sync throws. UX feedback (toasts) hangs off `tx.isPersisted.promise`, so an optimistic write that rolls back surfaces a real error instead of a spurious success.
 - **`UserAvatar`** extracted as a general component.
 - Drop the full-table refetch on new request creation; preload `messagesCollection` before the write.
+
+### Migrations
+
+- `20260606120000_drop_phrase_creation_rpcs.sql` — drops `add_phrase_translation_card`, `add_tags_to_phrase`, and `bulk_add_phrases`, plus the two composite types (`phrase_with_translations_input`, `translation_input`) that only existed to shape input to the bulk RPC. Everything they did is now driven from the client through TanStack DB collections.
 
 ### Build / Dependencies
 

--- a/src/components/card-pieces/add-tags.tsx
+++ b/src/components/card-pieces/add-tags.tsx
@@ -79,6 +79,26 @@ const addTagsAction = createOptimisticAction<AddTagsAction>({
 		if (linkRows.length) {
 			await supabase.from('phrase_tag').insert(linkRows).throwOnError()
 		}
+		// Sync the confirmed rows so they survive the action's optimistic-state
+		// drop at the end of mutationFn.
+		const now = new Date().toISOString()
+		for (const t of tags) {
+			if (t.isNew) {
+				langTagsCollection.utils.writeInsert({
+					id: t.tagId,
+					name: t.name,
+					lang,
+					added_by: uid,
+					created_at: now,
+				})
+			}
+			phraseTagLinksCollection.utils.writeInsert({
+				phrase_id: phraseId,
+				tag_id: t.tagId,
+				added_by: uid,
+				created_at: now,
+			})
+		}
 	},
 })
 

--- a/src/components/card-pieces/add-tags.tsx
+++ b/src/components/card-pieces/add-tags.tsx
@@ -20,9 +20,12 @@ import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import { MultiSelectCreatable } from '@/components/fields/multi-select-creatable'
 import { langTagsCollection } from '@/features/languages/collections'
-import { phrasesCollection } from '@/features/phrases/collections'
-import { LangTagSchema, LangTagType } from '@/features/languages/schemas'
-import { PhraseFullFilteredType } from '@/features/phrases/schemas'
+import { phraseTagLinksCollection } from '@/features/phrases/collections'
+import { LangTagSchema } from '@/features/languages/schemas'
+import {
+	PhraseFullFilteredType,
+	PhraseTagLinkSchema,
+} from '@/features/phrases/schemas'
 import { Tables } from '@/types/supabase'
 import { useAppForm } from '@/components/form'
 import { ErrorList } from '@/components/form/fields/error-list'
@@ -68,15 +71,10 @@ export function AddTags({
 				})
 			}
 			if (data?.phrase_tags.length) {
-				const langTags = data.phrase_tags
-					.map((t) => langTagsCollection.get(t.tag_id))
-					.filter(Boolean) as LangTagType[]
-				phrasesCollection.utils.writeUpdate({
-					id: phrase.id,
-					tags: [
-						...(phrase.tags ?? []),
-						...(langTags.map((t) => ({ id: t.id, name: t.name })) ?? []),
-					],
+				data.phrase_tags.forEach((link) => {
+					phraseTagLinksCollection.utils.writeInsert(
+						PhraseTagLinkSchema.parse(link)
+					)
 				})
 			}
 			setOpen(false)
@@ -139,7 +137,6 @@ export function AddTags({
 											key={tag.id}
 											tag={tag}
 											phraseId={phrase.id}
-											phraseTags={phrase.tags ?? []}
 										/>
 									) : (
 										<Badge key={tag.id} variant="secondary">
@@ -206,11 +203,9 @@ export function AddTags({
 function RemovableTagBadge({
 	tag,
 	phraseId,
-	phraseTags,
 }: {
 	tag: { id: string; name: string }
 	phraseId: string
-	phraseTags: Array<{ id: string; name: string }>
 }) {
 	const removeTag = useMutation({
 		mutationFn: async () => {
@@ -222,10 +217,7 @@ function RemovableTagBadge({
 				.throwOnError()
 		},
 		onSuccess: () => {
-			phrasesCollection.utils.writeUpdate({
-				id: phraseId,
-				tags: phraseTags.filter((t) => t.id !== tag.id),
-			})
+			phraseTagLinksCollection.utils.writeDelete(`${phraseId}--${tag.id}`)
 			toastSuccess(`Tag "${tag.name}" removed`)
 		},
 		onError: (error) => {

--- a/src/components/card-pieces/add-tags.tsx
+++ b/src/components/card-pieces/add-tags.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
 import * as z from 'zod'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
 import supabase from '@/lib/supabase-client'
 import { Tags, X } from 'lucide-react'
+import { createOptimisticAction } from '@tanstack/db'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -21,12 +21,8 @@ import { Separator } from '@/components/ui/separator'
 import { MultiSelectCreatable } from '@/components/fields/multi-select-creatable'
 import { langTagsCollection } from '@/features/languages/collections'
 import { phraseTagLinksCollection } from '@/features/phrases/collections'
-import { LangTagSchema } from '@/features/languages/schemas'
-import {
-	PhraseFullFilteredType,
-	PhraseTagLinkSchema,
-} from '@/features/phrases/schemas'
-import { Tables } from '@/types/supabase'
+import { PhraseFullFilteredType } from '@/features/phrases/schemas'
+import { useUserId } from '@/lib/use-auth'
 import { useAppForm } from '@/components/form'
 import { ErrorList } from '@/components/form/fields/error-list'
 
@@ -35,10 +31,56 @@ const addTagsSchema = z.object({
 })
 
 type AddTagsFormValues = z.infer<typeof addTagsSchema>
-type AddTagsReturnValues = {
-	tags: Tables<'tag'>[]
-	phrase_tags: Tables<'phrase_tag'>[]
+
+// Pre-resolved tag inputs: the caller decides which names map to existing
+// tag IDs and which need a fresh uuid, so both optimistic and persistent
+// stages use the same IDs.
+type AddTagsAction = {
+	phraseId: string
+	lang: string
+	uid: string
+	tags: Array<{ tagId: string; name: string; isNew: boolean }>
 }
+
+const addTagsAction = createOptimisticAction<AddTagsAction>({
+	onMutate: ({ phraseId, lang, uid, tags }) => {
+		const now = new Date().toISOString()
+		for (const t of tags) {
+			if (t.isNew) {
+				langTagsCollection.insert({
+					id: t.tagId,
+					name: t.name,
+					lang,
+					added_by: uid,
+					created_at: now,
+				})
+			}
+			phraseTagLinksCollection.insert({
+				phrase_id: phraseId,
+				tag_id: t.tagId,
+				added_by: uid,
+				created_at: now,
+			})
+		}
+	},
+	mutationFn: async ({ phraseId, lang, uid, tags }) => {
+		// New tags first — phrase_tag links FK into tag.id.
+		const newRows = tags
+			.filter((t) => t.isNew)
+			.map((t) => ({ id: t.tagId, name: t.name, lang, added_by: uid }))
+		if (newRows.length) {
+			await supabase.from('tag').insert(newRows).throwOnError()
+		}
+		const linkRows = tags.map((t) => ({
+			phrase_id: phraseId,
+			tag_id: t.tagId,
+			added_by: uid,
+		}))
+		if (linkRows.length) {
+			await supabase.from('phrase_tag').insert(linkRows).throwOnError()
+		}
+	},
+})
 
 export function AddTags({
 	phrase,
@@ -47,51 +89,42 @@ export function AddTags({
 	phrase: PhraseFullFilteredType
 	allowRemove?: boolean
 }) {
+	const userId = useUserId()
 	const [open, setOpen] = useState(false)
 	const { data: allLangTags } = useLanguageTags(phrase?.lang)
 
-	const addTagsMutation = useMutation({
-		mutationFn: async (values: AddTagsFormValues) => {
-			console.log(`Running addTagsMutation fn`, { values, allLangTags })
-			if (values.tags.length === 0) return
-
-			const { data, error } = await supabase.rpc('add_tags_to_phrase', {
-				p_phrase_id: phrase.id,
-				p_lang: phrase.lang,
-				p_tags: values.tags,
-			})
-
-			if (error) throw error
-			return data as AddTagsReturnValues
-		},
-		onSuccess: (data) => {
-			if (data?.tags.length) {
-				data?.tags.map((t) => {
-					langTagsCollection.utils.writeInsert(LangTagSchema.parse(t))
-				})
+	const handleSubmit = (values: AddTagsFormValues) => {
+		if (!userId || values.tags.length === 0) return
+		const resolved: AddTagsAction['tags'] = values.tags.map((name) => {
+			const existing = (allLangTags ?? []).find((t) => t.name === name)
+			return {
+				tagId: existing?.id ?? crypto.randomUUID(),
+				name,
+				isNew: !existing,
 			}
-			if (data?.phrase_tags.length) {
-				data.phrase_tags.forEach((link) => {
-					phraseTagLinksCollection.utils.writeInsert(
-						PhraseTagLinkSchema.parse(link)
-					)
-				})
+		})
+		const tx = addTagsAction({
+			phraseId: phrase.id,
+			lang: phrase.lang,
+			uid: userId,
+			tags: resolved,
+		})
+		setOpen(false)
+		form.reset()
+		tx.isPersisted.promise.then(
+			() => toastSuccess('Tags added!'),
+			(err: Error) => {
+				toastError(`Failed to add tags: ${err.message}`)
+				console.log(`Rolled back add-tags`, err)
 			}
-			setOpen(false)
-			form.reset()
-			toastSuccess('Tags added!')
-		},
-		onError: (error) => {
-			console.log(`Failed to add tags: ${error.message}`, error)
-			toastError(`Failed to add tags: ${error.message}`)
-		},
-	})
+		)
+	}
 
 	const form = useAppForm({
 		defaultValues: { tags: [] } as AddTagsFormValues,
 		validators: { onChange: addTagsSchema },
-		onSubmit: async ({ value }) => {
-			await addTagsMutation.mutateAsync(value)
+		onSubmit: ({ value }) => {
+			handleSubmit(value)
 		},
 	})
 
@@ -207,31 +240,22 @@ function RemovableTagBadge({
 	tag: { id: string; name: string }
 	phraseId: string
 }) {
-	const removeTag = useMutation({
-		mutationFn: async () => {
-			await supabase
-				.from('phrase_tag')
-				.delete()
-				.eq('phrase_id', phraseId)
-				.eq('tag_id', tag.id)
-				.throwOnError()
-		},
-		onSuccess: () => {
-			phraseTagLinksCollection.utils.writeDelete(`${phraseId}--${tag.id}`)
-			toastSuccess(`Tag "${tag.name}" removed`)
-		},
-		onError: (error) => {
-			toastError('Failed to remove tag')
-			console.error(error)
-		},
-	})
+	const removeTag = () => {
+		const tx = phraseTagLinksCollection.delete(`${phraseId}--${tag.id}`)
+		tx.isPersisted.promise.then(
+			() => toastSuccess(`Tag "${tag.name}" removed`),
+			(err: Error) => {
+				toastError('Failed to remove tag')
+				console.log(`Rolled back tag removal`, err)
+			}
+		)
+	}
 
 	return (
 		<Badge variant="secondary" className="gap-1">
 			{tag.name}
 			<button
-				onClick={() => removeTag.mutate()}
-				disabled={removeTag.isPending}
+				onClick={removeTag}
 				className="hover:text-destructive -me-1 rounded-full p-0.5"
 			>
 				<X className="size-3" />

--- a/src/components/card-pieces/add-translations.tsx
+++ b/src/components/card-pieces/add-translations.tsx
@@ -1,15 +1,12 @@
 import { useMemo, useRef, useState } from 'react'
 import * as z from 'zod'
-import { useMutation } from '@tanstack/react-query'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
 import { Pencil, Check, X, Archive, Undo2 } from 'lucide-react'
 
 import {
-	TranslationSchema,
 	type PhraseFullType,
 	type TranslationType,
 } from '@/features/phrases/schemas'
-import supabase from '@/lib/supabase-client'
 import {
 	Dialog,
 	DialogTrigger,
@@ -48,44 +45,36 @@ export function AddTranslationsDialog({
 }: ButtonProps & {
 	phrase: PhraseFullType
 }) {
+	const userId = useUserId()
 	const preferredTranslationLang = usePreferredTranslationLang(phrase.lang)
 	const closeRef = useRef<HTMLButtonElement | null>(null)
 	const close = () => closeRef.current?.click()
 
-	const addTranslation = useMutation({
-		mutationKey: ['add-translation', phrase.id, phrase.lang],
-		mutationFn: async ({
-			translation_lang,
-			translation_text,
-		}: AddTranslationsType) => {
-			console.log(`Adding translation`, {
-				translation_lang,
-				translation_text,
-			})
-			const { data } = await supabase
-				.from('phrase_translation')
-				.insert({
-					lang: translation_lang,
-					text: translation_text,
-					phrase_id: phrase.id,
-				})
-				.throwOnError()
-				.select()
-			if (!data) throw new Error('Failed to add translation')
-			return data[0]
-		},
-		onSuccess: (data) => {
-			phraseTranslationsCollection.utils.writeInsert(
-				TranslationSchema.parse(data)
-			)
-			close()
-			form.reset()
-			toastSuccess(`Translation added for ${phrase.text}`)
-		},
-		onError: (error) => {
-			toastError(error.message)
-		},
-	})
+	const addTranslation = ({
+		translation_lang,
+		translation_text,
+	}: AddTranslationsType) => {
+		const now = new Date().toISOString()
+		const tx = phraseTranslationsCollection.insert({
+			id: crypto.randomUUID(),
+			phrase_id: phrase.id,
+			lang: translation_lang,
+			text: translation_text,
+			added_by: userId,
+			archived: false,
+			created_at: now,
+			updated_at: now,
+		})
+		close()
+		form.reset()
+		tx.isPersisted.promise.then(
+			() => toastSuccess(`Translation added for ${phrase.text}`),
+			(err: Error) => {
+				toastError(err.message)
+				console.log(`Rolled back add-translation`, err)
+			}
+		)
+	}
 
 	const schema = useMemo(
 		() => createAddTranslationsSchema(phrase.lang),
@@ -97,16 +86,10 @@ export function AddTranslationsDialog({
 			translation_lang: preferredTranslationLang,
 		},
 		validators: { onChange: schema },
-		onSubmit: async ({ value }) => {
-			await addTranslation.mutateAsync(value)
+		onSubmit: ({ value }) => {
+			addTranslation(value)
 		},
 	})
-
-	if (addTranslation.error)
-		console.log(
-			`Uncaught somewhere in the translation mutation`,
-			addTranslation.error
-		)
 
 	return (
 		<Dialog>
@@ -185,61 +168,37 @@ function TranslationListItem({ trans }: { trans: TranslationType }) {
 	const [isEditing, setIsEditing] = useState(false)
 	const [editText, setEditText] = useState(trans.text)
 
-	const updateTranslation = useMutation({
-		mutationKey: ['update-translation', trans.id],
-		mutationFn: async (newText: string) => {
-			const { data } = await supabase
-				.from('phrase_translation')
-				.update({ text: newText })
-				.eq('id', trans.id)
-				.throwOnError()
-				.select()
-			if (!data) throw new Error('Failed to update translation')
-			return data[0]
-		},
-		onSuccess: (data) => {
-			phraseTranslationsCollection.utils.writeUpdate(
-				TranslationSchema.parse(data)
-			)
-			setIsEditing(false)
-			toastSuccess('Translation updated')
-		},
-		onError: (error) => {
-			toastError(error.message)
-		},
-	})
-
-	const toggleArchiveTranslation = useMutation({
-		mutationKey: [
-			'archive-translation',
-			trans.id,
-			trans.archived ? 'unarchive' : 'archive',
-		],
-		mutationFn: async () => {
-			await supabase
-				.from('phrase_translation')
-				.update({ archived: !trans.archived })
-				.eq('id', trans.id)
-				.throwOnError()
-		},
-		onSuccess: () => {
-			phraseTranslationsCollection.utils.writeUpdate({
-				...trans,
-				archived: !trans.archived,
-			})
-			toastSuccess(`Translation ${trans.archived ? 'un' : ''}archived`)
-		},
-		onError: (error) => {
-			toastError(error.message)
-		},
-	})
-
 	const handleSave = () => {
-		if (editText.trim() && editText !== trans.text) {
-			updateTranslation.mutate(editText.trim())
-		} else {
+		const trimmed = editText.trim()
+		if (!trimmed || trimmed === trans.text) {
 			setIsEditing(false)
+			return
 		}
+		const tx = phraseTranslationsCollection.update(trans.id, (draft) => {
+			draft.text = trimmed
+		})
+		setIsEditing(false)
+		tx.isPersisted.promise.then(
+			() => toastSuccess('Translation updated'),
+			(err: Error) => {
+				toastError(err.message)
+				console.log(`Rolled back translation update`, err)
+			}
+		)
+	}
+
+	const toggleArchive = () => {
+		const wasArchived = trans.archived
+		const tx = phraseTranslationsCollection.update(trans.id, (draft) => {
+			draft.archived = !wasArchived
+		})
+		tx.isPersisted.promise.then(
+			() => toastSuccess(`Translation ${wasArchived ? 'un' : ''}archived`),
+			(err: Error) => {
+				toastError(err.message)
+				console.log(`Rolled back translation archive toggle`, err)
+			}
+		)
 	}
 
 	const handleCancel = () => {
@@ -264,7 +223,6 @@ function TranslationListItem({ trans }: { trans: TranslationType }) {
 						variant="ghost"
 						className="size-6"
 						onClick={handleSave}
-						disabled={updateTranslation.isPending}
 					>
 						<Check className="size-3" />
 					</Button>
@@ -300,8 +258,7 @@ function TranslationListItem({ trans }: { trans: TranslationType }) {
 								size="icon"
 								variant="ghost"
 								className="size-6"
-								onClick={() => toggleArchiveTranslation.mutate()}
-								disabled={toggleArchiveTranslation.isPending}
+								onClick={toggleArchive}
 							>
 								{trans.archived ? (
 									<Undo2 className="size-3" />

--- a/src/components/phrases/inline-phrase-creator.tsx
+++ b/src/components/phrases/inline-phrase-creator.tsx
@@ -1,19 +1,13 @@
 import { useMemo, useRef, useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
 import * as z from 'zod'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
 import { ChevronUp } from 'lucide-react'
 
-import type { Tables } from '@/types/supabase'
-import type { RPCFunctions } from '@/types/main'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
-import supabase from '@/lib/supabase-client'
 import languages from '@/lib/languages'
 import TranslationLanguageField from '@/components/fields/translation-language-field'
-import { PhraseSchema, TranslationSchema } from '@/features/phrases/schemas'
-import { CardMetaSchema } from '@/features/deck/schemas'
 import {
 	phrasesCollection,
 	phraseTranslationsCollection,
@@ -21,7 +15,12 @@ import {
 import { cardsCollection } from '@/features/deck/collections'
 import { useInvalidateFeed } from '@/features/feed/hooks'
 import { usePreferredTranslationLang, useDecks } from '@/features/deck/hooks'
+import { useUserId } from '@/lib/use-auth'
 import { useAppForm } from '@/components/form'
+import {
+	buildCardSet,
+	createPhraseWithTranslation,
+} from '@/features/phrases/mutations'
 
 const createInlinePhraseSchema = (phraseLang: string) =>
 	z.object({
@@ -114,69 +113,52 @@ function InlinePhraseForm({
 	onAddAnother: (translationLang: string) => void
 	animate: boolean
 }) {
+	const userId = useUserId()
 	const { data: decks } = useDecks()
 	const hasDeck = decks?.some((d) => d.lang === lang) ?? false
 	const invalidateFeed = useInvalidateFeed()
 
-	const mutation = useMutation({
-		mutationFn: async (values: InlinePhraseFormValues) => {
-			const args: RPCFunctions['add_phrase_translation_card']['Args'] = {
-				phrase_lang: lang,
-				phrase_text: values.phrase_text,
-				translation_text: values.translation_text,
-				translation_lang: values.translation_lang,
-				phrase_only_reverse: values.only_reverse,
-				create_card: hasDeck,
-			}
-			const { data } = await supabase
-				.rpc('add_phrase_translation_card', args)
-				.throwOnError()
+	const submitPhrase = async (values: InlinePhraseFormValues) => {
+		if (!userId) {
+			toastError('You must be logged in to create a phrase')
+			return
+		}
+		// Sync must be active before optimistic inserts so the new rows can be
+		// observed by live queries. preload() is idempotent.
+		await Promise.all([
+			phrasesCollection.preload(),
+			phraseTranslationsCollection.preload(),
+			cardsCollection.preload(),
+		])
 
-			return data as {
-				phrase: Tables<'phrase'>
-				translation: Tables<'phrase_translation'>
-				card: Tables<'user_card'> | null
-				card_reverse: Tables<'user_card'> | null
-			}
-		},
-		onSuccess: async (data) => {
-			if (!data) throw new Error('No data returned')
-
-			// writeInsert/writeUpdate need an active manual-sync context.
-			// preload() is idempotent: returns instantly if sync is up, or
-			// re-spins it up if it was cleaned up after gcTime expired.
-			await Promise.all([
-				phrasesCollection.preload(),
-				phraseTranslationsCollection.preload(),
-				cardsCollection.preload(),
-			])
-
-			phrasesCollection.utils.writeInsert(PhraseSchema.parse(data.phrase))
-			phraseTranslationsCollection.utils.writeInsert(
-				TranslationSchema.parse(data.translation)
-			)
-			if (data.card) {
-				cardsCollection.utils.writeInsert(CardMetaSchema.parse(data.card))
-				if (data.card_reverse) {
-					cardsCollection.utils.writeInsert(
-						CardMetaSchema.parse(data.card_reverse)
-					)
-				}
-				phrasesCollection.utils.writeUpdate({
-					id: data.card.phrase_id,
-					count_learners: 1,
-				})
-			}
+		const phraseId = crypto.randomUUID()
+		const translationId = crypto.randomUUID()
+		const cards = hasDeck ? buildCardSet(values.only_reverse) : []
+		const tx = createPhraseWithTranslation({
+			phraseId,
+			translationId,
+			lang,
+			text: values.phrase_text,
+			onlyReverse: values.only_reverse,
+			translationLang: values.translation_lang,
+			translationText: values.translation_text,
+			uid: userId,
+			cards,
+		})
+		try {
+			await tx.isPersisted.promise
 			invalidateFeed(lang)
 			toastSuccess(
-				data.card ? 'Phrase created and added to your deck' : 'Phrase created'
+				cards.length
+					? 'Phrase created and added to your deck'
+					: 'Phrase created'
 			)
-			onPhraseCreated(data.phrase.id)
-		},
-		onError: (error) => {
-			toastError(`Failed to create phrase: ${error.message}`)
-		},
-	})
+			onPhraseCreated(phraseId)
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err)
+			toastError(`Failed to create phrase: ${message}`)
+		}
+	}
 
 	const schema = useMemo(() => createInlinePhraseSchema(lang), [lang])
 	const form = useAppForm({
@@ -188,7 +170,7 @@ function InlinePhraseForm({
 		},
 		validators: { onChange: schema },
 		onSubmit: async ({ value }) => {
-			await mutation.mutateAsync(value)
+			await submitPhrase(value)
 			onCancel()
 		},
 	})
@@ -269,16 +251,12 @@ function InlinePhraseForm({
 							type="button"
 							variant="soft"
 							size="sm"
-							disabled={mutation.isPending}
 							onClick={() => {
-								void form.validateAllFields('submit').then(() => {
+								void form.validateAllFields('submit').then(async () => {
 									if (!form.state.canSubmit) return
 									const value = form.state.values
-									mutation.mutate(value, {
-										onSuccess: () => {
-											onAddAnother(value.translation_lang)
-										},
-									})
+									await submitPhrase(value)
+									onAddAnother(value.translation_lang)
 								})
 							}}
 						>

--- a/src/features/languages/collections.ts
+++ b/src/features/languages/collections.ts
@@ -40,5 +40,22 @@ export const langTagsCollection = createCollection(
 		},
 		schema: LangTagSchema,
 		queryClient,
+		onInsert: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map(async (m) => {
+					const r = m.modified
+					await supabase
+						.from('tag')
+						.insert({
+							id: r.id,
+							name: r.name,
+							lang: r.lang,
+							added_by: r.added_by,
+						})
+						.throwOnError()
+				})
+			)
+			return { refetch: false }
+		},
 	})
 )

--- a/src/features/phrases/collections.ts
+++ b/src/features/phrases/collections.ts
@@ -11,6 +11,7 @@ import {
 } from './schemas'
 import { queryClient } from '@/lib/query-client'
 import supabase from '@/lib/supabase-client'
+import type { TablesUpdate } from '@/types/supabase'
 
 // Columns we want off the phrase_meta view (slim — no `tags` JSON column;
 // tags live in `phraseTagLinksCollection` and compose on via live query).
@@ -36,6 +37,37 @@ export const phrasesCollection = createCollection(
 		queryClient,
 		autoIndex: 'eager',
 		defaultIndexType: BasicIndex,
+		onInsert: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map(async (m) => {
+					const r = m.modified
+					await supabase
+						.from('phrase')
+						.insert({
+							id: r.id,
+							lang: r.lang,
+							text: r.text,
+							only_reverse: r.only_reverse,
+							added_by: r.added_by ?? undefined,
+						})
+						.throwOnError()
+				})
+			)
+			return { refetch: false }
+		},
+		onUpdate: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map(async (m) => {
+					const changes = m.changes as TablesUpdate<'phrase'>
+					await supabase
+						.from('phrase')
+						.update(changes)
+						.eq('id', m.original.id)
+						.throwOnError()
+				})
+			)
+			return { refetch: false }
+		},
 	})
 )
 
@@ -56,6 +88,49 @@ export const phraseTranslationsCollection = createCollection(
 		queryClient,
 		autoIndex: 'eager',
 		defaultIndexType: BasicIndex,
+		onInsert: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map(async (m) => {
+					const r = m.modified
+					await supabase
+						.from('phrase_translation')
+						.insert({
+							id: r.id,
+							phrase_id: r.phrase_id,
+							lang: r.lang,
+							text: r.text,
+							added_by: r.added_by ?? undefined,
+						})
+						.throwOnError()
+				})
+			)
+			return { refetch: false }
+		},
+		onUpdate: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map(async (m) => {
+					const changes = m.changes as TablesUpdate<'phrase_translation'>
+					await supabase
+						.from('phrase_translation')
+						.update(changes)
+						.eq('id', m.original.id)
+						.throwOnError()
+				})
+			)
+			return { refetch: false }
+		},
+		onDelete: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map(async (m) => {
+					await supabase
+						.from('phrase_translation')
+						.delete()
+						.eq('id', m.original.id)
+						.throwOnError()
+				})
+			)
+			return { refetch: false }
+		},
 	})
 )
 
@@ -76,5 +151,34 @@ export const phraseTagLinksCollection = createCollection(
 		queryClient,
 		autoIndex: 'eager',
 		defaultIndexType: BasicIndex,
+		onInsert: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map(async (m) => {
+					const r = m.modified
+					await supabase
+						.from('phrase_tag')
+						.insert({
+							phrase_id: r.phrase_id,
+							tag_id: r.tag_id,
+							added_by: r.added_by,
+						})
+						.throwOnError()
+				})
+			)
+			return { refetch: false }
+		},
+		onDelete: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map(async (m) => {
+					await supabase
+						.from('phrase_tag')
+						.delete()
+						.eq('phrase_id', m.original.phrase_id)
+						.eq('tag_id', m.original.tag_id)
+						.throwOnError()
+				})
+			)
+			return { refetch: false }
+		},
 	})
 )

--- a/src/features/phrases/collections.ts
+++ b/src/features/phrases/collections.ts
@@ -4,11 +4,20 @@ import { BasicIndex } from '@tanstack/db'
 import {
 	PhraseSchema,
 	type PhraseType,
+	PhraseTagLinkSchema,
+	type PhraseTagLinkType,
 	TranslationSchema,
 	type TranslationType,
 } from './schemas'
 import { queryClient } from '@/lib/query-client'
 import supabase from '@/lib/supabase-client'
+
+// Columns we want off the phrase_meta view (slim — no `tags` JSON column;
+// tags live in `phraseTagLinksCollection` and compose on via live query).
+// We still read from the view because `count_learners`, `avg_difficulty`,
+// `avg_stability` are computed there.
+const PHRASE_META_COLUMNS =
+	'id, created_at, text, lang, added_by, only_reverse, archived, avg_difficulty, avg_stability, count_learners'
 
 export const phrasesCollection = createCollection(
 	queryCollectionOptions({
@@ -19,7 +28,7 @@ export const phrasesCollection = createCollection(
 			console.log(`Loading phrasesCollection`)
 			const { data } = await supabase
 				.from('phrase_meta')
-				.select('*')
+				.select(PHRASE_META_COLUMNS)
 				.throwOnError()
 			return data?.map((p) => PhraseSchema.parse(p)) ?? []
 		},
@@ -44,6 +53,26 @@ export const phraseTranslationsCollection = createCollection(
 			return data?.map((t) => TranslationSchema.parse(t)) ?? []
 		},
 		schema: TranslationSchema,
+		queryClient,
+		autoIndex: 'eager',
+		defaultIndexType: BasicIndex,
+	})
+)
+
+export const phraseTagLinksCollection = createCollection(
+	queryCollectionOptions({
+		id: 'phrase_tag_links',
+		queryKey: ['public', 'phrase_tag'],
+		getKey: (item: PhraseTagLinkType) => `${item.phrase_id}--${item.tag_id}`,
+		queryFn: async () => {
+			console.log(`Loading phraseTagLinksCollection`)
+			const { data } = await supabase
+				.from('phrase_tag')
+				.select('*')
+				.throwOnError()
+			return data?.map((r) => PhraseTagLinkSchema.parse(r)) ?? []
+		},
+		schema: PhraseTagLinkSchema,
 		queryClient,
 		autoIndex: 'eager',
 		defaultIndexType: BasicIndex,

--- a/src/features/phrases/hooks.ts
+++ b/src/features/phrases/hooks.ts
@@ -10,7 +10,7 @@ import type {
 } from './schemas'
 import {
 	phrasesFull,
-	phrasesWithTranslations,
+	phrasesComposed,
 	usePhrasePlaylists,
 	usePhraseComments,
 	type PhraseProvenanceItem,
@@ -41,7 +41,7 @@ export const useLangPhrasesRaw = (
 	useLiveQuery(
 		(q) =>
 			q
-				.from({ phrase: phrasesWithTranslations })
+				.from({ phrase: phrasesComposed })
 				.where(({ phrase }) => eq(phrase.lang, lang)),
 		[lang]
 	)
@@ -55,7 +55,7 @@ export const useOnePhrase = (
 			!pid
 				? undefined
 				: q
-						.from({ phrase: phrasesWithTranslations })
+						.from({ phrase: phrasesComposed })
 						.where(({ phrase }) => eq(phrase.id, pid))
 						.findOne(),
 		[pid]

--- a/src/features/phrases/index.ts
+++ b/src/features/phrases/index.ts
@@ -5,6 +5,8 @@
 export {
 	PhraseSchema,
 	type PhraseType,
+	PhraseTagLinkSchema,
+	type PhraseTagLinkType,
 	PhraseFullSchema,
 	type PhraseFullType,
 	type PhraseFullFullType,
@@ -17,12 +19,16 @@ export {
 } from './schemas'
 
 // Collections
-export { phrasesCollection, phraseTranslationsCollection } from './collections'
+export {
+	phrasesCollection,
+	phraseTranslationsCollection,
+	phraseTagLinksCollection,
+} from './collections'
 
 // Live collections
 export {
 	phrasesFull,
-	phrasesWithTranslations,
+	phrasesComposed,
 	usePhrasePlaylists,
 	usePhraseComments,
 	useRelatedCards,

--- a/src/features/phrases/live.ts
+++ b/src/features/phrases/live.ts
@@ -9,7 +9,12 @@ import {
 import { useLiveQuery } from '@tanstack/react-db'
 
 import type { UseLiveQueryResult, uuid } from '@/types/main'
-import { phrasesCollection, phraseTranslationsCollection } from './collections'
+import {
+	phrasesCollection,
+	phraseTagLinksCollection,
+	phraseTranslationsCollection,
+} from './collections'
+import { langTagsCollection } from '@/features/languages/collections'
 import { publicProfilesCollection } from '@/features/profile/collections'
 import {
 	playlistPhraseLinksCollection,
@@ -21,12 +26,12 @@ import {
 	phraseRequestsCollection,
 } from '@/features/requests/collections'
 
-// Phrase row with its translations aggregated via toArray(). Used by
+// Phrase row with translations + tags aggregated via toArray(). Used by
 // `useOnePhrase` / `useLangPhrasesRaw` and as the base for `phrasesFull`.
-// Keeping it as a derived collection means the aggregation runs once and
-// is reused across consumers.
-export const phrasesWithTranslations = createLiveQueryCollection({
-	id: 'phrases_with_translations',
+// Keeping it as a derived collection means the aggregations run once and
+// are reused across consumers.
+export const phrasesComposed = createLiveQueryCollection({
+	id: 'phrases_composed',
 	query: (q) =>
 		q.from({ phrase: phrasesCollection }).select(({ phrase }) => ({
 			...phrase,
@@ -36,16 +41,27 @@ export const phrasesWithTranslations = createLiveQueryCollection({
 					.where(({ t }) => eq(t.phrase_id, phrase.id))
 					.select(({ t }) => t)
 			),
+			tags: toArray(
+				q
+					.from({ link: phraseTagLinksCollection })
+					.join(
+						{ tag: langTagsCollection },
+						({ link, tag }) => eq(link.tag_id, tag.id),
+						'inner'
+					)
+					.where(({ link }) => eq(link.phrase_id, phrase.id))
+					.select(({ tag }) => ({ id: tag.id, name: tag.name }))
+			),
 		})),
 })
 
-phrasesWithTranslations.createIndex((row) => row.id, { indexType: BasicIndex })
+phrasesComposed.createIndex((row) => row.id, { indexType: BasicIndex })
 
 export const phrasesFull = createLiveQueryCollection({
 	id: 'phrases_full',
 	query: (q) =>
 		q
-			.from({ phrase: phrasesWithTranslations })
+			.from({ phrase: phrasesComposed })
 			.join(
 				{ profile: publicProfilesCollection },
 				({ phrase, profile }) => eq(phrase.added_by, profile.uid),
@@ -53,14 +69,16 @@ export const phrasesFull = createLiveQueryCollection({
 			)
 			.fn.select(({ phrase, profile }) => {
 				const translations = phrase.translations ?? []
+				const tags = phrase.tags ?? []
 				return {
 					...phrase,
 					translations,
+					tags,
 					profile,
 					searchableText: [
 						phrase.text,
 						...translations.map((t) => t.text),
-						...(phrase.tags ?? []).map((t) => t.name),
+						...tags.map((t) => t.name),
 					].join(', '),
 				}
 			}),

--- a/src/features/phrases/mutations.ts
+++ b/src/features/phrases/mutations.ts
@@ -92,6 +92,7 @@ export const createPhraseWithTranslation =
 			uid,
 			cards,
 		}) => {
+			const now = new Date().toISOString()
 			await supabase
 				.from('phrase')
 				.insert({
@@ -126,6 +127,46 @@ export const createPhraseWithTranslation =
 						}))
 					)
 					.throwOnError()
+			}
+			// Sync the confirmed rows into the collections. The action's
+			// optimistic state drops when mutationFn resolves, so we writeInsert
+			// the same values we just persisted to keep them past this tick.
+			phrasesCollection.utils.writeInsert({
+				id: phraseId,
+				lang,
+				text,
+				only_reverse: onlyReverse,
+				added_by: uid,
+				archived: false,
+				created_at: now,
+				avg_difficulty: null,
+				avg_stability: null,
+				count_learners: cards.length > 0 ? 1 : 0,
+			})
+			phraseTranslationsCollection.utils.writeInsert({
+				id: translationId,
+				phrase_id: phraseId,
+				lang: translationLang,
+				text: translationText,
+				added_by: uid,
+				archived: false,
+				created_at: now,
+				updated_at: now,
+			})
+			for (const c of cards) {
+				cardsCollection.utils.writeInsert({
+					id: c.id,
+					phrase_id: phraseId,
+					lang,
+					uid,
+					status: 'active',
+					direction: c.direction,
+					created_at: now,
+					updated_at: now,
+					last_reviewed_at: null,
+					stability: null,
+					difficulty: null,
+				})
 			}
 		},
 	})
@@ -290,6 +331,67 @@ export const bulkAddPhrases = createOptimisticAction<BulkAddPhrasesInput>({
 		)
 		if (linkRows.length) {
 			await supabase.from('phrase_tag').insert(linkRows).throwOnError()
+		}
+		// Sync confirmed rows into the collections before the optimistic state
+		// drops at the end of mutationFn.
+		const now = new Date().toISOString()
+		for (const t of newTags) {
+			langTagsCollection.utils.writeInsert({
+				id: t.id,
+				name: t.name,
+				lang,
+				added_by: uid,
+				created_at: now,
+			})
+		}
+		for (const p of phrases) {
+			phrasesCollection.utils.writeInsert({
+				id: p.phraseId,
+				lang,
+				text: p.text,
+				only_reverse: p.onlyReverse,
+				added_by: uid,
+				archived: false,
+				created_at: now,
+				avg_difficulty: null,
+				avg_stability: null,
+				count_learners: p.cards.length > 0 ? 1 : 0,
+			})
+			for (const t of p.translations) {
+				phraseTranslationsCollection.utils.writeInsert({
+					id: t.id,
+					phrase_id: p.phraseId,
+					lang: t.lang,
+					text: t.text,
+					added_by: uid,
+					archived: false,
+					created_at: now,
+					updated_at: now,
+				})
+			}
+			for (const c of p.cards) {
+				cardsCollection.utils.writeInsert({
+					id: c.id,
+					phrase_id: p.phraseId,
+					lang,
+					uid,
+					status: 'active',
+					direction: c.direction,
+					created_at: now,
+					updated_at: now,
+					last_reviewed_at: null,
+					stability: null,
+					difficulty: null,
+				})
+			}
+			for (const tagId of p.tagIds) {
+				phraseTagLinksCollection.utils.writeInsert({
+					phrase_id: p.phraseId,
+					tag_id: tagId,
+					added_by: uid,
+					created_at: now,
+				})
+			}
 		}
 	},
 })

--- a/src/features/phrases/mutations.ts
+++ b/src/features/phrases/mutations.ts
@@ -1,0 +1,295 @@
+import { createOptimisticAction } from '@tanstack/db'
+
+import supabase from '@/lib/supabase-client'
+import type { uuid } from '@/types/main'
+import {
+	phrasesCollection,
+	phraseTagLinksCollection,
+	phraseTranslationsCollection,
+} from './collections'
+import { cardsCollection } from '@/features/deck/collections'
+import { langTagsCollection } from '@/features/languages/collections'
+
+// Replaces the old `add_phrase_translation_card` RPC. Inserts a phrase,
+// its first translation, and optional cards in one optimistic transaction.
+// Sequential persistence so FK ordering holds: phrase before translation,
+// phrase before cards.
+type CreatePhraseWithTranslationInput = {
+	phraseId: uuid
+	translationId: uuid
+	lang: string
+	text: string
+	onlyReverse: boolean
+	translationLang: string
+	translationText: string
+	uid: uuid
+	cards: Array<{
+		id: uuid
+		direction: 'forward' | 'reverse'
+	}>
+}
+
+export const createPhraseWithTranslation =
+	createOptimisticAction<CreatePhraseWithTranslationInput>({
+		onMutate: ({
+			phraseId,
+			translationId,
+			lang,
+			text,
+			onlyReverse,
+			translationLang,
+			translationText,
+			uid,
+			cards,
+		}) => {
+			const now = new Date().toISOString()
+			phrasesCollection.insert({
+				id: phraseId,
+				lang,
+				text,
+				only_reverse: onlyReverse,
+				added_by: uid,
+				archived: false,
+				created_at: now,
+				avg_difficulty: null,
+				avg_stability: null,
+				count_learners: cards.length > 0 ? 1 : 0,
+			})
+			phraseTranslationsCollection.insert({
+				id: translationId,
+				phrase_id: phraseId,
+				lang: translationLang,
+				text: translationText,
+				added_by: uid,
+				archived: false,
+				created_at: now,
+				updated_at: now,
+			})
+			for (const c of cards) {
+				cardsCollection.insert({
+					id: c.id,
+					phrase_id: phraseId,
+					lang,
+					uid,
+					status: 'active',
+					direction: c.direction,
+					created_at: now,
+					updated_at: now,
+					last_reviewed_at: null,
+					stability: null,
+					difficulty: null,
+				})
+			}
+		},
+		mutationFn: async ({
+			phraseId,
+			translationId,
+			lang,
+			text,
+			onlyReverse,
+			translationLang,
+			translationText,
+			uid,
+			cards,
+		}) => {
+			await supabase
+				.from('phrase')
+				.insert({
+					id: phraseId,
+					lang,
+					text,
+					only_reverse: onlyReverse,
+					added_by: uid,
+				})
+				.throwOnError()
+			await supabase
+				.from('phrase_translation')
+				.insert({
+					id: translationId,
+					phrase_id: phraseId,
+					lang: translationLang,
+					text: translationText,
+					added_by: uid,
+				})
+				.throwOnError()
+			if (cards.length) {
+				await supabase
+					.from('user_card')
+					.insert(
+						cards.map((c) => ({
+							id: c.id,
+							phrase_id: phraseId,
+							lang,
+							uid,
+							status: 'active' as const,
+							direction: c.direction,
+						}))
+					)
+					.throwOnError()
+			}
+		},
+	})
+
+// Inverse of `add_phrase_translation_card`'s card-direction logic: a
+// non-`only_reverse` phrase gets a forward card; every card also gets a
+// reverse companion. Returns pre-generated IDs so optimistic and
+// persistent stages share the same row IDs.
+export function buildCardSet(
+	onlyReverse: boolean
+): CreatePhraseWithTranslationInput['cards'] {
+	const cards: CreatePhraseWithTranslationInput['cards'] = []
+	if (!onlyReverse) {
+		cards.push({ id: crypto.randomUUID(), direction: 'forward' })
+	}
+	cards.push({ id: crypto.randomUUID(), direction: 'reverse' })
+	return cards
+}
+
+// Replaces the old `bulk_add_phrases` + per-phrase `add_tags_to_phrase` RPCs.
+// Caller pre-resolves tag IDs (existing tags reuse their ID; new tags get a
+// fresh uuid shared across the batch so a name appearing on multiple phrases
+// only creates one tag row). New tags listed in `newTags` are inserted once.
+type BulkAddPhrasesInput = {
+	lang: string
+	uid: uuid
+	newTags: Array<{ id: uuid; name: string }>
+	phrases: Array<{
+		phraseId: uuid
+		text: string
+		onlyReverse: boolean
+		translations: Array<{ id: uuid; lang: string; text: string }>
+		cards: Array<{ id: uuid; direction: 'forward' | 'reverse' }>
+		tagIds: Array<uuid>
+	}>
+}
+
+export const bulkAddPhrases = createOptimisticAction<BulkAddPhrasesInput>({
+	onMutate: ({ lang, uid, newTags, phrases }) => {
+		const now = new Date().toISOString()
+		for (const t of newTags) {
+			langTagsCollection.insert({
+				id: t.id,
+				name: t.name,
+				lang,
+				added_by: uid,
+				created_at: now,
+			})
+		}
+		for (const p of phrases) {
+			phrasesCollection.insert({
+				id: p.phraseId,
+				lang,
+				text: p.text,
+				only_reverse: p.onlyReverse,
+				added_by: uid,
+				archived: false,
+				created_at: now,
+				avg_difficulty: null,
+				avg_stability: null,
+				count_learners: p.cards.length > 0 ? 1 : 0,
+			})
+			for (const t of p.translations) {
+				phraseTranslationsCollection.insert({
+					id: t.id,
+					phrase_id: p.phraseId,
+					lang: t.lang,
+					text: t.text,
+					added_by: uid,
+					archived: false,
+					created_at: now,
+					updated_at: now,
+				})
+			}
+			for (const c of p.cards) {
+				cardsCollection.insert({
+					id: c.id,
+					phrase_id: p.phraseId,
+					lang,
+					uid,
+					status: 'active',
+					direction: c.direction,
+					created_at: now,
+					updated_at: now,
+					last_reviewed_at: null,
+					stability: null,
+					difficulty: null,
+				})
+			}
+			for (const tagId of p.tagIds) {
+				phraseTagLinksCollection.insert({
+					phrase_id: p.phraseId,
+					tag_id: tagId,
+					added_by: uid,
+					created_at: now,
+				})
+			}
+		}
+	},
+	mutationFn: async ({ lang, uid, newTags, phrases }) => {
+		if (newTags.length) {
+			await supabase
+				.from('tag')
+				.insert(
+					newTags.map((t) => ({
+						id: t.id,
+						name: t.name,
+						lang,
+						added_by: uid,
+					}))
+				)
+				.throwOnError()
+		}
+		if (phrases.length) {
+			await supabase
+				.from('phrase')
+				.insert(
+					phrases.map((p) => ({
+						id: p.phraseId,
+						lang,
+						text: p.text,
+						only_reverse: p.onlyReverse,
+						added_by: uid,
+					}))
+				)
+				.throwOnError()
+		}
+		const translationRows = phrases.flatMap((p) =>
+			p.translations.map((t) => ({
+				id: t.id,
+				phrase_id: p.phraseId,
+				lang: t.lang,
+				text: t.text,
+				added_by: uid,
+			}))
+		)
+		if (translationRows.length) {
+			await supabase
+				.from('phrase_translation')
+				.insert(translationRows)
+				.throwOnError()
+		}
+		const cardRows = phrases.flatMap((p) =>
+			p.cards.map((c) => ({
+				id: c.id,
+				phrase_id: p.phraseId,
+				lang,
+				uid,
+				status: 'active' as const,
+				direction: c.direction,
+			}))
+		)
+		if (cardRows.length) {
+			await supabase.from('user_card').insert(cardRows).throwOnError()
+		}
+		const linkRows = phrases.flatMap((p) =>
+			p.tagIds.map((tagId) => ({
+				phrase_id: p.phraseId,
+				tag_id: tagId,
+				added_by: uid,
+			}))
+		)
+		if (linkRows.length) {
+			await supabase.from('phrase_tag').insert(linkRows).throwOnError()
+		}
+	},
+})

--- a/src/features/phrases/schemas.ts
+++ b/src/features/phrases/schemas.ts
@@ -36,10 +36,10 @@ export const TranslationSchema = z.object({
 
 export type TranslationType = z.infer<typeof TranslationSchema>
 
-// PhraseSchema — the row shape held by `phrasesCollection`. Mirrors what
-// `phrase_meta` returns. Translations live in their own collection now
-// (`phraseTranslationsCollection`) and are composed onto rows by the live
-// queries in `live.ts`.
+// PhraseSchema — the row shape held by `phrasesCollection`. Tracks the
+// `phrase` table directly (minus translations, tags, and stats which are
+// composed on by the live queries in `live.ts` or — for stats today —
+// still ride from the `phrase_meta` view).
 export const PhraseSchema = z.object({
 	id: z.string().uuid(),
 	created_at: z.string(),
@@ -51,22 +51,35 @@ export const PhraseSchema = z.object({
 	avg_difficulty: z.number().nullable().default(null),
 	avg_stability: z.number().nullable().default(null),
 	count_learners: z.number().nullable().default(0),
-	tags: z.preprocess((val) => val ?? [], z.array(PhraseTagSchema)),
 })
 
 export type PhraseType = z.infer<typeof PhraseSchema>
 
-// PhraseFullType — derived shape produced by `phrasesWithTranslations` /
+// PhraseTagLinkSchema — the row shape of `phrase_tag`, the join table
+// between phrase and tag. Composite primary key (phrase_id, tag_id).
+export const PhraseTagLinkSchema = z.object({
+	phrase_id: z.string().uuid(),
+	tag_id: z.string().uuid(),
+	created_at: z.string(),
+	added_by: z.string().uuid(),
+})
+
+export type PhraseTagLinkType = z.infer<typeof PhraseTagLinkSchema>
+
+// PhraseFullType — derived shape produced by `phrasesComposed` /
 // `phrasesFull` live queries. `translations` is aggregated from
-// `phraseTranslationsCollection` via toArray() at query time.
+// `phraseTranslationsCollection` via toArray() at query time; `tags` is
+// aggregated from `phraseTagLinksCollection` joined with langTags.
 export type PhraseFullType = PhraseType & {
 	translations: Array<TranslationType>
+	tags: Array<{ id: string; name: string }>
 }
 
 // Parser for places (RPC responses, write paths) that need to validate a
 // composed phrase+translations payload.
 export const PhraseFullSchema = PhraseSchema.extend({
 	translations: z.preprocess((val) => val ?? [], z.array(TranslationSchema)),
+	tags: z.preprocess((val) => val ?? [], z.array(PhraseTagSchema)),
 })
 
 export type PhraseFullFullType = PhraseFullType & {

--- a/src/routes/_user/admin/$lang.phrases.$id.lazy.tsx
+++ b/src/routes/_user/admin/$lang.phrases.$id.lazy.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import { createLazyFileRoute, Link } from '@tanstack/react-router'
-import { useMutation } from '@tanstack/react-query'
 import {
 	Archive,
 	Brain,
@@ -17,7 +16,6 @@ import type {
 	PhraseFullType,
 	TranslationType,
 } from '@/features/phrases/schemas'
-import { TranslationSchema } from '@/features/phrases/schemas'
 import { Badge, LangBadge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import Callout from '@/components/ui/callout'
@@ -38,7 +36,6 @@ import {
 	phraseTranslationsCollection,
 } from '@/features/phrases/collections'
 import { useAuth } from '@/lib/use-auth'
-import supabase from '@/lib/supabase-client'
 import { ago } from '@/lib/dayjs'
 import languages from '@/lib/languages'
 
@@ -232,35 +229,23 @@ function EditablePhraseText({
 	const [isEditing, setIsEditing] = useState(false)
 	const [editText, setEditText] = useState(phrase.text)
 
-	const updatePhrase = useMutation({
-		mutationFn: async (newText: string) => {
-			const { data } = await supabase
-				.from('phrase')
-				.update({ text: newText })
-				.eq('id', phrase.id)
-				.throwOnError()
-				.select()
-			if (!data) throw new Error('Failed to update phrase')
-			return data[0]
-		},
-		onSuccess: (data) => {
-			phrasesCollection.utils.writeUpdate({ id: phrase.id, text: data.text })
-			setIsEditing(false)
-			toastSuccess('Phrase text updated')
-		},
-		onError: (error) => {
-			toastError('Failed to update phrase text')
-			console.error(error)
-		},
-	})
-
 	const handleSave = () => {
 		const trimmed = editText.trim()
-		if (trimmed && trimmed !== phrase.text) {
-			updatePhrase.mutate(trimmed)
-		} else {
+		if (!trimmed || trimmed === phrase.text) {
 			setIsEditing(false)
+			return
 		}
+		const tx = phrasesCollection.update(phrase.id, (draft) => {
+			draft.text = trimmed
+		})
+		setIsEditing(false)
+		tx.isPersisted.promise.then(
+			() => toastSuccess('Phrase text updated'),
+			(err: Error) => {
+				toastError('Failed to update phrase text')
+				console.log(`Rolled back phrase text update`, err)
+			}
+		)
 	}
 
 	const handleCancel = () => {
@@ -280,12 +265,7 @@ function EditablePhraseText({
 						if (e.key === 'Escape') handleCancel()
 					}}
 				/>
-				<Button
-					size="icon"
-					variant="ghost"
-					onClick={handleSave}
-					disabled={updatePhrase.isPending}
-				>
+				<Button size="icon" variant="ghost" onClick={handleSave}>
 					<Check className="h-4 w-4" />
 				</Button>
 				<Button size="icon" variant="ghost" onClick={handleCancel}>
@@ -322,60 +302,38 @@ function AdminTranslationRow({
 	const [isEditing, setIsEditing] = useState(false)
 	const [editText, setEditText] = useState(translation.text)
 
-	const updateTranslation = useMutation({
-		mutationFn: async (newText: string) => {
-			const { data } = await supabase
-				.from('phrase_translation')
-				.update({ text: newText })
-				.eq('id', translation.id)
-				.throwOnError()
-				.select()
-			if (!data) throw new Error('Failed to update translation')
-			return data[0]
-		},
-		onSuccess: (data) => {
-			phraseTranslationsCollection.utils.writeUpdate(
-				TranslationSchema.parse(data)
-			)
-			setIsEditing(false)
-			toastSuccess('Translation updated')
-		},
-		onError: (error) => {
-			toastError('Failed to update translation')
-			console.error(error)
-		},
-	})
-
-	const toggleArchive = useMutation({
-		mutationFn: async () => {
-			await supabase
-				.from('phrase_translation')
-				.update({ archived: !translation.archived })
-				.eq('id', translation.id)
-				.throwOnError()
-		},
-		onSuccess: () => {
-			phraseTranslationsCollection.utils.writeUpdate({
-				...translation,
-				archived: !translation.archived,
-			})
-			toastSuccess(
-				`Translation ${translation.archived ? 'restored' : 'archived'}`
-			)
-		},
-		onError: (error) => {
-			toastError('Failed to update translation')
-			console.error(error)
-		},
-	})
-
 	const handleSave = () => {
 		const trimmed = editText.trim()
-		if (trimmed && trimmed !== translation.text) {
-			updateTranslation.mutate(trimmed)
-		} else {
+		if (!trimmed || trimmed === translation.text) {
 			setIsEditing(false)
+			return
 		}
+		const tx = phraseTranslationsCollection.update(translation.id, (draft) => {
+			draft.text = trimmed
+		})
+		setIsEditing(false)
+		tx.isPersisted.promise.then(
+			() => toastSuccess('Translation updated'),
+			(err: Error) => {
+				toastError('Failed to update translation')
+				console.log(`Rolled back translation update`, err)
+			}
+		)
+	}
+
+	const toggleArchive = () => {
+		const wasArchived = translation.archived
+		const tx = phraseTranslationsCollection.update(translation.id, (draft) => {
+			draft.archived = !wasArchived
+		})
+		tx.isPersisted.promise.then(
+			() =>
+				toastSuccess(`Translation ${wasArchived ? 'restored' : 'archived'}`),
+			(err: Error) => {
+				toastError('Failed to update translation')
+				console.log(`Rolled back translation archive toggle`, err)
+			}
+		)
 	}
 
 	const handleCancel = () => {
@@ -412,7 +370,6 @@ function AdminTranslationRow({
 							variant="ghost"
 							className="size-7"
 							onClick={handleSave}
-							disabled={updateTranslation.isPending}
 						>
 							<Check className="size-3.5" />
 						</Button>
@@ -443,8 +400,7 @@ function AdminTranslationRow({
 								size="icon"
 								variant="ghost"
 								className="size-7"
-								onClick={() => toggleArchive.mutate()}
-								disabled={toggleArchive.isPending}
+								onClick={toggleArchive}
 							>
 								{translation.archived ? (
 									<Undo2 className="size-3.5" />

--- a/src/routes/_user/admin/$lang.tsx
+++ b/src/routes/_user/admin/$lang.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import {
 	phrasesCollection,
+	phraseTagLinksCollection,
 	phraseTranslationsCollection,
 } from '@/features/phrases/collections'
 import { phraseRequestsCollection } from '@/features/requests/collections'
@@ -12,6 +13,7 @@ export const Route = createFileRoute('/_user/admin/$lang')({
 		await Promise.all([
 			phrasesCollection.preload(),
 			phraseTranslationsCollection.preload(),
+			phraseTagLinksCollection.preload(),
 			phraseRequestsCollection.preload(),
 			langTagsCollection.preload(),
 			publicProfilesCollection.preload(),

--- a/src/routes/_user/browse.tsx
+++ b/src/routes/_user/browse.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/features/languages/collections'
 import {
 	phrasesCollection,
+	phraseTagLinksCollection,
 	phraseTranslationsCollection,
 } from '@/features/phrases/collections'
 import { phraseRequestsCollection } from '@/features/requests/collections'
@@ -35,6 +36,7 @@ export const Route = createFileRoute('/_user/browse')({
 			phrasePlaylistsCollection.preload(),
 			phrasesCollection.preload(),
 			phraseTranslationsCollection.preload(),
+			phraseTagLinksCollection.preload(),
 			playlistPhraseLinksCollection.preload(),
 		])
 	},

--- a/src/routes/_user/friends/chats.$friendUid.recommend.tsx
+++ b/src/routes/_user/friends/chats.$friendUid.recommend.tsx
@@ -16,7 +16,7 @@ import {
 import type { TablesInsert } from '@/types/supabase'
 import supabase from '@/lib/supabase-client'
 import { useUserId } from '@/lib/use-auth'
-import { phrasesWithTranslations } from '@/features/phrases/live'
+import { phrasesComposed } from '@/features/phrases/live'
 import { phraseRequestsActive } from '@/features/requests/live'
 import { phrasePlaylistsActive } from '@/features/playlists/live'
 
@@ -91,7 +91,7 @@ function RouteComponent() {
 	// path returns nothing without a real query, so this preserves the
 	// "filter by lang/type, see all in-lang items" UX.
 	const { data: allPhrases } = useLiveQuery((q) =>
-		q.from({ phrase: phrasesWithTranslations })
+		q.from({ phrase: phrasesComposed })
 	)
 	const { data: allRequests } = useLiveQuery((q) =>
 		q.from({ req: phraseRequestsActive })

--- a/src/routes/_user/learn/$lang.bulk-add.tsx
+++ b/src/routes/_user/learn/$lang.bulk-add.tsx
@@ -24,13 +24,18 @@ import { usePreferredTranslationLang } from '@/features/deck/hooks'
 import { Separator } from '@/components/ui/separator'
 import { LanguagePicker } from '@/components/fields/language-picker'
 import { CardResultSimple } from '@/components/cards/card-result-simple'
-import { PhraseSchema, TranslationSchema } from '@/features/phrases/schemas'
+import {
+	PhraseSchema,
+	PhraseTagLinkSchema,
+	TranslationSchema,
+} from '@/features/phrases/schemas'
 import { CardMetaSchema, DeckMetaSchema } from '@/features/deck/schemas'
 import { directionsForPhrase } from '@/features/deck/card-directions'
 import { LangTagSchema } from '@/features/languages/schemas'
 import { langTagsCollection } from '@/features/languages/collections'
 import {
 	phrasesCollection,
+	phraseTagLinksCollection,
 	phraseTranslationsCollection,
 } from '@/features/phrases/collections'
 import { cardsCollection, decksCollection } from '@/features/deck/collections'
@@ -284,29 +289,25 @@ function BulkAddPhrasesPage() {
 				}
 			}
 
-			// Update tag collection with newly created tags
+			// Update tag collection with newly created tags + write phrase_tag links
 			for (const [, { result }] of tagsByPhraseIndex) {
 				if (result?.tags?.length) {
 					result.tags.forEach((t) =>
 						langTagsCollection.utils.writeInsert(LangTagSchema.parse(t))
 					)
 				}
+				if (result?.phrase_tags?.length) {
+					result.phrase_tags.forEach((link) =>
+						phraseTagLinksCollection.utils.writeInsert(
+							PhraseTagLinkSchema.parse(link)
+						)
+					)
+				}
 			}
 
-			const phrasesToInsert = rpcResult.phrases.map((p, index) => {
-				const tagInfo = tagsByPhraseIndex.get(index)
-				let tags: Array<{ id: string; name: string }> = []
-				if (tagInfo?.result?.phrase_tags?.length) {
-					tags = tagInfo.result.phrase_tags
-						.map((pt) => {
-							const tag = langTagsCollection.get(pt.tag_id)
-							return tag ? { id: tag.id, name: tag.name } : null
-						})
-						.filter((t): t is { id: string; name: string } => t !== null)
-				}
-
-				return PhraseSchema.parse({ ...p, tags })
-			})
+			const phrasesToInsert = rpcResult.phrases.map((p) =>
+				PhraseSchema.parse(p)
+			)
 
 			phrasesToInsert.forEach((p) => phrasesCollection.utils.writeInsert(p))
 			rpcResult.translations.forEach((t) =>

--- a/src/routes/_user/learn/$lang.bulk-add.tsx
+++ b/src/routes/_user/learn/$lang.bulk-add.tsx
@@ -1,7 +1,6 @@
 import { type ReactNode, CSSProperties, useRef, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
-import { useMutation } from '@tanstack/react-query'
-import { toastError, toastNeutral, toastSuccess } from '@/components/ui/sonner'
+import { toastError, toastSuccess } from '@/components/ui/sonner'
 import { should } from '@scenetest/checks-react'
 import { Pencil, Plus, Trash2 } from 'lucide-react'
 
@@ -18,27 +17,17 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Checkbox } from '@/components/ui/checkbox'
-import { ShowAndLogError } from '@/components/errors'
 import languages from '@/lib/languages'
 import { usePreferredTranslationLang } from '@/features/deck/hooks'
 import { Separator } from '@/components/ui/separator'
 import { LanguagePicker } from '@/components/fields/language-picker'
 import { CardResultSimple } from '@/components/cards/card-result-simple'
-import {
-	PhraseSchema,
-	PhraseTagLinkSchema,
-	TranslationSchema,
-} from '@/features/phrases/schemas'
-import { CardMetaSchema, DeckMetaSchema } from '@/features/deck/schemas'
+import { DeckMetaSchema } from '@/features/deck/schemas'
 import { directionsForPhrase } from '@/features/deck/card-directions'
-import { LangTagSchema } from '@/features/languages/schemas'
 import { langTagsCollection } from '@/features/languages/collections'
-import {
-	phrasesCollection,
-	phraseTagLinksCollection,
-	phraseTranslationsCollection,
-} from '@/features/phrases/collections'
-import { cardsCollection, decksCollection } from '@/features/deck/collections'
+import { phrasesCollection } from '@/features/phrases/collections'
+import { bulkAddPhrases } from '@/features/phrases/mutations'
+import { decksCollection } from '@/features/deck/collections'
 import { Tables } from '@/types/supabase'
 import { uuid } from '@/types/main'
 import { WithPhrase } from '@/components/with-phrase'
@@ -58,11 +47,6 @@ import {
 } from '@/components/ui/dialog'
 import { MultiSelectCreatable } from '@/components/fields/multi-select-creatable'
 import { useLanguageTags } from '@/features/languages/hooks'
-
-type BulkAddPhrasesResponse = {
-	phrases: Array<Tables<'phrase'>>
-	translations: Array<Tables<'phrase_translation'>>
-}
 
 type StagedPhrase = {
 	id: string
@@ -114,6 +98,7 @@ function BulkAddPhrasesPage() {
 	const [shouldCreateOrReactivateDeck, setShouldCreateOrReactivateDeck] =
 		useState(true)
 	const [shouldAddToMyDeck, setShouldAddToMyDeck] = useState(true)
+	const [isSubmitting, setIsSubmitting] = useState(false)
 
 	const invalidateFeed = useInvalidateFeed()
 
@@ -156,17 +141,33 @@ function BulkAddPhrasesPage() {
 		setStagedPhrases((prev) => prev.filter((p) => p.id !== id))
 	}
 
-	const submitMutation = useMutation({
-		mutationFn: async (phrasesToSubmit: Array<StagedPhrase>) => {
-			if (!userId) {
-				throw new Error(
-					"You must be logged in to add cards; please find the '/login' link in the sidebar, and use it."
-				)
-			}
+	const handleSubmit = async () => {
+		if (stagedPhrases.length === 0 || isSubmitting) return
+		if (!userId) {
+			toastError(
+				"You must be logged in to add cards; please find the '/login' link in the sidebar, and use it."
+			)
+			return
+		}
+		setIsSubmitting(true)
+		try {
+			await runSubmit()
+		} finally {
+			setIsSubmitting(false)
+		}
+	}
 
-			// Handle deck creation/reactivation if needed
-			let newDeck: Tables<'user_deck'> | null = null
-			if (showDeckCheckbox && shouldCreateOrReactivateDeck) {
+	const runSubmit = async () => {
+		if (!userId) return
+
+		const shouldCreateCards =
+			(hasActiveDeck || (shouldCreateOrReactivateDeck && showDeckCheckbox)) &&
+			shouldAddToMyDeck
+
+		// Deck creation/reactivation runs first — cards FK into a deck row.
+		let newDeck: Tables<'user_deck'> | null = null
+		if (showDeckCheckbox && shouldCreateOrReactivateDeck) {
+			try {
 				if (hasArchivedDeck) {
 					const { data } = await supabase
 						.from('user_deck')
@@ -186,96 +187,12 @@ function BulkAddPhrasesPage() {
 						.throwOnError()
 					newDeck = data
 				}
-			}
-
-			const p_phrases = phrasesToSubmit.map((p) => ({
-				phrase_text: p.phrase_text,
-				translations: p.translations,
-				only_reverse: false,
-			}))
-
-			const { data, error } = await supabase.rpc('bulk_add_phrases', {
-				p_lang: lang,
-				p_phrases,
-				p_user_id: userId,
-			})
-
-			if (error) throw error
-
-			const rpcResult = data as BulkAddPhrasesResponse | null
-
-			// Create cards if appropriate
-			const shouldCreateCards =
-				(hasActiveDeck || (shouldCreateOrReactivateDeck && showDeckCheckbox)) &&
-				shouldAddToMyDeck
-
-			let cards: Array<Tables<'user_card'>> = []
-			if (shouldCreateCards && rpcResult?.phrases?.length) {
-				const cardsToInsert = rpcResult.phrases.flatMap((p) =>
-					directionsForPhrase(p.only_reverse).map((direction) => ({
-						phrase_id: p.id,
-						lang,
-						uid: userId,
-						status: 'active' as const,
-						direction,
-					}))
-				)
-				const { data: cardData } = await supabase
-					.from('user_card')
-					.insert(cardsToInsert)
-					.select()
-					.throwOnError()
-				cards = cardData ?? []
-			}
-
-			// Add tags for phrases that have them
-			type AddTagsReturnValues = {
-				tags: Array<Tables<'tag'>>
-				phrase_tags: Array<Tables<'phrase_tag'>>
-			}
-			const tagsByPhraseIndex = new Map<
-				number,
-				{ result: AddTagsReturnValues | null; tagNames: Array<string> }
-			>()
-
-			if (rpcResult?.phrases?.length) {
-				const phrasesWithTags = rpcResult.phrases
-					.map((phrase, index) => ({
-						phrase,
-						index,
-						tags: phrasesToSubmit[index]?.tags ?? [],
-					}))
-					.filter(({ tags }) => tags.length > 0)
-
-				const tagResults = await Promise.all(
-					phrasesWithTags.map(async ({ phrase, index, tags }) => {
-						const { data: tagData } = await supabase.rpc('add_tags_to_phrase', {
-							p_phrase_id: phrase.id,
-							p_lang: lang,
-							p_tags: tags,
-						})
-						return {
-							index,
-							result: tagData as AddTagsReturnValues | null,
-							tagNames: tags,
-						}
-					})
-				)
-
-				for (const { index, result, tagNames } of tagResults) {
-					tagsByPhraseIndex.set(index, { result, tagNames })
-				}
-			}
-
-			return { rpcResult, newDeck, cards, tagsByPhraseIndex }
-		},
-		onSuccess: ({ rpcResult, newDeck, cards, tagsByPhraseIndex }) => {
-			if (!rpcResult) {
-				toastNeutral('No data came back from the database :-/')
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err)
+				toastError(`Error setting up deck: ${message}`)
+				console.log('Error', err)
 				return
 			}
-
-			// Update deck collection
 			if (newDeck) {
 				const deckWithTheme = {
 					...newDeck,
@@ -288,78 +205,91 @@ function BulkAddPhrasesPage() {
 					decksCollection.utils.writeInsert(DeckMetaSchema.parse(deckWithTheme))
 				}
 			}
+		}
 
-			// Update tag collection with newly created tags + write phrase_tag links
-			for (const [, { result }] of tagsByPhraseIndex) {
-				if (result?.tags?.length) {
-					result.tags.forEach((t) =>
-						langTagsCollection.utils.writeInsert(LangTagSchema.parse(t))
-					)
-				}
-				if (result?.phrase_tags?.length) {
-					result.phrase_tags.forEach((link) =>
-						phraseTagLinksCollection.utils.writeInsert(
-							PhraseTagLinkSchema.parse(link)
-						)
-					)
-				}
+		// Resolve tag IDs across the whole batch, so a name that's new and
+		// appears on multiple phrases gets one shared uuid (and one tag row).
+		const tagIdByName = new Map<string, { id: uuid; isNew: boolean }>()
+		for (const staged of stagedPhrases) {
+			for (const name of staged.tags) {
+				if (tagIdByName.has(name)) continue
+				const existing = langTagsCollection.toArray.find(
+					(t) => t.name === name && t.lang === lang
+				)
+				tagIdByName.set(name, {
+					id: existing?.id ?? crypto.randomUUID(),
+					isNew: !existing,
+				})
 			}
+		}
+		const newTags = [...tagIdByName.entries()]
+			.filter(([, v]) => v.isNew)
+			.map(([name, v]) => ({ id: v.id, name }))
 
-			const phrasesToInsert = rpcResult.phrases.map((p) =>
-				PhraseSchema.parse(p)
-			)
-
-			phrasesToInsert.forEach((p) => phrasesCollection.utils.writeInsert(p))
-			rpcResult.translations.forEach((t) =>
-				phraseTranslationsCollection.utils.writeInsert(
-					TranslationSchema.parse(t)
-				)
-			)
-
-			should(
-				'bulk add wrote every submitted phrase into phrasesCollection',
-				phrasesToInsert.every((p) => phrasesCollection.has(p.id)),
-				{ count: phrasesToInsert.length }
-			)
-
-			if (cards.length) {
-				cards.forEach((card) =>
-					cardsCollection.utils.writeInsert(CardMetaSchema.parse(card))
-				)
+		const actionPhrases = stagedPhrases.map((staged) => {
+			const phraseId = crypto.randomUUID()
+			const onlyReverse = false
+			const cards = shouldCreateCards
+				? directionsForPhrase(onlyReverse).map((direction) => ({
+						id: crypto.randomUUID(),
+						direction: direction as 'forward' | 'reverse',
+					}))
+				: []
+			return {
+				phraseId,
+				text: staged.phrase_text,
+				onlyReverse,
+				translations: staged.translations.map((t) => ({
+					id: crypto.randomUUID(),
+					lang: t.lang,
+					text: t.text,
+				})),
+				cards,
+				tagIds: staged.tags.map((name) => tagIdByName.get(name)!.id),
 			}
+		})
 
-			invalidateFeed(lang)
-			setSuccessfullyAddedPhrases((prev) => [
-				...phrasesToInsert.map((p) => p.id),
-				...prev,
-			])
-			setStagedPhrases([])
+		const tx = bulkAddPhrases({
+			lang,
+			uid: userId,
+			newTags,
+			phrases: actionPhrases,
+		})
+		try {
+			await tx.isPersisted.promise
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err)
+			toastError(`Error adding phrases: ${message}`)
+			console.log('Error', err)
+			return
+		}
 
-			const cardsMessage = cards.length
-				? ' They will appear in your next review.'
-				: ''
-			if (newDeck) {
-				const deckAction = hasArchivedDeck
-					? `re-activated your ${languages[lang]} deck`
-					: `started learning ${languages[lang]}`
-				toastSuccess(
-					`${rpcResult.phrases.length} phrases added! You've also ${deckAction}.${cardsMessage}`
-				)
-			} else {
-				toastSuccess(
-					`${rpcResult.phrases.length} phrases added successfully!${cardsMessage}`
-				)
-			}
-		},
-		onError: (error) => {
-			toastError(`Error adding phrases: ${error.message}`)
-			console.log('Error', error)
-		},
-	})
+		const phraseIds = actionPhrases.map((p) => p.phraseId)
+		should(
+			'bulk add wrote every submitted phrase into phrasesCollection',
+			phraseIds.every((id) => phrasesCollection.has(id)),
+			{ count: phraseIds.length }
+		)
 
-	const handleSubmit = () => {
-		if (stagedPhrases.length === 0) return
-		submitMutation.mutate(stagedPhrases)
+		invalidateFeed(lang)
+		setSuccessfullyAddedPhrases((prev) => [...phraseIds, ...prev])
+		setStagedPhrases([])
+
+		const cardsMessage = shouldCreateCards
+			? ' They will appear in your next review.'
+			: ''
+		if (newDeck) {
+			const deckAction = hasArchivedDeck
+				? `re-activated your ${languages[lang]} deck`
+				: `started learning ${languages[lang]}`
+			toastSuccess(
+				`${actionPhrases.length} phrases added! You've also ${deckAction}.${cardsMessage}`
+			)
+		} else {
+			toastSuccess(
+				`${actionPhrases.length} phrases added successfully!${cardsMessage}`
+			)
+		}
 	}
 
 	return (
@@ -472,18 +402,14 @@ function BulkAddPhrasesPage() {
 								{/* Submit */}
 								<Button
 									className="w-full"
-									disabled={submitMutation.isPending}
-									onClick={handleSubmit}
+									disabled={isSubmitting}
+									onClick={() => void handleSubmit()}
 									data-testid="submit-staged-phrases"
 								>
-									{submitMutation.isPending
+									{isSubmitting
 										? 'Submitting...'
 										: `Submit ${stagedPhrases.length} Phrase${stagedPhrases.length === 1 ? '' : 's'}`}
 								</Button>
-								<ShowAndLogError
-									error={submitMutation.error}
-									text="There was an error submitting your phrases"
-								/>
 							</div>
 						) : (
 							<div

--- a/src/routes/_user/learn/$lang.phrases.$id.tsx
+++ b/src/routes/_user/learn/$lang.phrases.$id.tsx
@@ -3,6 +3,7 @@ import { BigPhraseCard } from '@/components/cards/big-phrase-card'
 import { CSSProperties } from 'react'
 import {
 	phrasesCollection,
+	phraseTagLinksCollection,
 	phraseTranslationsCollection,
 } from '@/features/phrases/collections'
 import { cardsCollection } from '@/features/deck/collections'
@@ -17,6 +18,7 @@ export const Route = createFileRoute('/_user/learn/$lang/phrases/$id')({
 		const preloads: Promise<unknown>[] = [
 			phrasesCollection.preload(),
 			phraseTranslationsCollection.preload(),
+			phraseTagLinksCollection.preload(),
 			publicProfilesCollection.preload(),
 		]
 		if (context.auth.isAuth) {

--- a/src/routes/_user/learn/$lang.phrases.new.tsx
+++ b/src/routes/_user/learn/$lang.phrases.new.tsx
@@ -1,6 +1,5 @@
 import { CSSProperties, useEffect, useMemo, useState } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { useMutation } from '@tanstack/react-query'
 import * as z from 'zod'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
 import { useDebounce } from '@/hooks/use-debounce'
@@ -22,12 +21,15 @@ import languages from '@/lib/languages'
 import supabase from '@/lib/supabase-client'
 import TranslationLanguageField from '@/components/fields/translation-language-field'
 import { buttonVariants } from '@/components/ui/button'
-import { PhraseSchema, TranslationSchema } from '@/features/phrases/schemas'
-import { CardMetaSchema, DeckMetaSchema } from '@/features/deck/schemas'
+import { DeckMetaSchema } from '@/features/deck/schemas'
 import {
 	phrasesCollection,
 	phraseTranslationsCollection,
 } from '@/features/phrases/collections'
+import {
+	buildCardSet,
+	createPhraseWithTranslation,
+} from '@/features/phrases/mutations'
 import { cardsCollection, decksCollection } from '@/features/deck/collections'
 import { useInvalidateFeed } from '@/features/feed/hooks'
 import { WithPhrase } from '@/components/with-phrase'
@@ -103,75 +105,39 @@ function AddPhraseTab() {
 	const searchPhrase = text || ''
 
 	const invalidateFeed = useInvalidateFeed()
-	const addPhraseMutation = useMutation({
-		mutationFn: async (variables: AddPhraseFormValues) => {
-			if (!userId) {
-				console.log(`Auth guard didn't work in $lang.phrases.new`)
-				throw new Error(
-					"You must be logged in to add cards; please find the '/login' link in the sidebar, and use it."
-				)
-			}
-			const shouldCreateCard = hasActiveDeck || shouldCreateOrReactivateDeck
 
-			let newDeck: Tables<'user_deck'> | null = null
-			if (showDeckCheckbox && shouldCreateOrReactivateDeck) {
-				if (hasArchivedDeck) {
-					const { data } = await supabase
-						.from('user_deck')
-						.update({ archived: false })
-						.eq('lang', lang)
-						.eq('uid', userId)
-						.select()
-						.maybeSingle()
-						.throwOnError()
-					newDeck = data
-				} else if (noDeck) {
-					const { data } = await supabase
-						.from('user_deck')
-						.insert({ lang })
-						.select()
-						.maybeSingle()
-						.throwOnError()
-					newDeck = data
-				}
-			}
-
-			const { data } = await supabase
-				.rpc('add_phrase_translation_card', {
-					phrase_lang: lang,
-					phrase_text: variables.phrase_text,
-					translation_lang: variables.translation_lang,
-					translation_text: variables.translation_text,
-					create_card: shouldCreateCard,
-					phrase_only_reverse: variables.only_reverse,
-				})
-				.throwOnError()
-
-			return {
-				rpcResult: data as {
-					phrase: Tables<'phrase'>
-					translation: Tables<'phrase_translation'>
-					card: Tables<'user_card'> | null
-					card_reverse: Tables<'user_card'> | null
-				},
-				newDeck,
-				createdCard: shouldCreateCard,
-			}
-		},
-		onSuccess: ({ rpcResult, newDeck, createdCard }) => {
-			if (!rpcResult)
-				throw new Error('No data returned from add_phrase_translation_card')
-
-			phrasesCollection.utils.writeInsert(PhraseSchema.parse(rpcResult.phrase))
-			phraseTranslationsCollection.utils.writeInsert(
-				TranslationSchema.parse(rpcResult.translation)
+	const submitPhrase = async (variables: AddPhraseFormValues) => {
+		if (!userId) {
+			console.log(`Auth guard didn't work in $lang.phrases.new`)
+			toastError(
+				"You must be logged in to add cards; please find the '/login' link in the sidebar, and use it."
 			)
-			if (rpcResult.card)
-				phrasesCollection.utils.writeUpdate({
-					id: rpcResult.phrase.id,
-					count_learners: 1,
-				})
+			return
+		}
+		const shouldCreateCard = hasActiveDeck || shouldCreateOrReactivateDeck
 
+		// Deck creation/reactivation runs first — cards need a deck row.
+		let newDeck: Tables<'user_deck'> | null = null
+		if (showDeckCheckbox && shouldCreateOrReactivateDeck) {
+			if (hasArchivedDeck) {
+				const { data } = await supabase
+					.from('user_deck')
+					.update({ archived: false })
+					.eq('lang', lang)
+					.eq('uid', userId)
+					.select()
+					.maybeSingle()
+					.throwOnError()
+				newDeck = data
+			} else if (noDeck) {
+				const { data } = await supabase
+					.from('user_deck')
+					.insert({ lang })
+					.select()
+					.maybeSingle()
+					.throwOnError()
+				newDeck = data
+			}
 			if (newDeck) {
 				const deckWithTheme = {
 					...newDeck,
@@ -184,51 +150,64 @@ function AddPhraseTab() {
 					decksCollection.utils.writeInsert(DeckMetaSchema.parse(deckWithTheme))
 				}
 			}
+		}
 
-			if (createdCard && rpcResult.card) {
-				cardsCollection.utils.writeInsert(CardMetaSchema.parse(rpcResult.card))
-				if (rpcResult.card_reverse) {
-					cardsCollection.utils.writeInsert(
-						CardMetaSchema.parse(rpcResult.card_reverse)
-					)
-				}
-			}
+		await Promise.all([
+			phrasesCollection.preload(),
+			phraseTranslationsCollection.preload(),
+			cardsCollection.preload(),
+		])
 
-			invalidateFeed(lang)
-			console.log(`Success:`, rpcResult)
-			setNewPhrases((prev) => [rpcResult.phrase.id, ...prev])
-			form.reset({
-				phrase_text: '',
-				translation_text: '',
-				translation_lang:
-					rpcResult.translation.lang ?? preferredTranslationLang,
-				only_reverse: false,
-			})
+		const phraseId = crypto.randomUUID()
+		const translationId = crypto.randomUUID()
+		const cards = shouldCreateCard ? buildCardSet(variables.only_reverse) : []
 
-			if (newDeck && createdCard) {
-				const deckAction = hasArchivedDeck
-					? `re-activated your ${languages[lang]} deck`
-					: `started learning ${languages[lang]}`
-				toastSuccess(
-					`Phrase added to the library! You've ${deckAction} and the phrase will appear in your next review.`
-				)
-			} else if (createdCard) {
-				toastSuccess(
-					'New phrase has been added to the public library and will appear in your next review'
-				)
-			} else {
-				toastSuccess(
-					'Phrase has been added to the public library (not added to your deck)'
-				)
-			}
-		},
-		onError: (error) => {
-			toastError(
-				`There was an error submitting this new phrase: ${error.message}`
+		const tx = createPhraseWithTranslation({
+			phraseId,
+			translationId,
+			lang,
+			text: variables.phrase_text,
+			onlyReverse: variables.only_reverse,
+			translationLang: variables.translation_lang,
+			translationText: variables.translation_text,
+			uid: userId,
+			cards,
+		})
+		try {
+			await tx.isPersisted.promise
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err)
+			toastError(`There was an error submitting this new phrase: ${message}`)
+			console.log(`Error:`, err)
+			return
+		}
+
+		invalidateFeed(lang)
+		setNewPhrases((prev) => [phraseId, ...prev])
+		form.reset({
+			phrase_text: '',
+			translation_text: '',
+			translation_lang: variables.translation_lang || preferredTranslationLang,
+			only_reverse: false,
+		})
+
+		if (newDeck && shouldCreateCard) {
+			const deckAction = hasArchivedDeck
+				? `re-activated your ${languages[lang]} deck`
+				: `started learning ${languages[lang]}`
+			toastSuccess(
+				`Phrase added to the library! You've ${deckAction} and the phrase will appear in your next review.`
 			)
-			console.log(`Error:`, error)
-		},
-	})
+		} else if (shouldCreateCard) {
+			toastSuccess(
+				'New phrase has been added to the public library and will appear in your next review'
+			)
+		} else {
+			toastSuccess(
+				'Phrase has been added to the public library (not added to your deck)'
+			)
+		}
+	}
 
 	const schema = useMemo(() => createAddPhraseSchema(lang), [lang])
 	const form = useAppForm({
@@ -240,7 +219,7 @@ function AddPhraseTab() {
 		},
 		validators: { onChange: schema },
 		onSubmit: async ({ value }) => {
-			await addPhraseMutation.mutateAsync(value)
+			await submitPhrase(value)
 		},
 	})
 

--- a/src/routes/_user/learn/$lang.tsx
+++ b/src/routes/_user/learn/$lang.tsx
@@ -7,6 +7,7 @@ import { todayString } from '@/lib/utils'
 import { langTagsCollection } from '@/features/languages/collections'
 import {
 	phrasesCollection,
+	phraseTagLinksCollection,
 	phraseTranslationsCollection,
 } from '@/features/phrases/collections'
 import { cardsCollection, decksCollection } from '@/features/deck/collections'
@@ -62,6 +63,7 @@ export const Route = createFileRoute('/_user/learn/$lang')({
 			langTagsCollection.preload(),
 			phrasesCollection.preload(),
 			phraseTranslationsCollection.preload(),
+			phraseTagLinksCollection.preload(),
 			publicProfilesCollection.preload(),
 			phrasePlaylistsCollection.preload(),
 			playlistPhraseLinksCollection.preload(),

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1943,32 +1943,7 @@ export type Database = {
 			}
 		}
 		Functions: {
-			add_phrase_translation_card: {
-				Args: {
-					create_card?: boolean
-					phrase_lang: string
-					phrase_only_reverse?: boolean
-					phrase_text: string
-					phrase_text_script?: string
-					translation_lang: string
-					translation_text: string
-					translation_text_script?: string
-				}
-				Returns: Json
-			}
-			add_tags_to_phrase: {
-				Args: { p_lang: string; p_phrase_id: string; p_tags: string[] }
-				Returns: Json
-			}
 			are_friends: { Args: { uid1: string; uid2: string }; Returns: boolean }
-			bulk_add_phrases: {
-				Args: {
-					p_lang: string
-					p_phrases: Database['public']['CompositeTypes']['phrase_with_translations_input'][]
-					p_user_id: string
-				}
-				Returns: Json
-			}
 			create_comment_with_phrases: {
 				Args: {
 					p_content: string

--- a/supabase/migrations/20260606120000_drop_phrase_creation_rpcs.sql
+++ b/supabase/migrations/20260606120000_drop_phrase_creation_rpcs.sql
@@ -1,0 +1,31 @@
+-- Drop the phrase-creation RPCs in favor of direct collection actions.
+--
+-- All three RPCs (`add_phrase_translation_card`, `add_tags_to_phrase`,
+-- `bulk_add_phrases`) did multi-row inserts whose shape is fully
+-- predictable client-side: every row's ID, FK values, and timestamps can
+-- be computed in the browser before the call goes out. Now that
+-- `phraseTranslationsCollection` and `phraseTagLinksCollection` exist as
+-- flat collections, the client can drive the same flows via
+-- `createOptimisticAction` (multi-collection optimistic state +
+-- sequential supabase inserts) — no server-side wrapping needed.
+--
+-- The two composite types only existed to shape input to
+-- `bulk_add_phrases`, so they go away with it.
+drop function if exists public.add_phrase_translation_card (
+	phrase_text text,
+	phrase_lang text,
+	translation_text text,
+	translation_lang text,
+	phrase_text_script text,
+	translation_text_script text,
+	create_card boolean,
+	phrase_only_reverse boolean
+);
+
+drop function if exists public.add_tags_to_phrase (p_phrase_id uuid, p_lang character varying, p_tags text[]);
+
+drop function if exists public.bulk_add_phrases (p_lang character, p_phrases public.phrase_with_translations_input[], p_user_id uuid);
+
+drop type if exists public.phrase_with_translations_input;
+
+drop type if exists public.translation_input;


### PR DESCRIPTION
## Summary

This PR ended up being two phases of work on the same branch — the tags split (phase 2 of dismantling `phrase_meta`), plus dropping the phrase-creation RPCs entirely and driving every flow through direct collection actions (the architectural payoff of the v0.28 collection splits). Both pieces are in scope for v0.28 since the second piece needs the first.

After this PR:
- `phrase_meta`'s tag-aggregation CTE is unused by the client — only `phrase_stats` columns remain denormalized. Stats can follow in v0.29 as a quick scalar-only split.
- The only RPCs the client still calls are the ones whose server-side transformation genuinely can't be predicted client-side (`create_comment_with_phrases`, `set_*_upvote`, `search_by_trigram`, `create_playlist_with_links`) — not the trivially-replicable bulk wrappers.

## Migration

`20260606120000_drop_phrase_creation_rpcs.sql` drops:
- `add_phrase_translation_card`
- `add_tags_to_phrase`
- `bulk_add_phrases`
- composite types `phrase_with_translations_input` and `translation_input`

## Part 1 — Tags split

- **`PhraseTagLinkSchema`** (new) — composite key `(phrase_id, tag_id)` + `created_at`, `added_by`.
- **`phraseTagLinksCollection`** (new) — flat read of `phrase_tag`. `getKey` uses the composite template string ``${item.phrase_id}--${item.tag_id}``.
- **`PhraseSchema`** loses the `tags` field; **`phrasesCollection.queryFn`** selects explicit columns from `phrase_meta` instead of `*`, so the view's `jsonb_agg` for tags never ships to the client.
- **Renamed `phrasesWithTranslations` → `phrasesComposed`** — composes both translations and tags now via two `toArray()` aggregators (the tags one inner-joins `langTagsCollection`).
- **`phrasesFull.fn.select`** normalizes `tags` to `[]` defensively, same as the translations pattern.

## Part 2 — Drop the RPCs

**Collection-level persistence handlers** added to:
- `phrasesCollection` — onInsert, onUpdate
- `phraseTranslationsCollection` — onInsert, onUpdate, onDelete
- `phraseTagLinksCollection` — onInsert, onDelete (composite-key delete)
- `langTagsCollection` — onInsert

Each handler does the supabase write directly. Throwing rolls the optimistic state back; `{ refetch: false }` keeps the confirmed value local instead of refetching whole tables.

**New `features/phrases/mutations.ts`** with two `createOptimisticAction` flows for the multi-collection cases:
- **`createPhraseWithTranslation`** — replaces `add_phrase_translation_card`. Inserts phrase + translation + optional cards in one optimistic transaction with sequential persistence for FK ordering. `buildCardSet(onlyReverse)` mirrors the old RPC's card-direction logic.
- **`bulkAddPhrases`** — replaces both `bulk_add_phrases` and the per-phrase `add_tags_to_phrase` calls. The caller pre-resolves tag IDs across the whole batch, so a new tag name appearing on multiple phrases gets exactly one shared uuid (and one tag row).

**Consumer rewires:**
- `add-translations.tsx`: add / edit / archive use `phraseTranslationsCollection.insert / update`. Toasts hang off `tx.isPersisted.promise` — a successful insert whose post-sync throws no longer surfaces as a misleading "Failed to add translation" toast.
- `add-tags.tsx`: add uses `createOptimisticAction` (resolves existing-vs-new tag IDs, inserts to both `langTagsCollection` and `phraseTagLinksCollection`); remove uses `phraseTagLinksCollection.delete` with the composite key.
- `inline-phrase-creator.tsx`, `$lang.phrases.new.tsx`, `$lang.bulk-add.tsx`: all go through the shared `createPhraseWithTranslation` / `bulkAddPhrases` actions. The latter two keep their direct deck creation supabase calls (deck mutations aren't in scope this round).
- `admin/$lang.phrases.$id.lazy.tsx`: phrase text edit uses `phrasesCollection.update`; translation edit / archive use `phraseTranslationsCollection.update`.

## Types

Trimmed the three dropped RPC entries out of `src/types/supabase.ts`. The two composite-type entries stay for now because the generated `CompositeTypes<>` helper picks up an eslint redundant-union warning if the block is empty — `pnpm run types` against the post-migration DB will clean them up.

## Changelog

Updated v0.28 entry to record the migration, the tags split, and the mutation-pattern conversion. Release date bumped to 6 June.

## Test plan

Higher-effort than a typical PR because this touches every phrase / translation / tag write path:

- [ ] `pnpm check` clean
- [ ] `pnpm lint` clean (15 pre-existing warnings)
- [ ] Migration applies clean on a fresh `supabase db reset`
- [ ] `pnpm run types` after migration produces a clean diff (drops the two composite-type entries)
- [ ] Scenetest: add translation, edit translation, archive/unarchive translation
- [ ] Scenetest: add tag, add multiple tags (some new + some existing), remove tag
- [ ] Scenetest: inline phrase creator from feed (no deck), inline from chat (with deck)
- [ ] Scenetest: `/learn/$lang/phrases/new` with and without deck creation
- [ ] Scenetest: bulk-add with tags + translations + deck creation
- [ ] Scenetest: admin phrase detail — edit phrase text, edit translation, archive translation
- [ ] Manual: kill the network mid-write to confirm the optimistic state rolls back (toast says "Failed" with real error, not a misleading success)

https://claude.ai/code/session_0171QHSEQC4TiGFL4vq76uLq