### PR TITLE
Migrate review session state to collections & localStorage

### DIFF
--- a/src/components/review/continue-review.tsx
+++ b/src/components/review/continue-review.tsx
@@ -28,10 +28,11 @@ export function ContinueReview({
 	const initLocalReviewState = useInitialiseReviewStore()
 
 	const progressString =
-		reviewStats.stage === 5 ? `All ${reviewStats.complete} cards complete!`
-		: reviewStats.stage >= 3 ?
-			`${reviewStats.again} remaining out of ${reviewStats.count} cards today`
-		:	`${reviewStats.complete} reviewed out of ${reviewStats.count} cards today`
+		reviewStats.stage === 5
+			? `All ${reviewStats.complete} cards complete!`
+			: reviewStats.stage >= 3
+				? `${reviewStats.again} remaining out of ${reviewStats.count} cards today`
+				: `${reviewStats.complete} reviewed out of ${reviewStats.count} cards today`
 	return (
 		<Card>
 			<CardHeader>
@@ -46,25 +47,26 @@ export function ContinueReview({
 					{dayjs(dayString).format('dddd')}: You already have a review in
 					progress for today.
 				</p>
-				{reviewStats.reviewed === 0 ?
+				{reviewStats.reviewed === 0 ? (
 					<p>
 						You've set up a review with {reviewStats.count} cards in it, but you
 						haven't started reviewing yet. Go ahead and get started!
 					</p>
-				: reviewStats.stage === 1 ?
+				) : reviewStats.stage === 1 ? (
 					<p>
 						Today's review session has {reviewStats.count} cards in it, and
 						you've reviewed {reviewStats?.reviewed ?? 0} of them. Continue where
 						you left off?
 					</p>
-				:	<p>
+				) : (
+					<p>
 						You've reviewed all {reviewStats.count} cards, but there{' '}
-						{reviewStats?.again === 1 ?
-							`is one card`
-						:	`are ${reviewStats.again} cards`}{' '}
+						{reviewStats?.again === 1
+							? `is one card`
+							: `are ${reviewStats.again} cards`}{' '}
 						left that you've asked to see again. Continue where you left off?
 					</p>
-				}
+				)}
 			</CardContent>
 			<CardFooter>
 				<Button
@@ -74,8 +76,6 @@ export function ContinueReview({
 							lang,
 							dayString,
 							reviewStats.count,
-							null, // newCardEntries not available when continuing
-							reviewStats.stage,
 							reviewStats.index
 						)
 					}

--- a/src/components/review/new-cards-preview.tsx
+++ b/src/components/review/new-cards-preview.tsx
@@ -8,14 +8,17 @@ import { CardContent } from '@/components/ui/card'
 import { LangBadge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import { usePhrase } from '@/hooks/composite-phrase'
-import { useNewCardEntries } from '@/features/review/store'
+import { and, eq, inArray, lt, useLiveQuery } from '@tanstack/react-db'
+import { cardReviewsCollection } from '@/features/review/collections'
 import type { uuid } from '@/types/main'
 import type { TranslationType } from '@/features/phrases/schemas'
 import type { CardDirectionType } from '@/features/deck/schemas'
 import {
 	parseManifestEntry,
+	toManifestEntry,
 	type ManifestEntry,
 } from '@/features/review/manifest'
+import { todayString } from '@/lib/utils'
 
 function PreviewCard({
 	pid,
@@ -57,18 +60,19 @@ function PreviewCard({
 			}
 		>
 			<CardContent className="flex flex-col items-center justify-center gap-3 p-4">
-				{isReverse ?
+				{isReverse ? (
 					<>
 						{translationsDisplay}
 						<Separator />
 						{phraseDisplay}
 					</>
-				:	<>
+				) : (
+					<>
 						{phraseDisplay}
 						<Separator />
 						{translationsDisplay}
 					</>
-				}
+				)}
 			</CardContent>
 		</CardlikeFlashcard>
 	)
@@ -80,21 +84,34 @@ export function NewCardsPreview({
 	manifest: Array<ManifestEntry>
 }) {
 	const { lang } = useParams({ strict: false })
-	const newCardEntries = useNewCardEntries()
 	const navigate = useNavigate()
 
 	const handleStartReview = () => {
 		void navigate({ to: '/learn/$lang/review/go', params: { lang: lang! } })
 	}
 
-	// Use the session's captured list of fresh-for-today entries. Filtering the
-	// manifest by "unreviewed" state is unreliable — last_reviewed_at comes from
-	// the user_card_plus view's "most recent review" join, which can be shaped
-	// by prior same-day (phase-3) reviews.
-	const newEntriesSet = new Set<ManifestEntry>(newCardEntries ?? [])
-	const unreviewedInOrder = manifest.filter((entry) =>
-		newEntriesSet.has(entry)
+	// "New" = never scored before today. Derive it from the card_review log —
+	// specifically prior-session scoring reviews (stages 1–2, day_session < today)
+	// — rather than the card's last_reviewed_at, which same-day again-round
+	// reviews can shape. An entry with no earlier-session scoring review is fresh.
+	const today = todayString()
+	const { data: priorReviews } = useLiveQuery(
+		(q) =>
+			q
+				.from({ review: cardReviewsCollection })
+				.where(({ review }) =>
+					and(
+						eq(review.lang, lang ?? ''),
+						inArray(review.stage, [1, 2]),
+						lt(review.day_session, today)
+					)
+				),
+		[lang, today]
 	)
+	const seenBefore = new Set<ManifestEntry>(
+		priorReviews.map((r) => toManifestEntry(r.phrase_id, r.direction))
+	)
+	const unreviewedInOrder = manifest.filter((entry) => !seenBefore.has(entry))
 
 	if (unreviewedInOrder.length === 0) {
 		// No unreviewed cards to preview - show helpful guidance

--- a/src/components/review/new-cards-preview.tsx
+++ b/src/components/review/new-cards-preview.tsx
@@ -8,17 +8,14 @@ import { CardContent } from '@/components/ui/card'
 import { LangBadge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import { usePhrase } from '@/hooks/composite-phrase'
-import { and, eq, inArray, lt, useLiveQuery } from '@tanstack/react-db'
-import { cardReviewsCollection } from '@/features/review/collections'
+import { useNewManifestEntries } from '@/features/review/hooks'
 import type { uuid } from '@/types/main'
 import type { TranslationType } from '@/features/phrases/schemas'
 import type { CardDirectionType } from '@/features/deck/schemas'
 import {
 	parseManifestEntry,
-	toManifestEntry,
 	type ManifestEntry,
 } from '@/features/review/manifest'
-import { todayString } from '@/lib/utils'
 
 function PreviewCard({
 	pid,
@@ -90,28 +87,7 @@ export function NewCardsPreview({
 		void navigate({ to: '/learn/$lang/review/go', params: { lang: lang! } })
 	}
 
-	// "New" = never scored before today. Derive it from the card_review log —
-	// specifically prior-session scoring reviews (stages 1–2, day_session < today)
-	// — rather than the card's last_reviewed_at, which same-day again-round
-	// reviews can shape. An entry with no earlier-session scoring review is fresh.
-	const today = todayString()
-	const { data: priorReviews } = useLiveQuery(
-		(q) =>
-			q
-				.from({ review: cardReviewsCollection })
-				.where(({ review }) =>
-					and(
-						eq(review.lang, lang ?? ''),
-						inArray(review.stage, [1, 2]),
-						lt(review.day_session, today)
-					)
-				),
-		[lang, today]
-	)
-	const seenBefore = new Set<ManifestEntry>(
-		priorReviews.map((r) => toManifestEntry(r.phrase_id, r.direction))
-	)
-	const unreviewedInOrder = manifest.filter((entry) => !seenBefore.has(entry))
+	const unreviewedInOrder = useNewManifestEntries(manifest, lang ?? '')
 
 	if (unreviewedInOrder.length === 0) {
 		// No unreviewed cards to preview - show helpful guidance

--- a/src/components/review/when-review-complete-screen.tsx
+++ b/src/components/review/when-review-complete-screen.tsx
@@ -4,7 +4,6 @@ import { Button, buttonVariants } from '@/components/ui/button'
 import { SuccessCheckmark } from '@/components/success-checkmark'
 import {
 	useReviewActions,
-	useReviewStage,
 	useReviewLang,
 	useReviewDayString,
 } from '@/features/review/store'
@@ -19,13 +18,13 @@ import { ReviewShareButton } from './review-share-button'
 export function WhenComplete() {
 	const lang = useReviewLang()
 	const dayString = useReviewDayString()
-	const storeStage = useReviewStage()
 	const actions = useReviewActions()
 	const { data: stats } = useReviewsTodayStats(lang, dayString)
 	const updateStage = useUpdateReviewStage(lang, dayString)
 
-	// Prefer ephemeral store stage (responsive) with server stage as fallback (cold load)
-	const stage = storeStage || stats?.stage
+	// Single source of truth: the milestone-derived stage (optimistic on tap,
+	// realtime across devices, mirrored to localStorage for cold loads).
+	const stage = stats?.stage ?? 0
 
 	const showWhich =
 		stats?.unreviewed && stage < 2 ? 'a' : stats?.again && stage < 5 ? 'b' : 'c'
@@ -59,7 +58,7 @@ export function WhenComplete() {
 						<Button
 							size="lg"
 							onClick={() => {
-								actions.gotoReviewUnreviewed(stats.firstUnreviewedIndex)
+								actions.gotoIndex(stats.firstUnreviewedIndex)
 								updateStage(2)
 							}}
 						>
@@ -69,7 +68,6 @@ export function WhenComplete() {
 							size="lg"
 							variant="neutral"
 							onClick={() => {
-								actions.skipReviewUnreviewed()
 								updateStage(3)
 							}}
 						>
@@ -88,7 +86,7 @@ export function WhenComplete() {
 						<Button
 							size="lg"
 							onClick={() => {
-								actions.gotoReviewAgains(stats.firstAgainIndex)
+								actions.gotoIndex(stats.firstAgainIndex)
 								updateStage(4)
 							}}
 						>
@@ -119,7 +117,6 @@ export function WhenComplete() {
 							variant="neutral"
 							size="lg"
 							onClick={() => {
-								actions.skipReviewAgains()
 								updateStage(5)
 							}}
 						>

--- a/src/components/review/when-review-complete-screen.tsx
+++ b/src/components/review/when-review-complete-screen.tsx
@@ -24,19 +24,17 @@ export function WhenComplete() {
 
 	// Single source of truth: the milestone-derived stage (optimistic on tap,
 	// realtime across devices, mirrored to localStorage for cold loads).
-	const stage = stats?.stage ?? 0
+	const stage = stats.stage
 
 	const showWhich =
-		stats?.unreviewed && stage < 2 ? 'a' : stats?.again && stage < 5 ? 'b' : 'c'
+		stats.unreviewed && stage < 2 ? 'a' : stats.again && stage < 5 ? 'b' : 'c'
 
 	// When the user naturally finishes (no skip button), persist stage 5
 	useEffect(() => {
-		if (showWhich === 'c' && stats?.stage && stats.stage < 5) {
+		if (showWhich === 'c' && stats.stage < 5) {
 			updateStage(5)
 		}
-	}, [showWhich, stats?.stage])
-
-	if (!stats) return null
+	}, [showWhich, stats.stage])
 
 	return (
 		<Card

--- a/src/features/review/hooks.ts
+++ b/src/features/review/hooks.ts
@@ -21,6 +21,7 @@ import {
 	type ReviewMilestoneType,
 } from './schemas'
 import { useUserId } from '@/lib/use-auth'
+import { todayString } from '@/lib/utils'
 import { calculateFSRS, type Score } from './fsrs'
 import type { CardDirectionType } from '@/features/deck/schemas'
 import { toManifestEntry, type ManifestEntry } from './manifest'
@@ -217,8 +218,8 @@ export function useReviewsTodayStats(lang: string, day_session: string) {
 		query.data.manifest ?? [],
 		query.data.reviews
 	)
-	// Use server-persisted stage when available, fall back to inferred
-	const stage = (query.data.stage as ReviewStages) ?? computed.inferred.stage
+	// Use the milestone-derived stage when present, fall back to inferred
+	const stage = query.data.stage ?? computed.inferred.stage
 	const index =
 		stage >= 5
 			? computed.count
@@ -227,11 +228,42 @@ export function useReviewsTodayStats(lang: string, day_session: string) {
 				: computed.firstUnreviewedIndex
 	return {
 		...query,
-		data: { ...computed, stage, index },
+		data: { ...computed, stage, index, reviewsMap: query.data.reviewsMap },
 	}
 }
 
 export type ReviewStats = ReturnType<typeof useReviewsTodayStats>['data']
+
+/**
+ * The manifest entries that are new for today — never scored in an earlier
+ * session. Derived from prior-session scoring reviews (`isScoringReview`, i.e.
+ * stages 1–2, from a `day_session` before today) rather than the card's
+ * `last_reviewed_at`, which same-day again-round reviews can shape. Replaces the
+ * session's old captured `newCardEntries` snapshot.
+ */
+export function useNewManifestEntries(
+	manifest: Array<ManifestEntry>,
+	lang: string
+): Array<ManifestEntry> {
+	const today = todayString()
+	const { data: priorReviews } = useLiveQuery(
+		(q) =>
+			q
+				.from({ review: cardReviewsCollection })
+				.where(({ review }) =>
+					and(
+						eq(review.lang, lang),
+						inArray(review.stage, [1, 2]),
+						lt(review.day_session, today)
+					)
+				),
+		[lang, today]
+	)
+	const seenBefore = new Set<ManifestEntry>(
+		priorReviews.map((r) => toManifestEntry(r.phrase_id, r.direction))
+	)
+	return manifest.filter((entry) => !seenBefore.has(entry))
+}
 
 export function useReviewDay(
 	lang: string,

--- a/src/features/review/hooks.ts
+++ b/src/features/review/hooks.ts
@@ -6,7 +6,6 @@ import {
 	useReviewActions,
 	useReviewDayString,
 	useReviewLang,
-	useReviewStage,
 } from './store'
 import { PostgrestError } from '@supabase/supabase-js'
 import {
@@ -150,22 +149,23 @@ export function useNextValid(): number {
 	const currentCardIndex = useCardIndex()
 	const lang = useReviewLang()
 	const day_session = useReviewDayString()
-	const stage = useReviewStage()
 	const { data: reviewsData } = useReviewsToday(lang, day_session)
-	const { manifest, reviewsMap } = reviewsData
+	const { manifest, reviewsMap, stage } = reviewsData
 	return (stage ?? 0) < 3
 		? getIndexOfNextUnreviewedCard(manifest!, reviewsMap, currentCardIndex)
 		: getIndexOfNextAgainCard(manifest!, reviewsMap, currentCardIndex)
 }
 
 /**
- * The server-persisted stage for a session: the `stage` of the latest
- * user_review_milestone. Replaces the old mutable `user_review_session.stage` —
- * progress is now an append-only log, so the newest milestone wins. Returns
- * undefined when no milestone has landed yet (brand-new session), which lets
- * callers fall back to the client-inferred stage.
+ * The current stage for a session: the `stage` of the latest
+ * user_review_milestone. Progress is an append-only log, so the newest
+ * milestone wins. The collection is realtime-synced *and* mirrored to
+ * localStorage (see PERSISTED_COLLECTIONS), so this resolves across devices
+ * and paints instantly on a cold reload — no separate store copy to go stale.
+ * Returns undefined when no milestone has landed yet (brand-new session),
+ * which lets callers fall back to the client-inferred stage.
  */
-export function useReviewStageServer(
+export function useReviewStage(
 	lang: string,
 	day_session: string
 ): ReviewStages | undefined {
@@ -198,7 +198,7 @@ export function useReviewsToday(lang: string, day_session: string) {
 	)
 	const reviewDayQuery = useReviewDay(lang, day_session)
 	// Stage now folds out of the append-only milestone log, not the session row.
-	const stage = useReviewStageServer(lang, day_session)
+	const stage = useReviewStage(lang, day_session)
 	return {
 		isLoading: reviewsQuery.isLoading || reviewDayQuery.isLoading,
 		data: {
@@ -556,7 +556,7 @@ export const useOneCardReviews = (
 /**
  * Append a review-session milestone as an optimistic collection action. The
  * row (client-generated id + created_at) lands in the collection immediately —
- * so `useReviewStageServer` reflects it at once — and the collection's onInsert
+ * so `useReviewStage` reflects it at once — and the collection's onInsert
  * persists it and owns any error.
  */
 export function insertMilestone(input: {

--- a/src/features/review/index.ts
+++ b/src/features/review/index.ts
@@ -31,6 +31,7 @@ export {
 // Hooks
 export {
 	useNextValid,
+	useReviewStage,
 	useReviewsToday,
 	useReviewsTodayStats,
 	useReviewDay,

--- a/src/features/review/review-utils.ts
+++ b/src/features/review/review-utils.ts
@@ -10,14 +10,13 @@ import type { uuid } from '@/types/main'
 import { toManifestEntry, type ManifestEntry } from './manifest'
 
 /*
-	null: not yet initialised (zustand store only)
 	1. doing the first review
 	2. going back for unreviewed
 	3. skip unreviewed and see screen asking to re-review
 	4. doing re-reviews
 	5. skip re-reviews and end
 */
-export type ReviewStages = null | 1 | 2 | 3 | 4 | 5
+export type ReviewStages = 1 | 2 | 3 | 4 | 5
 export type ReviewsMap = {
 	[key: ManifestEntry]: CardReviewType
 }

--- a/src/features/review/store.ts
+++ b/src/features/review/store.ts
@@ -34,9 +34,11 @@ export type ReviewStore = ReturnType<typeof createReviewStore>
  * exist (manifest), which have been reviewed (card_review), and what stage the
  * session is at (milestone log) — lives in the collections, synced across
  * devices and mirrored to localStorage. This store holds only the current
- * card index within the manifest, an in-tab navigation position that is fine
- * to re-derive on a fresh mount (see `stats.index`). It is persisted purely so
- * a hard refresh lands back on the same card rather than the resume point.
+ * card index within the manifest — an in-tab navigation position. The go route
+ * re-seeds it from `stats.index` on mount and on every stage change, so the
+ * actual position is always derived from the shared (stage, reviews); the
+ * persisted copy survives only as the "a session was started in this tab"
+ * signal the routing guard reads (`countCards`/`currentCardIndex` !== -1).
  */
 export function createReviewStore(lang: string, dayString: string) {
 	return createStore<ReviewState>()(

--- a/src/features/review/store.ts
+++ b/src/features/review/store.ts
@@ -3,23 +3,14 @@ import { createStore } from 'zustand'
 import { useStore } from 'zustand'
 import { devtools, persist } from 'zustand/middleware'
 
-import type { ReviewStages } from './review-utils'
-import type { ManifestEntry } from './manifest'
-
 const DEFAULT_PROPS = {
 	lang: '',
 	dayString: '',
 	countCards: -1,
-	stage: null as ReviewStages,
 	currentCardIndex: -1,
-	newCardEntries: null as Array<ManifestEntry> | null,
 }
 
 type ReviewActions = {
-	skipReviewUnreviewed: () => void
-	skipReviewAgains: () => void
-	gotoReviewUnreviewed: (i: number) => void
-	gotoReviewAgains: (i: number) => void
 	gotoIndex: (i: number) => void
 	gotoNext: () => void
 	gotoEnd: () => void
@@ -28,8 +19,6 @@ type ReviewActions = {
 		lang: string,
 		dayString: string,
 		countCards: number,
-		newCardEntries?: Array<ManifestEntry> | null,
-		stage?: ReviewStages,
 		index?: number
 	) => void
 }
@@ -40,6 +29,15 @@ export type ReviewState = typeof DEFAULT_PROPS & {
 
 export type ReviewStore = ReturnType<typeof createReviewStore>
 
+/**
+ * A throwaway per-session cursor, nothing more. Session *state* — which cards
+ * exist (manifest), which have been reviewed (card_review), and what stage the
+ * session is at (milestone log) — lives in the collections, synced across
+ * devices and mirrored to localStorage. This store holds only the current
+ * card index within the manifest, an in-tab navigation position that is fine
+ * to re-derive on a fresh mount (see `stats.index`). It is persisted purely so
+ * a hard refresh lands back on the same card rather than the resume point.
+ */
 export function createReviewStore(lang: string, dayString: string) {
 	return createStore<ReviewState>()(
 		devtools(
@@ -49,19 +47,6 @@ export function createReviewStore(lang: string, dayString: string) {
 					lang,
 					dayString,
 					actions: {
-						skipReviewUnreviewed: () => set({ stage: 3 }),
-						skipReviewAgains: () => set({ stage: 5 }),
-
-						gotoReviewUnreviewed: (i: number) =>
-							set({
-								stage: 2,
-								currentCardIndex: i,
-							}),
-						gotoReviewAgains: (i: number) =>
-							set({
-								stage: 4,
-								currentCardIndex: i,
-							}),
 						gotoIndex: (i) => set({ currentCardIndex: i }),
 						gotoNext: () =>
 							set((state) => ({
@@ -80,8 +65,6 @@ export function createReviewStore(lang: string, dayString: string) {
 							lang: string,
 							dayString: string,
 							countCards: number,
-							newCardEntries: Array<ManifestEntry> | null = null,
-							stage: ReviewStages = 1,
 							index: number = 0
 						) =>
 							set((state) => {
@@ -90,14 +73,12 @@ export function createReviewStore(lang: string, dayString: string) {
 									throw new Error(
 										'Mismatching language or dayString between params and current store state'
 									)
-								// ensure we only init once
-								if (state.stage !== null) return state
+								// ensure we only init once (countCards is -1 until initialised)
+								if (state.countCards !== -1) return state
 								return {
 									lang,
 									dayString,
 									countCards,
-									newCardEntries,
-									stage,
 									currentCardIndex: index,
 								}
 							}),
@@ -109,9 +90,7 @@ export function createReviewStore(lang: string, dayString: string) {
 						lang: state.lang,
 						dayString: state.dayString,
 						countCards: state.countCards,
-						stage: state.stage,
 						currentCardIndex: state.currentCardIndex,
-						newCardEntries: state.newCardEntries,
 					}),
 				}
 			)
@@ -135,10 +114,6 @@ export const useReviewDayString = (): string => {
 	return useReviewStore((store) => store.dayString)
 }
 
-export const useReviewStage = (): ReviewStages => {
-	return useReviewStore((state) => state.stage)
-}
-
 export const useCardIndex = (): number => {
 	return useReviewStore((state) => state.currentCardIndex)
 }
@@ -149,8 +124,4 @@ export const useInitialiseReviewStore = (): ReviewActions['init'] => {
 
 export const useReviewActions = (): ReviewActions => {
 	return useReviewStore((state) => state.actions)
-}
-
-export const useNewCardEntries = (): Array<ManifestEntry> | null => {
-	return useReviewStore((state) => state.newCardEntries)
 }

--- a/src/lib/collections/local-cache.ts
+++ b/src/lib/collections/local-cache.ts
@@ -6,6 +6,17 @@ import {
 import { MyProfileSchema } from '@/features/profile/schemas'
 import { decksCollection } from '@/features/deck/collections'
 import { DeckMetaSchema } from '@/features/deck/schemas'
+import {
+	cardReviewsCollection,
+	reviewSessionsCollection,
+	reviewMilestonesCollection,
+} from '@/features/review/collections'
+import {
+	CardReviewSchema,
+	ReviewSessionSchema,
+	ReviewMilestoneSchema,
+} from '@/features/review/schemas'
+import { todayString } from '@/lib/utils'
 
 /**
  * Local persistence for user-owned collections — currently the profile and
@@ -44,6 +55,20 @@ export type PersistedCollection = {
 		subscribeChanges: (callback: () => void) => unknown
 	}
 	parseRow: (row: unknown) => unknown
+	// Optional reducer applied before persisting: mirror only a bounded slice of
+	// an otherwise-unbounded collection. Used for the append-only review logs,
+	// where we only need *today's* rows on the next cold start — never the whole
+	// history. Absent → the whole `toArray` is mirrored (profile, decks).
+	project?: (rows: ReadonlyArray<unknown>) => ReadonlyArray<unknown>
+}
+
+// Keep only rows belonging to the current review day (4am-cutoff `todayString`).
+// Evaluated at persist time, so it always tracks the live day.
+const onlyToday = (rows: ReadonlyArray<unknown>): ReadonlyArray<unknown> => {
+	const today = todayString()
+	return (rows as ReadonlyArray<{ day_session?: string }>).filter(
+		(r) => r.day_session === today
+	)
 }
 
 export const PERSISTED_COLLECTIONS: ReadonlyArray<PersistedCollection> = [
@@ -60,6 +85,35 @@ export const PERSISTED_COLLECTIONS: ReadonlyArray<PersistedCollection> = [
 		queryKey: ['user', 'deck_plus'],
 		collection: decksCollection,
 		parseRow: (row) => DeckMetaSchema.parse(row),
+	},
+	// Review session state, mirrored per-day so a hard refresh (or a second
+	// device catching up) repaints an in-progress session — its stage, its
+	// card history — on the first frame, across every language being reviewed.
+	// All three project to today's rows only: the logs are append-only and grow
+	// without bound, but only the current day is needed to resume.
+	{
+		label: 'review-sessions',
+		storageKey: 'sunlo-cache-review-sessions',
+		queryKey: ['user', 'user_review_session'],
+		collection: reviewSessionsCollection,
+		parseRow: (row) => ReviewSessionSchema.parse(row),
+		project: onlyToday,
+	},
+	{
+		label: 'review-milestones',
+		storageKey: 'sunlo-cache-review-milestones',
+		queryKey: ['user', 'user_review_milestone'],
+		collection: reviewMilestonesCollection,
+		parseRow: (row) => ReviewMilestoneSchema.parse(row),
+		project: onlyToday,
+	},
+	{
+		label: 'card-reviews',
+		storageKey: 'sunlo-cache-card-reviews',
+		queryKey: ['user', 'card_review'],
+		collection: cardReviewsCollection,
+		parseRow: (row) => CardReviewSchema.parse(row),
+		project: onlyToday,
 	},
 ]
 
@@ -85,10 +139,10 @@ export function hasSupabaseSessionToken(): boolean {
 export function attachMirror(entry: PersistedCollection): void {
 	entry.collection.subscribeChanges(() => {
 		try {
-			localStorage.setItem(
-				entry.storageKey,
-				JSON.stringify(entry.collection.toArray)
-			)
+			const rows = entry.project
+				? entry.project(entry.collection.toArray)
+				: entry.collection.toArray
+			localStorage.setItem(entry.storageKey, JSON.stringify(rows))
 		} catch (error) {
 			console.warn(`[local-cache] could not save ${entry.storageKey}`, error)
 		}

--- a/src/routes/_user/learn/$lang.review.go.tsx
+++ b/src/routes/_user/learn/$lang.review.go.tsx
@@ -7,12 +7,12 @@ import {
 	useReviewActions,
 	useReviewDayString,
 	useReviewLang,
-	useReviewStage,
 } from '@/features/review/store'
 import {
 	ensureManifestCardsInCollection,
 	useNextValid,
 	useReviewDay,
+	useReviewsTodayStats,
 } from '@/features/review/hooks'
 import { Loader } from '@/components/ui/loader'
 import { WhenComplete } from '@/components/review/when-review-complete-screen'
@@ -51,11 +51,14 @@ export const Route = createFileRoute('/_user/learn/$lang/review/go')({
 function ReviewPage() {
 	const lang = useReviewLang()
 	const dayString = useReviewDayString()
+	const currentCardIndex = useCardIndex()
 	const { data: day, isLoading } = useReviewDay(lang, dayString)
-	const stage = useReviewStage()
 
 	if (isLoading) return <Loader />
-	if (!day?.manifest?.length || stage === null)
+	// currentCardIndex === -1 means the cursor store hasn't been initialised —
+	// i.e. we landed here without going through setup/continue. Redirect back so
+	// the index route can seed the cursor (from stats.index) before we render.
+	if (!day?.manifest?.length || currentCardIndex === -1)
 		return <Navigate to="/learn/$lang/review" from={Route.fullPath} />
 
 	return (
@@ -71,7 +74,8 @@ function FlashCardReviewSession({
 	dayString: string
 }) {
 	const currentCardIndex = useCardIndex()
-	const reviewStage = useReviewStage()
+	const lang = useReviewLang()
+	const reviewStage = useReviewsTodayStats(lang, dayString).data.stage
 	const { gotoNext, gotoPrevious, gotoIndex } = useReviewActions()
 	const nextValidIndex = useNextValid()
 

--- a/src/routes/_user/learn/$lang.review.go.tsx
+++ b/src/routes/_user/learn/$lang.review.go.tsx
@@ -13,6 +13,7 @@ import {
 	useNextValid,
 	useReviewDay,
 	useReviewsTodayStats,
+	useUpdateReviewStage,
 } from '@/features/review/hooks'
 import { Loader } from '@/components/ui/loader'
 import { WhenComplete } from '@/components/review/when-review-complete-screen'
@@ -79,6 +80,22 @@ function FlashCardReviewSession({
 	const reviewStage = stats.stage
 	const { gotoNext, gotoPrevious, gotoIndex } = useReviewActions()
 	const nextValidIndex = useNextValid()
+	const updateStage = useUpdateReviewStage(lang, dayString)
+
+	// "Skip for today" means different things per phase. In the go-back phase
+	// (stage 2) it skips one unreviewed card and walks forward to the end. In the
+	// again round (stage >= 3) there's no forward end to walk to — unmastered
+	// Again cards keep the complete-screen re-offering the round, and the phase
+	// only closes by advancing to stage 5. So skipping the again round finishes
+	// it outright rather than cycling back onto the remaining Again cards.
+	const handleSkipForToday = useCallback(() => {
+		if ((reviewStage ?? 0) >= 3) {
+			updateStage(5)
+			gotoIndex(manifest.length)
+		} else {
+			gotoIndex(nextValidIndex)
+		}
+	}, [reviewStage, updateStage, gotoIndex, manifest.length, nextValidIndex])
 
 	// Position derives from the shared (stage, reviews). The stored cursor is a
 	// within-stage browse offset only; on mount and whenever the stage advances —
@@ -156,9 +173,7 @@ function FlashCardReviewSession({
 							size="sm"
 							variant="ghost"
 							aria-label="skip for today"
-							onClick={() =>
-								animateAndNavigate(() => gotoIndex(nextValidIndex))
-							}
+							onClick={() => animateAndNavigate(handleSkipForToday)}
 							className="ps-4 pe-2"
 						>
 							Skip for today <ChevronRight className="size-4" />

--- a/src/routes/_user/learn/$lang.review.go.tsx
+++ b/src/routes/_user/learn/$lang.review.go.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 
 import { createFileRoute, Navigate } from '@tanstack/react-router'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
@@ -75,9 +75,25 @@ function FlashCardReviewSession({
 }) {
 	const currentCardIndex = useCardIndex()
 	const lang = useReviewLang()
-	const reviewStage = useReviewsTodayStats(lang, dayString).data.stage
+	const stats = useReviewsTodayStats(lang, dayString).data
+	const reviewStage = stats.stage
 	const { gotoNext, gotoPrevious, gotoIndex } = useReviewActions()
 	const nextValidIndex = useNextValid()
+
+	// Position derives from the shared (stage, reviews). The stored cursor is a
+	// within-stage browse offset only; on mount and whenever the stage advances —
+	// including a stage change pushed in from another device — snap back to the
+	// stage's canonical resume index (stats.index). Without this, a cursor left
+	// mid-manifest under a now-stale stage gets read against the wrong phase (e.g.
+	// a stage-5 session rendering a leftover card, where one "skip" jumps to the
+	// again-round's empty set and lands on "finished"). The ref keeps the effect
+	// keyed on stage alone — re-seeding on every stats.index change would fight
+	// in-stage navigation and answer-advance.
+	const seedRef = useRef(stats.index)
+	seedRef.current = stats.index
+	useLayoutEffect(() => {
+		gotoIndex(seedRef.current)
+	}, [reviewStage, gotoIndex])
 
 	const atTheEnd = currentCardIndex === manifest.length
 

--- a/src/routes/_user/learn/$lang.review.go.tsx
+++ b/src/routes/_user/learn/$lang.review.go.tsx
@@ -10,11 +10,14 @@ import {
 } from '@/features/review/store'
 import {
 	ensureManifestCardsInCollection,
-	useNextValid,
 	useReviewDay,
 	useReviewsTodayStats,
 	useUpdateReviewStage,
 } from '@/features/review/hooks'
+import {
+	getIndexOfNextAgainCard,
+	getIndexOfNextUnreviewedCard,
+} from '@/features/review/review-utils'
 import { Loader } from '@/components/ui/loader'
 import { WhenComplete } from '@/components/review/when-review-complete-screen'
 import { ReviewSingleCard } from '@/components/review/review-single-card'
@@ -79,8 +82,17 @@ function FlashCardReviewSession({
 	const stats = useReviewsTodayStats(lang, dayString).data
 	const reviewStage = stats.stage
 	const { gotoNext, gotoPrevious, gotoIndex } = useReviewActions()
-	const nextValidIndex = useNextValid()
 	const updateStage = useUpdateReviewStage(lang, dayString)
+	// The next card needing attention this phase, computed off the same reviews
+	// data the stats already loaded (no second useReviewsToday subscription).
+	const nextValidIndex =
+		reviewStage < 3
+			? getIndexOfNextUnreviewedCard(
+					manifest,
+					stats.reviewsMap,
+					currentCardIndex
+				)
+			: getIndexOfNextAgainCard(manifest, stats.reviewsMap, currentCardIndex)
 
 	// "Skip for today" means different things per phase. In the go-back phase
 	// (stage 2) it skips one unreviewed card and walks forward to the end. In the
@@ -88,14 +100,14 @@ function FlashCardReviewSession({
 	// Again cards keep the complete-screen re-offering the round, and the phase
 	// only closes by advancing to stage 5. So skipping the again round finishes
 	// it outright rather than cycling back onto the remaining Again cards.
-	const handleSkipForToday = useCallback(() => {
-		if ((reviewStage ?? 0) >= 3) {
+	const handleSkipForToday = () => {
+		if (reviewStage >= 3) {
 			updateStage(5)
 			gotoIndex(manifest.length)
 		} else {
 			gotoIndex(nextValidIndex)
 		}
-	}, [reviewStage, updateStage, gotoIndex, manifest.length, nextValidIndex])
+	}
 
 	// Position derives from the shared (stage, reviews). The stored cursor is a
 	// within-stage browse offset only; on mount and whenever the stage advances —
@@ -168,7 +180,7 @@ function FlashCardReviewSession({
 								<ChevronRight className="size-4" />
 							</Button>
 						</>
-					) : !atTheEnd && (reviewStage ?? 0) > 1 ? (
+					) : !atTheEnd && reviewStage > 1 ? (
 						<Button
 							size="sm"
 							variant="ghost"
@@ -207,7 +219,7 @@ function FlashCardReviewSession({
 								<ReviewSingleCard
 									pid={phraseId}
 									direction={direction}
-									reviewStage={reviewStage ?? 1}
+									reviewStage={reviewStage}
 									dayString={dayString}
 									triggerSlide={triggerSlide}
 								/>

--- a/src/routes/_user/learn/$lang.review.index.tsx
+++ b/src/routes/_user/learn/$lang.review.index.tsx
@@ -31,9 +31,9 @@ import { Button } from '@/components/ui/button'
 import { Drawer, DrawerTrigger } from '@/components/ui/drawer'
 import Flagged from '@/components/flagged'
 import {
+	useCardIndex,
 	useInitialiseReviewStore,
 	useReviewDayString,
-	useReviewStage,
 } from '@/features/review/store'
 import { arrayDifference, arrayUnion, min0 } from '@/lib/utils'
 import { useDeckMeta, useDeckPids } from '@/features/deck/hooks'
@@ -101,7 +101,7 @@ function ReviewPageContent() {
 	const { lang } = Route.useParams()
 	const navigate = useNavigate()
 	const dayString = useReviewDayString()
-	const stage = useReviewStage()
+	const currentCardIndex = useCardIndex()
 	const userId = useUserId()
 	// const retrievabilityTarget = 0.9
 	const { data: meta } = useDeckMeta(lang)
@@ -363,8 +363,6 @@ function ReviewPageContent() {
 				...reverseNew,
 			]
 
-			const freshCardEntries = [...forwardNew, ...reverseNew]
-
 			const { data: reviewDay } = await supabase
 				.from('user_review_session')
 				.insert({
@@ -390,7 +388,6 @@ function ReviewPageContent() {
 				countCardsFresh: freshCards.length,
 				countCardsCreated: newCards.length,
 				countCardsAlreadyExisted: cardInserts.length - newCards.length,
-				freshCardEntries,
 				newCards,
 				reviewDay,
 			}
@@ -423,12 +420,7 @@ function ReviewPageContent() {
 				event: 'session_started',
 				stage: 1,
 			})
-			initLocalReviewState(
-				lang,
-				dayString,
-				data.countCards,
-				data.freshCardEntries
-			)
+			initLocalReviewState(lang, dayString, data.countCards)
 			const toastMessage =
 				data.countCardsAlreadyExisted > 0
 					? `Ready! Could only create ${data.countCardsCreated} new cards — ${data.countCardsAlreadyExisted} already existed. You have ${data.countCards} total today.`
@@ -450,7 +442,8 @@ function ReviewPageContent() {
 	if (stats?.count && !sessionJustCreatedRef.current)
 		return stats.complete === stats.count || stats.stage >= 5 ? (
 			<WhenComplete />
-		) : stage !== null ? (
+		) : currentCardIndex !== -1 ? (
+			// cursor already initialised (mid-session in this tab) → resume directly
 			<Navigate to="/learn/$lang/review/go" from={Route.fullPath} />
 		) : (
 			<ContinueReview lang={lang} dayString={dayString} reviewStats={stats} />

--- a/src/routes/_user/learn/$lang.review.preview.tsx
+++ b/src/routes/_user/learn/$lang.review.preview.tsx
@@ -1,9 +1,5 @@
 import { createFileRoute, Navigate } from '@tanstack/react-router'
-import {
-	useReviewDayString,
-	useReviewLang,
-	useReviewStage,
-} from '@/features/review/store'
+import { useReviewDayString, useReviewLang } from '@/features/review/store'
 import {
 	ensureManifestCardsInCollection,
 	useReviewDay,
@@ -39,10 +35,9 @@ function PreviewPage() {
 	const reviewLang = useReviewLang()
 	const dayString = useReviewDayString()
 	const { data: day, isLoading } = useReviewDay(reviewLang, dayString)
-	const stage = useReviewStage()
 
 	if (isLoading) return <Loader />
-	if (!day?.manifest?.length || stage === null)
+	if (!day?.manifest?.length)
 		return (
 			<Navigate
 				to="/learn/$lang/review"


### PR DESCRIPTION
## Summary

Moves review session state (stage, manifest, card reviews) from ephemeral Zustand store to persistent TanStack DB collections, synced across devices and mirrored to localStorage. The store now holds only the current card index—a per-tab navigation cursor that's fine to re-derive on cold load.

## Key Changes

- **Collections-first architecture**: Review stage, milestones, and card reviews now live in `reviewSessionsCollection`, `reviewMilestonesCollection`, and `cardReviewsCollection`, synced in real-time and persisted to localStorage via `PERSISTED_COLLECTIONS`.

- **Per-day localStorage projection**: Added `project` field to `PersistedCollection` to mirror only today's rows (via `onlyToday` filter) for append-only review logs. This keeps localStorage bounded while preserving session state across hard refreshes and devices.

- **Simplified Zustand store**: Removed `stage`, `newCardEntries`, and stage-navigation actions (`skipReviewUnreviewed`, `gotoReviewAgains`, etc.). The store now only tracks `currentCardIndex` (in-tab cursor position) and basic session metadata (`lang`, `dayString`, `countCards`).

- **Derived "new cards" logic**: Replaced session-captured `newCardEntries` with a live query in `NewCardsPreview` that filters the manifest by prior-session scoring reviews (stages 1–2 before today), making it reliable across same-day again-round reviews.

- **Single source of truth for stage**: `useReviewStage` now queries the milestone log (via `useReviewsTodayStats`) instead of the store, ensuring stage is consistent across devices and survives cold loads via localStorage.

- **Cleaner component logic**: Removed stage-based branching from store actions; components now call `updateStage()` directly and derive stage from `useReviewsTodayStats`, eliminating stale ephemeral state.

## Implementation Details

- `attachMirror()` now applies the optional `project` function before persisting, allowing bounded snapshots of unbounded collections.
- `useReviewStage` renamed from `useReviewStageServer` to reflect it's now the canonical source (not a fallback).
- `ContinueReview` and `WhenComplete` now read stage from collections instead of store, and `gotoIndex` replaces the removed stage-navigation actions.
- Formatting fixes (ternary operators) applied to affected components for consistency.

https://claude.ai/code/session_01M9daGnzD8NkWVXDMo4hrvF