### PR TITLE
next-0.29.0: add `stage` to user_card_review, go append-only, retire day_first_review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## v0.29 - Review `stage` Column, Append-Only Again-Round
+
+_15 July, 2026_
+
+### Refactors
+
+- **`stage` replaces `day_first_review` on `user_card_review`** (#724). Each review records the session stage it happened in — 1 = first pass, 2 = go-back pass, 3 = again-round — mirroring `user_deck_review_state.stage`. Scheduling relevance becomes the predicate `stage IN (1, 2)` rather than a flag, which lets `useReviewMutation` drop its `prevDataToday` insert-vs-update dance and its FSRS-copy hack. The again-round is now **append-only**: each 'again' tap is its own tracking row (null FSRS) instead of overwriting one row per card per day, so retries are counted rather than destroyed. Scoring-pass corrections still update in place (`updated_at` is the tell). New `isScoringReview()` predicate carries the `stage IN (1, 2)` test across the client hooks, `review-utils`, and `bury-siblings`.
+
+### Migrations
+
+- `20260715120000_add_stage_to_user_card_review.sql` — adds `stage smallint` (backfilled `day_first_review ? 1 : 3`, set `NOT NULL`, `1..3` check); flips the two server-side FSRS readers `user_card_plus` (latest scoring review per card) and `phrase_stats` (latest scoring review per learner) to `stage IN (1, 2)`, since append-only stage-3 rows now carry null FSRS; drops `day_first_review`.
+
 ## v0.28 - LanguagePicker, Sharing Redesign, Translations & Tags Split
 
 _6 June, 2026_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sunlo-tanstack",
-	"version": "0.28.0",
+	"version": "0.29.0",
 	"private": false,
 	"type": "module",
 	"scripts": {

--- a/readme/fsrs-how-it-works.md
+++ b/readme/fsrs-how-it-works.md
@@ -65,11 +65,13 @@ The client also maintains local copies of all the above in TanStack DB collectio
 
 A review session moves through stages:
 
-1. **First pass** — work through every card in the manifest. Score each one. `day_first_review = true` for these.
-2. **Unreviewed cards** — go back for any you skipped.
+1. **First pass** — work through every card in the manifest. Score each one. These rows record `stage = 1`.
+2. **Unreviewed cards** — go back for any you skipped. These are still scoring reviews (`stage = 2`).
 3. **Re-review prompt** — if you scored any card "Again" (score 1), you're asked if you want to re-review them.
-4. **Re-reviews** — re-do the "Again" cards. These get `day_first_review = false` and don't update FSRS state (the first-pass score is what counts for scheduling).
+4. **Re-reviews** — re-do the "Again" cards. These record `stage = 3`, carry NULL FSRS columns, and don't update FSRS state (the first-pass score is what counts for scheduling). Append-only: each tap is its own row.
 5. **Done.**
+
+FSRS reads only the scoring stages (`stage IN (1, 2)`); stage 3 is tracking-only. (This `stage` column replaced the old `day_first_review` boolean in #724.)
 
 Stage is tracked both in the Zustand store (for immediate UI response) and persisted to `user_deck_review_state.stage` on the server (so you can resume if you close the tab).
 

--- a/readme/review-interface-flow-logic.md
+++ b/readme/review-interface-flow-logic.md
@@ -2,22 +2,18 @@
 
 1. Phase 1. User sees all cards in no particular order, but with a clear indication "card 1 of 20" "2 of 20" etc.
 2. Phase 2. User sees all cards that were skipped the first time, and none of the cards have a review today/this session. If the user skips a card again in this phase, it's out for the day.
-3. Phase 3. User ses all cards whose first review was a (1 - Again) and reviews them all in a loop; cards are removed from the loop of they get skipped again, or marked 2, 3, or 4. These are "second reviews" and during phase 3, if there is more than one review there should still only be one record for this second review (and also the one from the earlier phase), making 2 reviews total for that card during that day_session, with the first review having score=1 and the second review hopefully having some other score (although it is possible to have a second review with score=1 and then skip the card again and so have two reviews on that day both with score=1).
+3. Phase 3. User sees all cards whose first review was a (1 - Again) and reviews them all in a loop; cards are removed from the loop if they get skipped again, or marked 2, 3, or 4. These are "second reviews". As of #724 the again-round is **append-only**: every tap writes a new row, so how many times a card was retried is preserved rather than overwritten. The card's place in the loop is driven by its _latest_ review (newest `created_at` wins per card).
 
 Some considerations:
 
-- When a card is skipped, its answer gets hidden. When a card is answered and then the user navigates back to it, the answer is shown and the same review can be UPDATED.
+- When a card is skipped, its answer gets hidden. When a card is answered and then the user navigates back to it (only possible in phase 1's header), the answer is shown and the same review can be UPDATED — a correction, not a new fact.
 - Nav at the top: In phase 1 the nav says "card 1 of 20" with little buttons for next and prev. But in phase 2 and 3 it switches to "4 cards left" with the same buttons.
-- In the first phase the reviews get a value `day_first_review=TRUE`. In the second phase we're just seeing skipped cards, so the value is still `TRUE`. In the third phase we are doing second results, which are meant to be left out of many of our mathematical equations, but can still be stored for posterity. They are not meant to recalculate the FSRS numbers but merely to record that the user has gone ahead and continued working on the phrase until success, so we set `day_first_review=FALSE`
+- Each review row records the session `stage` it happened in (mirroring `user_deck_review_state.stage`): **1** = first pass, **2** = go-back pass, **3** = again-round. FSRS reads only the scoring stages (`stage IN (1, 2)`); stage-3 rows are tracking-only and carry NULL FSRS columns. This replaced the old `day_first_review` flag (#724), which conflated "where in the session" with "does FSRS read it".
 
 ## SOLVED: Phase 3 Infinite Loop Bug
 
 **Problem:** During phase 3 we were seeing the same cards over and over and over again.
 
-**Root Causes (Fixed 2026-01-17):**
+**Root Cause (Fixed 2026-01-17):** `useReviewsToday` didn't order reviews by `created_at`, so when multiple reviews existed for the same card, `buildReviewsMap` could pick the OLDER review (score=1) instead of the NEWER one (score=3), and the card never left the again-loop. Fixed by adding `.orderBy(({ review }) => review.created_at, 'asc')` so the newest review wins per card.
 
-1. **reviewsMap ordering issue** - `useReviewsToday` didn't order reviews by `created_at`, so when multiple reviews existed for the same card (which happens in phase 3), `mapArray` could pick the OLDER review (score=1) instead of the NEWER one (score=3). Fixed by adding `.orderBy(({ review }) => review.created_at, 'asc')`.
-
-2. **Phase 3 always INSERTed instead of UPDATEing** - The mutation was creating NEW review records every time in phase 3 instead of updating the existing phase-3 review. This created multiple reviews per card, causing the ordering issue above. Fixed by checking if `prevDataToday?.day_first_review === false` and updating instead of inserting.
-
-3. **`day_first_review` wasn't being set correctly** - Phase 3 reviews should have `day_first_review=FALSE` to distinguish them from phase 1-2 reviews, but the code wasn't setting this. Fixed by passing `day_first_review: false` to `postReview` for phase 3 inserts.
+> Historical note: an earlier fix also made phase 3 UPDATE a single row in place (rather than insert) to sidestep the ordering bug. #724 reverted that — the again-round is append-only again — but the ASC ordering above keeps "latest review wins" correct regardless of how many rows a card accumulates.

--- a/readme/testing-checklist.md
+++ b/readme/testing-checklist.md
@@ -80,5 +80,5 @@ these examples, the user doesn't get direct feedback in the UI as to whether the
 has been taken, so we need to directly inspect either the mutation's return values or the contents
 of the database.
 
-- [ ] Reviews can be edited (without creating new reviews)
-- [ ] Second reviews get marked with new records but with the prev values and day_first_review=false
+- [ ] Scoring-pass reviews can be corrected in place (without creating new reviews)
+- [ ] Again-round reviews append a new record each tap, with `stage = 3` and NULL FSRS columns

--- a/scripts/reclassify-phase1-duplicates.ts
+++ b/scripts/reclassify-phase1-duplicates.ts
@@ -1,4 +1,11 @@
 /**
+ * ⚠️ OBSOLETE as of #724 (the `stage` migration). This tool operates on the
+ * `day_first_review` column, which no longer exists — `user_card_review` now
+ * records a `stage` (1–2 = scoring, 3 = again-round) and reviews are
+ * append-only. The misclassification it repaired is a `day_first_review`-era
+ * concern. Do not run it against the post-#724 schema without first porting it
+ * to `stage`; the queries below will error on the dropped column.
+ *
  * Reclassify misclassified phase-1 duplicates as phase-3 re-reviews.
  *
  * Why this script exists

--- a/scripts/recompute-reviews.ts
+++ b/scripts/recompute-reviews.ts
@@ -1,4 +1,12 @@
 /**
+ * ⚠️ PREDATES #724 (the `stage` migration) and needs porting before use. It
+ * reads `day_first_review`, which has been dropped — reviews now carry a
+ * `stage` (1–2 = scoring, 3 = again-round). It also assumes the old copy-hack
+ * where again-round rows mirror the same-session scoring row's FSRS values;
+ * under #724 those rows are tracking-only and carry NULL FSRS. Port the
+ * predicates to `isScoringReview`/`stage` and null-out again-round rows before
+ * running against the post-#724 schema.
+ *
  * Recompute FSRS state for every review in the database.
  *
  * Why this script exists

--- a/src/features/review/bury-siblings.test.ts
+++ b/src/features/review/bury-siblings.test.ts
@@ -31,7 +31,7 @@ function makeReview(
 		day_session: overrides.created_at.slice(0, 10),
 		lang: 'hin',
 		score: 3,
-		day_first_review: true,
+		stage: 1,
 		difficulty: 5,
 		review_time_retrievability: null,
 		stability: 3,
@@ -139,21 +139,21 @@ describe('decideBuryDirection — Rule 1 (reverse failed twice)', () => {
 				direction: 'reverse',
 				created_at: dayBefore(NOW, 5),
 				score: 3,
-				day_first_review: true,
+				stage: 1,
 			}),
 			makeReview({
 				phrase_id: P1,
 				direction: 'reverse',
 				created_at: dayBefore(NOW, 5),
 				score: 1,
-				day_first_review: false,
+				stage: 3,
 			}),
 			makeReview({
 				phrase_id: P1,
 				direction: 'reverse',
 				created_at: dayBefore(NOW, 5),
 				score: 1,
-				day_first_review: false,
+				stage: 3,
 			}),
 		]
 		// Identical FSRS state on both → Rule 2 ties to forward (bury reverse).

--- a/src/features/review/bury-siblings.ts
+++ b/src/features/review/bury-siblings.ts
@@ -35,6 +35,7 @@ import type { CardReviewType } from './schemas'
 import type { CardDirectionType } from '@/features/deck/schemas'
 import type { uuid } from '@/types/main'
 import { retrievability } from './fsrs'
+import { isScoringReview } from './review-utils'
 import { dateDiff } from '@/lib/utils'
 
 export interface BurySiblingCandidate {
@@ -86,7 +87,7 @@ function reverseFailedTwiceInARow(
 			(r) =>
 				r.phrase_id === phrase_id &&
 				r.direction === 'reverse' &&
-				r.day_first_review === true
+				isScoringReview(r)
 		)
 		.toSorted((a, b) =>
 			a.day_session === b.day_session

--- a/src/features/review/find-chain-predecessor.test.ts
+++ b/src/features/review/find-chain-predecessor.test.ts
@@ -22,7 +22,7 @@ function makeReview(
 		day_session: overrides.created_at.slice(0, 10),
 		lang: 'hin',
 		score: 3,
-		day_first_review: true,
+		stage: 1,
 		difficulty: 5,
 		review_time_retrievability: null,
 		stability: 3,
@@ -90,21 +90,21 @@ describe('findChainPredecessor', () => {
 		expect(pred?.direction).toBe('forward')
 	})
 
-	it('skips phase-3 rows (day_first_review=false)', () => {
-		// Even if a phase-3 row exists in an earlier session (shouldn't happen
-		// post-reclassify, but defensive), it shouldn't feed the scheduling
-		// chain. Only phase-1 rows do.
+	it('skips again-round rows (stage 3)', () => {
+		// Even if an again-round row exists in an earlier session (shouldn't
+		// happen normally, but defensive), it shouldn't feed the scheduling
+		// chain. Only scoring rows (stages 1–2) do.
 		const phase1 = makeReview({
 			phrase_id: P1,
 			direction: 'forward',
 			created_at: '2025-06-01T08:00:00Z',
-			day_first_review: true,
+			stage: 1,
 		})
 		const phase3 = makeReview({
 			phrase_id: P1,
 			direction: 'forward',
 			created_at: '2025-06-10T08:30:00Z',
-			day_first_review: false,
+			stage: 3,
 		})
 		const pred = findChainPredecessor(
 			[phase1, phase3],

--- a/src/features/review/fsrs.parity.test.ts
+++ b/src/features/review/fsrs.parity.test.ts
@@ -47,7 +47,7 @@ function mockReview(overrides: Partial<CardReviewType> = {}): CardReviewType {
 		phrase_id: '33333333-3333-4333-8333-333333333333',
 		direction: 'forward',
 		score: 3,
-		day_first_review: true,
+		stage: 1,
 		difficulty: null,
 		stability: null,
 		review_time_retrievability: null,

--- a/src/features/review/hooks.ts
+++ b/src/features/review/hooks.ts
@@ -12,7 +12,7 @@ import {
 import { PostgrestError } from '@supabase/supabase-js'
 import { cardReviewsCollection, reviewDaysCollection } from './collections'
 import { cardsCollection } from '@/features/deck/collections'
-import { and, eq, lt, useLiveQuery } from '@tanstack/react-db'
+import { and, eq, inArray, lt, useLiveQuery } from '@tanstack/react-db'
 import {
 	CardReviewSchema,
 	type CardReviewType,
@@ -27,6 +27,7 @@ import {
 	findChainPredecessor,
 	getIndexOfNextAgainCard,
 	getIndexOfNextUnreviewedCard,
+	isScoringReview,
 	type ReviewsMap,
 	type ReviewStages,
 } from './review-utils'
@@ -40,7 +41,7 @@ interface PostReviewInput {
 	direction: CardDirectionType
 	score: Score
 	day_session: string
-	day_first_review: boolean
+	stage: number
 	previousReview?: CardReviewType
 }
 
@@ -51,15 +52,16 @@ const postReview = async (submitData: PostReviewInput) => {
 		direction,
 		score,
 		day_session,
-		day_first_review,
+		stage,
 		previousReview,
 	} = submitData
 
-	// Calculate FSRS values client-side
-	const fsrs = calculateFSRS({
-		score,
-		previousReview,
-	})
+	// Calculate FSRS values client-side. Stage-3 (again-round) rows are
+	// tracking-only — they carry null FSRS columns and never feed scheduling —
+	// so only the scoring stages compute real values.
+	const fsrs = isScoringReview({ stage })
+		? calculateFSRS({ score, previousReview })
+		: { difficulty: null, stability: null, retrievability: null }
 
 	// Direct insert - CHECK constraints on table validate the values
 	const { data } = await supabase
@@ -70,7 +72,7 @@ const postReview = async (submitData: PostReviewInput) => {
 			direction,
 			score,
 			day_session,
-			day_first_review,
+			stage,
 			difficulty: fsrs.difficulty,
 			stability: fsrs.stability,
 			review_time_retrievability: fsrs.retrievability,
@@ -119,8 +121,8 @@ function mapToStats(
 	manifest: Array<ManifestEntry>,
 	allReviews: Array<CardReviewType> = []
 ) {
-	// First-try reviews: day_first_review=true reviews only
-	const firstTryReviews = allReviews.filter((r) => r.day_first_review === true)
+	// First-try reviews: scoring-pass reviews only (stages 1–2)
+	const firstTryReviews = allReviews.filter(isScoringReview)
 	// First-try success: recalled on first attempt (score > 1)
 	const firstTrySuccess = firstTryReviews.filter((r) => r.score > 1).length
 	const firstTryTotal = firstTryReviews.length
@@ -288,10 +290,10 @@ export function useOneReviewToday(
 }
 
 /**
- * Get the most recent phase-1 review for a phrase+direction (any day, not just today).
+ * Get the most recent scoring review for a phrase+direction (any day, not just today).
  * Used for FSRS calculations which need the previous difficulty/stability.
- * Filters to day_first_review=true so phase-3 re-reviews (which have throwaway
- * initial FSRS values) never feed into the scheduling chain.
+ * Filters to the scoring stages (1–2) so again-round re-reviews (which carry
+ * null FSRS values) never feed into the scheduling chain.
  */
 export function useLatestReviewForPhrase(
 	pid: uuid,
@@ -305,7 +307,7 @@ export function useLatestReviewForPhrase(
 					and(
 						eq(review.phrase_id, pid),
 						eq(review.direction, direction),
-						eq(review.day_first_review, true)
+						inArray(review.stage, [1, 2])
 					)
 				)
 				.orderBy(({ review }) => review.created_at, 'desc')
@@ -316,7 +318,7 @@ export function useLatestReviewForPhrase(
 }
 
 /**
- * The chain predecessor: the most recent phase-1 review from a session
+ * The chain predecessor: the most recent scoring review from a session
  * strictly earlier than `day_session`. Use this — not `useLatestReviewForPhrase`
  * — when you need "where was the card before today" for display (e.g. the
  * interval badges on each answer button). If today's row has already been
@@ -337,7 +339,7 @@ export function useChainPredecessorForPhrase(
 					and(
 						eq(review.phrase_id, pid),
 						eq(review.direction, direction),
-						eq(review.day_first_review, true),
+						inArray(review.stage, [1, 2]),
 						lt(review.day_session, day_session)
 					)
 				)
@@ -381,26 +383,29 @@ export function useReviewMutation(
 				stage,
 			})
 
-			// Stage 1-2: First pass through cards + skipped (day_first_review=true)
-			// - If same score as existing review, noop
-			// - If different score and review exists, update it
-			// - Otherwise insert new review
+			// Stages 1-2 (scoring pass): the first pass through the manifest plus
+			// the go-back pass for skipped cards. These are the reviews FSRS reads.
+			// - same score as the existing row → noop
+			// - different score on an existing row → correction, update in place
+			// - otherwise → insert a new scoring review at the current stage
 			if (stage < 3) {
 				if (prevDataToday?.score === score) {
 					return { action: 'noop', row: prevDataToday }
 				}
 				if (prevDataToday?.id) {
-					console.log(`Phase 1-2: Updating existing review`, {
+					console.log(`Scoring pass: correcting existing review`, {
 						prevDataToday,
 						score,
 					})
+					// Correction: the user went back and re-scored a card they already
+					// answered this session. Amend the existing row rather than append.
 					// `latestReview` (from useLatestReviewForPhrase) is the newest
-					// phase-1 row for this (pid, direction) — which IS prevDataToday
-					// whenever we're in this branch. Using it as previousReview
-					// would feed the row we're overwriting back into itself; using
-					// `undefined` wipes the prior chain and rewrites with brand-new-
-					// card values. Instead, look up the chain's predecessor — the
-					// newest phase-1 review from any strictly earlier session.
+					// scoring row for this (pid, direction) — which IS prevDataToday
+					// whenever we're in this branch. Using it as previousReview would
+					// feed the row we're overwriting back into itself; `undefined`
+					// wipes the prior chain and rewrites with brand-new-card values.
+					// Instead, look up the chain's predecessor — the newest scoring
+					// review from any strictly earlier session.
 					const chainPredecessor = findChainPredecessor(
 						cardReviewsCollection.toArray,
 						pid,
@@ -416,11 +421,12 @@ export function useReviewMutation(
 						}),
 					}
 				}
-				// First review for this card today
-				console.log(`Phase 1-2: Creating first review`, {
+				// First scoring review for this card today.
+				console.log(`Scoring pass: creating review`, {
 					pid,
 					direction,
 					score,
+					stage,
 				})
 				return {
 					action: 'insert',
@@ -430,66 +436,29 @@ export function useReviewMutation(
 						lang,
 						direction,
 						day_session,
-						day_first_review: true,
+						stage,
 						previousReview: latestReview,
 					}),
 				}
 			}
 
-			// Phase 3+: Re-review of "Again" cards (day_first_review=false).
-			// Phase-3 rows are tracking-only (never read for scheduling), so we
-			// copy the same-session phase-1 review's FSRS values directly onto
-			// them — that's the snapshot that actually reflects the card's
-			// state. `latestReview` is filtered to day_first_review=true and
-			// is by definition the same-session phase-1 here (you can't reach
-			// phase-3 without having done phase-1 today).
-			if (!latestReview) {
-				throw new Error(
-					'Phase-3 review requires a same-session phase-1 review to copy from'
-				)
-			}
-			const phase3Fsrs = {
-				difficulty: latestReview.difficulty,
-				stability: latestReview.stability,
-				review_time_retrievability: latestReview.review_time_retrievability,
-			}
-
-			if (prevDataToday?.day_first_review === false) {
-				console.log(`Phase 3: Updating existing phase-3 review`, {
-					prevDataToday,
-					score,
-				})
-				const { data } = await supabase
-					.from('user_card_review')
-					.update({
-						score,
-						...phase3Fsrs,
-						updated_at: new Date().toISOString(),
-					})
-					.eq('id', prevDataToday.id)
-					.select()
-					.single()
-					.throwOnError()
-				return { action: 'update', row: data }
-			}
-
-			// First phase-3 review for this card
-			console.log(`Phase 3: Creating phase-3 review`, { pid, direction, score })
-			const { data } = await supabase
-				.from('user_card_review')
-				.insert({
+			// Stage 3 (again-round): re-reviews of "Again" cards. Append-only —
+			// each tap becomes its own tracking row with null FSRS columns, so how
+			// many times a card was retried is counted rather than overwritten.
+			// There is no back button in this stage, so there are no corrections
+			// to amend; every tap inserts.
+			console.log(`Again-round: appending review`, { pid, direction, score })
+			return {
+				action: 'insert',
+				row: await postReview({
+					score: score as Score,
 					phrase_id: pid,
 					lang,
 					direction,
-					score,
 					day_session,
-					day_first_review: false,
-					...phase3Fsrs,
-				})
-				.select()
-				.single()
-				.throwOnError()
-			return { action: 'insert', row: data }
+					stage: 3,
+				}),
+			}
 		},
 		onSuccess: (data) => {
 			console.log(`mutation returns:`, data)
@@ -509,10 +478,10 @@ export function useReviewMutation(
 					)
 				}
 
-				// Only sync card scheduling state from phase-1 reviews.
-				// Phase-3 reviews are for tracking only — their FSRS values are
-				// throwaway initial values that would corrupt the scheduling chain.
-				if (data.row.day_first_review) {
+				// Only sync card scheduling state from scoring reviews (stages 1–2).
+				// Again-round rows are for tracking only — they carry null FSRS
+				// values that would corrupt the scheduling chain.
+				if (isScoringReview(data.row)) {
 					const existingCard = cardsCollection.toArray.find(
 						(c) =>
 							c.phrase_id === data.row.phrase_id &&

--- a/src/features/review/review-map.test.ts
+++ b/src/features/review/review-map.test.ts
@@ -30,7 +30,7 @@ function makeReview(
 		day_session: '2025-06-01',
 		lang: 'hin',
 		score: 3,
-		day_first_review: true,
+		stage: 1,
 		difficulty: 5,
 		review_time_retrievability: null,
 		stability: 3,
@@ -65,29 +65,29 @@ describe('buildReviewsMap', () => {
 	})
 
 	it('last review wins when multiple reviews exist for the same card', () => {
-		// In a single session a card may be reviewed in phase 1 (day_first_review=true)
-		// and again in phase 3 (day_first_review=false).  The array is ordered
-		// chronologically (ASC), so the phase-3 review — which comes last — wins.
+		// In a single session a card may be reviewed in the scoring pass (stage 1)
+		// and again in the again-round (stage 3).  The array is ordered
+		// chronologically (ASC), so the again-round review — which comes last — wins.
 		const phase1 = makeReview({
 			phrase_id: P1,
 			direction: 'forward',
 			score: 1,
-			day_first_review: true,
+			stage: 1,
 			created_at: '2025-06-01T12:00:00Z',
 		})
 		const phase3 = makeReview({
 			phrase_id: P1,
 			direction: 'forward',
 			score: 3,
-			day_first_review: false,
+			stage: 3,
 			created_at: '2025-06-01T12:30:00Z',
 		})
 
 		const map = buildReviewsMap([phase1, phase3])
 
 		const key = toManifestEntry(P1, 'forward')
-		expect(map[key]?.score).toBe(3) // phase-3 score wins
-		expect(map[key]?.day_first_review).toBe(false) // phase-3 review
+		expect(map[key]?.score).toBe(3) // again-round score wins
+		expect(map[key]?.stage).toBe(3) // again-round review
 	})
 
 	it('does not cross-contaminate between phrases or directions', () => {

--- a/src/features/review/review-utils.ts
+++ b/src/features/review/review-utils.ts
@@ -22,6 +22,18 @@ export type ReviewsMap = {
 	[key: ManifestEntry]: CardReviewType
 }
 
+/**
+ * A scoring review — one FSRS reads for scheduling. These are recorded in the
+ * session's first pass (stage 1) or the go-back pass (stage 2). Again-round
+ * re-reviews (stage 3) are tracking-only and never feed the scheduling chain.
+ * Replaces the old `day_first_review === true` predicate.
+ */
+export function isScoringReview(
+	review: Pick<CardReviewType, 'stage'>
+): boolean {
+	return review.stage === 1 || review.stage === 2
+}
+
 /** Build a ReviewsMap keyed by manifest entry (phrase_id:direction) */
 export function buildReviewsMap(reviews: Array<CardReviewType>): ReviewsMap {
 	const map: ReviewsMap = {}
@@ -43,7 +55,7 @@ export function firstTryReviewMap(
 ): Map<ManifestEntry, CardReviewType> {
 	return new Map(
 		reviews
-			.filter((r) => r.day_first_review === true)
+			.filter(isScoringReview)
 			.map((r) => [toManifestEntry(r.phrase_id, r.direction), r])
 	)
 }
@@ -92,7 +104,7 @@ export function findChainPredecessor(
 	for (const r of reviews) {
 		if (r.phrase_id !== pid) continue
 		if (r.direction !== direction) continue
-		if (!r.day_first_review) continue
+		if (!isScoringReview(r)) continue
 		if (r.day_session >= beforeSession) continue
 		// Pick the newest by session; tiebreak by created_at only if two
 		// phase-1 rows share a session (shouldn't happen post-reclassify).
@@ -117,7 +129,7 @@ export function getIndexOfNextAgainCard(
 		const indexChecking = (i + currentCardIndex + 1) % manifest.length
 		return reviewsMap[manifest[indexChecking]]?.score === 1
 	})
-	return index !== -1 ?
-			(index + currentCardIndex + 1) % manifest.length
-		:	manifest.length
+	return index !== -1
+		? (index + currentCardIndex + 1) % manifest.length
+		: manifest.length
 }

--- a/src/features/review/schemas.ts
+++ b/src/features/review/schemas.ts
@@ -12,7 +12,11 @@ export const CardReviewSchema = z.object({
 	phrase_id: z.string().uuid(),
 	direction: CardDirectionSchema.default('forward'),
 	score: z.number(),
-	day_first_review: z.boolean(),
+	// Which session stage recorded this review, mirroring
+	// `user_deck_review_state.stage`: 1 = first pass, 2 = go-back pass,
+	// 3 = again-round re-review. FSRS reads only the scoring stages (1–2);
+	// stage-3 rows are tracking-only and carry null FSRS columns.
+	stage: z.number().int().min(1).max(3),
 	difficulty: z.number().nullable(),
 	review_time_retrievability: z.number().nullable(),
 	stability: z.number().nullable(),

--- a/src/features/review/store.test.ts
+++ b/src/features/review/store.test.ts
@@ -40,7 +40,7 @@ function stubReview(score: number): CardReviewType {
 		phrase_id: P1,
 		direction: 'forward',
 		score,
-		day_first_review: true,
+		stage: 1,
 		difficulty: 5,
 		review_time_retrievability: null,
 		stability: 3,

--- a/src/lib/fsrs.test.ts
+++ b/src/lib/fsrs.test.ts
@@ -21,7 +21,7 @@ function mockReview(overrides: Partial<CardReviewType> = {}): CardReviewType {
 		phrase_id: '22222222-2222-4222-8222-222222222222',
 		direction: 'forward',
 		score: 3,
-		day_first_review: true,
+		stage: 1,
 		difficulty: 5.0,
 		stability: 10.0,
 		review_time_retrievability: 0.9,
@@ -507,20 +507,18 @@ describe('direction isolation', () => {
 // ---------------------------------------------------------------------------
 // During a review session, cards go through up to two phases:
 //
-// Phase 1 (day_first_review=true):
+// Phase 1 (stage 1–2, a scoring review):
 //   The first time you see each card today. FSRS is calculated normally,
 //   using the most recent PRIOR review (from a previous day) as the base.
 //   This is the review that matters for long-term scheduling.
 //
-// Phase 3 (day_first_review=false):
+// Phase 3 (stage 3, the again-round):
 //   Re-review of cards you scored Again in phase 1. These rows are
-//   tracking-only and never feed scheduling, so the mutation copies the
-//   same-session phase-1 review's FSRS values directly onto them — that's
-//   the meaningful snapshot of the card's state at that moment.
+//   tracking-only and never feed scheduling — they carry null FSRS columns.
 //
-// IMPORTANT: The onSuccess handler skips card sync for phase-3 reviews, and
-// useLatestReviewForPhrase filters to day_first_review=true. This ensures
-// the NEXT day's FSRS builds on the phase-1 values, not phase-3 rows.
+// IMPORTANT: The onSuccess handler skips card sync for again-round reviews, and
+// useLatestReviewForPhrase filters to the scoring stages (1–2). This ensures
+// the NEXT day's FSRS builds on the phase-1 values, not stage-3 rows.
 // See the scheduling tests below.
 //
 // The tests in this section verify `calculateFSRS` behavior when called
@@ -607,8 +605,8 @@ describe('phase 1 vs phase 3 FSRS values', () => {
 	})
 
 	describe('scheduling uses phase-1 values (phase-3 excluded from chain)', () => {
-		// After the fix, useLatestReviewForPhrase filters to day_first_review=true,
-		// and onSuccess skips card sync for phase-3 reviews. This means next-day
+		// After the fix, useLatestReviewForPhrase filters to the scoring stages
+		// (1–2), and onSuccess skips card sync for stage-3 reviews. Next-day
 		// FSRS always builds on the phase-1 review, not the phase-3 re-review.
 		//
 		// A card scored Again in phase 1 but Good in phase 3 will be scheduled
@@ -627,7 +625,7 @@ describe('phase 1 vs phase 3 FSRS values', () => {
 				currentTime: new Date('2025-06-01T12:30:00Z'),
 			})
 
-			// Next day: FSRS should build on the phase-1 review (day_first_review=true)
+			// Next day: FSRS should build on the phase-1 review (a scoring stage)
 			const nextDay = new Date('2025-06-02T12:00:00Z')
 
 			const scheduledFromPhase1 = calculateFSRS({
@@ -636,7 +634,7 @@ describe('phase 1 vs phase 3 FSRS values', () => {
 					difficulty: phase1.difficulty,
 					stability: phase1.stability,
 					created_at: '2025-06-01T12:00:00Z',
-					day_first_review: true,
+					stage: 1,
 				}),
 				currentTime: nextDay,
 			})
@@ -649,7 +647,7 @@ describe('phase 1 vs phase 3 FSRS values', () => {
 					difficulty: phase3.difficulty,
 					stability: phase3.stability,
 					created_at: '2025-06-01T12:30:00Z',
-					day_first_review: false,
+					stage: 3,
 				}),
 				currentTime: nextDay,
 			})
@@ -682,7 +680,7 @@ describe('phase 1 vs phase 3 FSRS values', () => {
 					difficulty: phase1Again.difficulty,
 					stability: phase1Again.stability,
 					created_at: '2025-06-01T12:00:00Z',
-					day_first_review: true,
+					stage: 1,
 				}),
 				currentTime: nextDay,
 			})
@@ -694,7 +692,7 @@ describe('phase 1 vs phase 3 FSRS values', () => {
 					difficulty: phase1Good.difficulty,
 					stability: phase1Good.stability,
 					created_at: '2025-06-01T12:00:00Z',
-					day_first_review: true,
+					stage: 1,
 				}),
 				currentTime: nextDay,
 			})

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1316,7 +1316,6 @@ export type Database = {
 			user_card_review: {
 				Row: {
 					created_at: string
-					day_first_review: boolean
 					day_session: string
 					difficulty: number | null
 					direction: Database['public']['Enums']['card_direction']
@@ -1326,12 +1325,12 @@ export type Database = {
 					review_time_retrievability: number | null
 					score: number
 					stability: number | null
+					stage: number
 					uid: string
 					updated_at: string
 				}
 				Insert: {
 					created_at?: string
-					day_first_review?: boolean
 					day_session: string
 					difficulty?: number | null
 					direction?: Database['public']['Enums']['card_direction']
@@ -1341,12 +1340,12 @@ export type Database = {
 					review_time_retrievability?: number | null
 					score: number
 					stability?: number | null
+					stage: number
 					uid?: string
 					updated_at?: string
 				}
 				Update: {
 					created_at?: string
-					day_first_review?: boolean
 					day_session?: string
 					difficulty?: number | null
 					direction?: Database['public']['Enums']['card_direction']
@@ -1356,6 +1355,7 @@ export type Database = {
 					review_time_retrievability?: number | null
 					score?: number
 					stability?: number | null
+					stage?: number
 					uid?: string
 					updated_at?: string
 				}

--- a/supabase/migrations/20260715120000_add_stage_to_user_card_review.sql
+++ b/supabase/migrations/20260715120000_add_stage_to_user_card_review.sql
@@ -1,0 +1,170 @@
+-- Migration: add `stage` to user_card_review, go append-only, retire day_first_review
+--
+-- See issue #724. `day_first_review` conflated two facts — *where* in the
+-- session a review happened, and *whether* FSRS should read it. We replace it
+-- with `stage`, reusing the numbering from `user_deck_review_state.stage`:
+--   1 = first review pass
+--   2 = go-back pass (cards skipped in stage 1)
+--   3 = again-round re-reviews (tracking-only; FSRS columns stay null)
+-- Scheduling relevance becomes the predicate `stage in (1, 2)` instead of a flag.
+--
+-- Reviews become append-only: each again-tap is now its own row rather than
+-- overwriting one row per card per day, so the count of retries is preserved.
+-- Corrections in the scoring pass still update in place (client-side), with
+-- `updated_at` as the tell.
+-- 1. Add the column, nullable so the backfill can run.
+alter table "public"."user_card_review"
+add column "stage" smallint;
+
+-- 2. Backfill from day_first_review: scoring reviews -> stage 1, re-reviews ->
+--    stage 3. Historical go-back (stage 2) reviews are indistinguishable from
+--    stage 1 here and backfill as 1 — harmless, both satisfy `stage in (1, 2)`.
+update "public"."user_card_review"
+set
+	"stage" = case
+		when "day_first_review" then 1
+		else 3
+	end;
+
+-- 3. Lock it down: every row now has a stage, and only 1-3 are valid on a
+--    review row (the session's stages 4/5 never write a review).
+alter table "public"."user_card_review"
+alter column "stage"
+set not null;
+
+alter table "public"."user_card_review"
+add constraint "user_card_review_stage_check" check (("stage" = any (array[1, 2, 3])));
+
+-- 4. Flip the server-side reader of per-card scheduling state. `user_card_plus`
+--    picks each card's latest review to derive FSRS state (difficulty,
+--    stability, last_reviewed_at, retrievability_now); the client's `cards`
+--    collection reads from it. It must now pick the latest *scoring* review
+--    (stage 1-2) so that append-only stage-3 rows — which carry null FSRS —
+--    never mask a card's real scheduling state. Output columns are unchanged,
+--    so `create or replace` is safe.
+create or replace view "public"."user_card_plus"
+with
+	("security_invoker" = 'true') as
+with
+	"review" as (
+		select
+			"rev"."id",
+			"rev"."uid",
+			"rev"."score",
+			"rev"."difficulty",
+			"rev"."stability",
+			"rev"."review_time_retrievability",
+			"rev"."created_at",
+			"rev"."updated_at",
+			"rev"."day_session",
+			"rev"."lang",
+			"rev"."phrase_id",
+			"rev"."direction"
+		from
+			(
+				"public"."user_card_review" "rev"
+				left join "public"."user_card_review" "rev2" on (
+					(
+						("rev"."phrase_id" = "rev2"."phrase_id")
+						and ("rev"."uid" = "rev2"."uid")
+						and ("rev"."direction" = "rev2"."direction")
+						and ("rev"."created_at" < "rev2"."created_at")
+						and ("rev2"."stage" = any (array[1, 2]))
+					)
+				)
+			)
+		where
+			("rev2"."created_at" is null)
+			and ("rev"."stage" = any (array[1, 2]))
+	)
+select
+	"card"."lang",
+	"card"."id",
+	"card"."uid",
+	"card"."status",
+	"card"."phrase_id",
+	"card"."direction",
+	"card"."created_at",
+	"card"."updated_at",
+	"review"."created_at" as "last_reviewed_at",
+	"review"."difficulty",
+	"review"."stability",
+	current_timestamp as "current_timestamp",
+	nullif(
+		"power" (
+			(
+				1.0 + (
+					(
+						(19.0 / 81.0) * (
+							(
+								extract(
+									epoch
+									from
+										(current_timestamp - "review"."created_at")
+								) / 3600.0
+							) / 24.0
+						)
+					) / nullif("review"."stability", (0)::numeric)
+				)
+			),
+			'-0.5'::numeric
+		),
+		'NaN'::numeric
+	) as "retrievability_now"
+from
+	(
+		"public"."user_card" "card"
+		left join "review" on (
+			(
+				("card"."phrase_id" = "review"."phrase_id")
+				and ("card"."uid" = "review"."uid")
+				and ("card"."direction" = "review"."direction")
+			)
+		)
+	);
+
+-- 5. Same fix for `phrase_stats`, the community-difficulty view. Its
+--    `latest_reviews` CTE takes each learner's most recent review to average
+--    difficulty/stability across learners. It must skip again-round rows too,
+--    or a learner mid-again-round would contribute null FSRS. Output columns
+--    are unchanged, so dependent views survive `create or replace`.
+create or replace view "public"."phrase_stats" as
+with
+	"latest_reviews" as (
+		select distinct
+			on ("rev"."uid", "rev"."phrase_id") "rev"."uid",
+			"rev"."phrase_id",
+			"rev"."difficulty",
+			"rev"."stability"
+		from
+			"public"."user_card_review" "rev"
+		where
+			("rev"."stage" = any (array[1, 2]))
+		order by
+			"rev"."uid",
+			"rev"."phrase_id",
+			"rev"."created_at" desc
+	)
+select
+	"card"."phrase_id",
+	"count" (*) as "count_learners",
+	"avg" ("lr"."difficulty") as "avg_difficulty",
+	"avg" ("lr"."stability") as "avg_stability"
+from
+	(
+		"public"."user_card" "card"
+		left join "latest_reviews" "lr" on (
+			(
+				("lr"."phrase_id" = "card"."phrase_id")
+				and ("lr"."uid" = "card"."uid")
+			)
+		)
+	)
+where
+	("card"."status" = any (array['active'::"public"."card_status", 'learned'::"public"."card_status"]))
+group by
+	"card"."phrase_id";
+
+-- 6. Retire day_first_review — no reader references it anymore.
+alter table "public"."user_card_review"
+drop column "day_first_review";

--- a/supabase/schemas/base.sql
+++ b/supabase/schemas/base.sql
@@ -1335,7 +1335,7 @@ create table if not exists "public"."user_card_review" (
 	"day_session" "date" not null,
 	"lang" character varying not null,
 	"phrase_id" "uuid" not null,
-	"day_first_review" boolean default true not null,
+	"stage" smallint not null,
 	"direction" "public"."card_direction" default 'forward'::"public"."card_direction" not null,
 	constraint "user_card_review_difficulty_check" check (
 		(
@@ -1354,7 +1354,8 @@ create table if not exists "public"."user_card_review" (
 	),
 	constraint "user_card_review_score_check" check (("score" = any (array[1, 2, 3, 4]))),
 	constraint "user_card_review_stability_check" check (("stability" >= 0.0)),
-	constraint "user_card_review_stability_max_check" check (("stability" <= 36500.0))
+	constraint "user_card_review_stability_max_check" check (("stability" <= 36500.0)),
+	constraint "user_card_review_stage_check" check (("stage" = any (array[1, 2, 3])))
 );
 
 alter table "public"."user_card_review" owner to "postgres";
@@ -1369,6 +1370,8 @@ with
 			"rev"."stability"
 		from
 			"public"."user_card_review" "rev"
+		where
+			("rev"."stage" = any (array[1, 2]))
 		order by
 			"rev"."uid",
 			"rev"."phrase_id",
@@ -1970,11 +1973,13 @@ with
 						and ("rev"."uid" = "rev2"."uid")
 						and ("rev"."direction" = "rev2"."direction")
 						and ("rev"."created_at" < "rev2"."created_at")
+						and ("rev2"."stage" = any (array[1, 2]))
 					)
 				)
 			)
 		where
 			("rev2"."created_at" is null)
+			and ("rev"."stage" = any (array[1, 2]))
 	)
 select
 	"card"."lang",

--- a/supabase/seeds/seed-2-team1.sql
+++ b/supabase/seeds/seed-2-team1.sql
@@ -4346,7 +4346,7 @@ insert into
 		"day_session",
 		"lang",
 		"phrase_id",
-		"day_first_review",
+		"stage",
 		"direction"
 	)
 values
@@ -4362,7 +4362,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'1f6bac22-b32a-4b77-9857-d2de02b538de',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4377,7 +4377,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'12536684-0b35-4aff-80cd-f4ce56c866b6',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4392,7 +4392,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'163d7f57-a76f-4e5b-9346-1de5cfeba7d8',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4407,7 +4407,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'24a18665-a343-4960-99fc-7e5ed54accb0',
-		true,
+		1,
 		'reverse'
 	),
 	(
@@ -4422,7 +4422,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'24a18665-a343-4960-99fc-7e5ed54accb0',
-		false,
+		3,
 		'reverse'
 	),
 	(
@@ -4437,7 +4437,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'295fbba3-892c-43f9-84ba-85cf15fd28a5',
-		true,
+		1,
 		'reverse'
 	),
 	(
@@ -4452,7 +4452,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'4677f15a-1cd9-40a3-876c-30662c5eec3f',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4467,7 +4467,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'fa26ba78-a7a3-49f8-8516-034424477dec',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4482,7 +4482,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'93d5d050-e9af-4652-9c76-9dc2a232640a',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4497,7 +4497,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'b2736292-1137-41db-a453-ad203726d8c5',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4512,7 +4512,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'b2736292-1137-41db-a453-ad203726d8c5',
-		false,
+		3,
 		'forward'
 	),
 	(
@@ -4527,7 +4527,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'b2736292-1137-41db-a453-ad203726d8c5',
-		false,
+		3,
 		'forward'
 	),
 	(
@@ -4542,7 +4542,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'b2736292-1137-41db-a453-ad203726d8c5',
-		false,
+		3,
 		'forward'
 	),
 	(
@@ -4557,7 +4557,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'ed70550e-da8a-44dc-8bfd-69965375b7f9',
-		true,
+		1,
 		'reverse'
 	),
 	(
@@ -4572,7 +4572,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'ed70550e-da8a-44dc-8bfd-69965375b7f9',
-		false,
+		3,
 		'reverse'
 	),
 	(
@@ -4587,7 +4587,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'ed70550e-da8a-44dc-8bfd-69965375b7f9',
-		false,
+		3,
 		'reverse'
 	),
 	(
@@ -4602,7 +4602,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'c3c81fa4-9c63-4569-b9b6-9c931ee3154f',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4617,7 +4617,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'fd535752-d602-4ab8-8656-9e11692f30fc',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4632,7 +4632,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'c3c81fa4-9c63-4569-b9b6-9c931ee3154f',
-		false,
+		3,
 		'forward'
 	),
 	(
@@ -4647,7 +4647,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'fd535752-d602-4ab8-8656-9e11692f30fc',
-		false,
+		3,
 		'forward'
 	),
 	(
@@ -4662,7 +4662,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'tam',
 		'fd535752-d602-4ab8-8656-9e11692f30fc',
-		false,
+		3,
 		'forward'
 	),
 	(
@@ -4677,7 +4677,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'tam',
 		'fd535752-d602-4ab8-8656-9e11692f30fc',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4692,7 +4692,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'tam',
 		'163d7f57-a76f-4e5b-9346-1de5cfeba7d8',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4707,7 +4707,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'tam',
 		'93d5d050-e9af-4652-9c76-9dc2a232640a',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4722,7 +4722,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'tam',
 		'fa26ba78-a7a3-49f8-8516-034424477dec',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4737,7 +4737,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'tam',
 		'c3c81fa4-9c63-4569-b9b6-9c931ee3154f',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4752,7 +4752,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'tam',
 		'ed70550e-da8a-44dc-8bfd-69965375b7f9',
-		true,
+		1,
 		'reverse'
 	),
 	(
@@ -4767,7 +4767,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'tam',
 		'c5c8cf9b-bf1a-4d4a-aff6-21b8dc86fcc9',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4782,7 +4782,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'tam',
 		'b2736292-1137-41db-a453-ad203726d8c5',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4797,7 +4797,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'tam',
 		'a875f6e4-a8cc-4f68-baf3-ca2aea273568',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4812,7 +4812,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'tam',
 		'a00febfd-e6d6-40bc-a3b8-e31563410db8',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4827,7 +4827,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'tam',
 		'97f2f7cb-a1c5-4bb1-a93b-d475fa96ae68',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4842,7 +4842,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'tam',
 		'4b7b3741-16ce-4ce8-a9b8-70556451a8e5',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4857,7 +4857,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'tam',
 		'49066ea2-e608-42ab-8817-1f20b0eada03',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4872,7 +4872,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'tam',
 		'4677f15a-1cd9-40a3-876c-30662c5eec3f',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4887,7 +4887,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'tam',
 		'44bcd224-b4b3-46ce-b260-2136712b0907',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4902,7 +4902,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'kan',
 		'b9e3edac-de8b-4796-b436-a0cded08d2ae',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4917,7 +4917,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'kan',
 		'c1cc1a36-1b77-41bf-9a05-6e7914d256e2',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4932,7 +4932,7 @@ values
 		(now() - interval '4 days' - interval '4 hours')::date,
 		'kan',
 		'b7247f31-3758-47ea-bdf8-1c2a7ff161ed',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4947,7 +4947,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'hin',
 		'235ce61c-be21-4697-815d-d5aa1a4ff121',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4962,7 +4962,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'hin',
 		'f1f5234e-0426-44f5-a007-b67329a70a81',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4977,7 +4977,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'hin',
 		'170f5fd4-58f8-4b05-aba4-23522f35800f',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -4992,7 +4992,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'hin',
 		'0e33be07-6d4a-4c99-8282-921038188cbf',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5007,7 +5007,7 @@ values
 		(now() - interval '3 days' - interval '4 hours')::date,
 		'hin',
 		'7dd33e23-2b6d-4b1f-bc8c-1da690d14bfb',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5022,7 +5022,7 @@ values
 		(now() - interval '32 hours' - interval '4 hours')::date,
 		'hin',
 		'9a2bc2c8-7d7a-4ddd-8eed-2812bbf73471',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5037,7 +5037,7 @@ values
 		(now() - interval '32 hours' - interval '4 hours')::date,
 		'hin',
 		'fae20b24-42dc-4b9e-aebc-22afcdfc4689',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5052,7 +5052,7 @@ values
 		(now() - interval '32 hours' - interval '4 hours')::date,
 		'hin',
 		'48edc28c-1530-4549-b48c-f678033a6892',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5067,7 +5067,7 @@ values
 		(now() - interval '32 hours' - interval '4 hours')::date,
 		'hin',
 		'cc3847f3-b151-401e-80c9-4aef221c54b5',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5082,7 +5082,7 @@ values
 		(now() - interval '32 hours' - interval '4 hours')::date,
 		'hin',
 		'8167b776-fc93-4e3f-b06e-5fa5818f2d3b',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5097,7 +5097,7 @@ values
 		(now() - interval '2 days' - interval '4 hours')::date,
 		'kan',
 		'b9e3edac-de8b-4796-b436-a0cded08d2ae',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5112,7 +5112,7 @@ values
 		(now() - interval '2 days' - interval '4 hours')::date,
 		'kan',
 		'c1cc1a36-1b77-41bf-9a05-6e7914d256e2',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5127,7 +5127,7 @@ values
 		(now() - interval '2 days' - interval '4 hours')::date,
 		'kan',
 		'aa110001-1111-4aaa-bbbb-cccccccccccc',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5142,7 +5142,7 @@ values
 		(now() - interval '2 days' - interval '4 hours')::date,
 		'kan',
 		'aa110002-2222-4aaa-bbbb-cccccccccccc',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5157,7 +5157,7 @@ values
 		(now() - interval '2 days' - interval '4 hours')::date,
 		'kan',
 		'aa110004-4444-4aaa-bbbb-cccccccccccc',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5172,7 +5172,7 @@ values
 		(now() - interval '2 days' - interval '4 hours')::date,
 		'kan',
 		'aa110008-8888-4aaa-bbbb-cccccccccccc',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5187,7 +5187,7 @@ values
 		(now() - interval '2 days' - interval '4 hours')::date,
 		'kan',
 		'b0fbbe1d-705e-4d93-a231-ac55263fcfee',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5202,7 +5202,7 @@ values
 		(now() - interval '32 hours' - interval '4 hours')::date,
 		'hin',
 		'0e33be07-6d4a-4c99-8282-921038188cbf',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5217,7 +5217,7 @@ values
 		(now() - interval '32 hours' - interval '4 hours')::date,
 		'hin',
 		'48fe0624-f586-4812-a1a5-33c634995671',
-		true,
+		1,
 		'forward'
 	),
 	(
@@ -5232,6 +5232,6 @@ values
 		(now() - interval '32 hours' - interval '4 hours')::date,
 		'hin',
 		'7dd33e23-2b6d-4b1f-bc8c-1da690d14bfb',
-		true,
+		1,
 		'forward'
 	);


### PR DESCRIPTION
Closes #724. Migration-track release branch `next-0.29.0` → `main`.

## What

Replaces the `day_first_review` boolean on `user_card_review` with a `stage` column (mirroring `user_deck_review_state.stage`): **1** = first pass, **2** = go-back pass, **3** = again-round. Scheduling relevance is now the predicate `stage IN (1, 2)` rather than a flag.

The again-round is now **append-only**: each 'again' tap writes its own row with null FSRS columns, so retries are counted instead of overwritten. Corrections in the scoring pass still update in place (`updated_at` is the tell). The phase-3 branch of `useReviewMutation`, its `prevDataToday` insert-vs-update dance, and the FSRS-copy hack all collapse into the same insert as phase 1.

## Migration (`20260715120000_add_stage_to_user_card_review.sql`)

1. Add `stage smallint`, backfill `day_first_review ? 1 : 3`, set `NOT NULL`, add a `1..3` check constraint.
2. Flip the server-side FSRS readers to `stage IN (1, 2)` — **two** views:
   - `user_card_plus` — latest scoring review per card (feeds the client `cards` collection).
   - `phrase_stats` — latest scoring review per learner (community difficulty averages).
   Both needed the filter because stage-3 rows now carry null FSRS; without it a card/learner mid-again-round would mask real scheduling state once the copy hack is gone. Output columns are unchanged, so dependent views (`phrase_meta`, `feed_activities`, `phrase_search_index`) survive `create or replace`.
3. Drop `day_first_review`.

## Client

- `stage` replaces `day_first_review` in the review schema and generated Supabase types.
- New `isScoringReview()` predicate (stage 1–2), threaded through `hooks` (`mapToStats`, `useLatestReviewForPhrase`, `useChainPredecessorForPhrase`, `onSuccess` card sync), `review-utils` (`firstTryReviewMap`, `findChainPredecessor`), and `bury-siblings`.
- Updated seed data, unit tests, and the review docs. The two out-of-CI maintenance scripts (`recompute-reviews`, `reclassify-phase1-duplicates`) carry deprecation banners rather than blind rewrites.

## Pre-implementation checks (from the issue)

- A card cannot receive two scoring reviews across stages 1–2: stage 2 only handles cards skipped in stage 1; re-scores in the scoring pass are in-place corrections, not new rows. So `day_first_review ≡ stage IN (1, 2)` holds.
- No unique constraint enforced one-row-per-card-per-day, so nothing to drop for append-only.
- FSRS is fully client-side (the plv8 RPCs were already removed), so `user_card_plus` and `phrase_stats` are the only server-side readers.

## Scope note

This carries the migration only — the release-ceremony bits (version bump `0.28.0` → `0.29.0`, `v0.29` CHANGELOG heading, tag) are still to do per `docs/deployment.md`.

## Verification

Local: `pnpm check` (0 type errors), `pnpm test:unit` (267/267), lint clean. Scenetest + prod build were not runnable locally (the `mhsnook/tailwind-oklch` git dependency is blocked by the sandbox egress proxy) — CI covers those here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcfH1dgU1VLAhi95ynfGui

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcfH1dgU1VLAhi95ynfGui)_