### PR TITLE
Transform batch: migrate playlist & deck mutations to collection handlers (#625)

### DIFF
--- a/src/components/card-pieces/card-status-dropdown.tsx
+++ b/src/components/card-pieces/card-status-dropdown.tsx
@@ -34,9 +34,13 @@ import {
 } from '@/features/deck/hooks'
 import languages from '@/lib/languages'
 import { Button } from '@/components/ui/button'
-import { phrasesCollection } from '@/features/phrases/collections'
 import { cardsCollection, decksCollection } from '@/features/deck/collections'
 import { directionsForPhrase } from '@/features/deck/card-directions'
+import {
+	updateCardsStatus,
+	updatePhraseLearnerCount,
+	type LearningStatus,
+} from '@/features/deck/card-status'
 import { postNewDeck } from '@/features/deck/mutations'
 import { DeckMetaSchema, type DeckMetaType } from '@/features/deck/schemas'
 import {
@@ -51,7 +55,6 @@ interface CardStatusDropdownProps {
 	className?: string
 }
 
-type LearningStatus = 'active' | 'skipped' | 'learned'
 type ShowableActions = LearningStatus | 'nodeck' | 'nocard'
 
 export const statusStrings: Record<ShowableActions, Required<ActionCopy>> = {
@@ -139,36 +142,6 @@ const triggerDotClass: Record<ShowableActions, string> = {
 	nodeck: 'bg-3-lo-neutral',
 }
 
-const isLearnerStatus = (s: LearningStatus | undefined) =>
-	s === 'active' || s === 'learned' ? 1 : 0
-
-// count_learners is server-derived (aggregated in the phrase_full view from
-// user_card status), so phrasesCollection has no direct mutation handler for
-// it — we apply the predicted delta optimistically via writeUpdate and revert
-// it manually if the card transaction rolls back.
-function updatePhraseCount(
-	phraseId: string,
-	oldStatus: LearningStatus | undefined,
-	newStatus: LearningStatus
-): (() => void) | undefined {
-	if (oldStatus === newStatus) return
-	const previous = phrasesCollection.get(phraseId)
-	if (!previous) {
-		console.error(`updatePhraseCount: no phrase ${phraseId} in collection`)
-		return
-	}
-	phrasesCollection.utils.writeUpdate({
-		id: previous.id,
-		count_learners: Math.max(
-			(previous.count_learners ?? 0) -
-				isLearnerStatus(oldStatus) +
-				isLearnerStatus(newStatus),
-			0
-		),
-	})
-	return () => phrasesCollection.utils.writeUpdate(previous)
-}
-
 function useCardStatusMutator(
 	phrase: AnyPhrase,
 	card: CardWithSibling | undefined
@@ -183,17 +156,15 @@ function useCardStatusMutator(
 		if (card?.status === status) return Promise.resolve()
 
 		const tx = card
-			? cardsCollection.update(
+			? updateCardsStatus(
 					card.sibling_id ? [card.id, card.sibling_id] : [card.id],
-					(drafts) => {
-						drafts.forEach((d) => {
-							d.status = status
-						})
-					}
+					phrase.id,
+					card.status,
+					status
 				)
 			: (() => {
 					const nowIso = new Date().toISOString()
-					return cardsCollection.insert(
+					const insertTx = cardsCollection.insert(
 						directionsForPhrase(phrase.only_reverse).map((direction) => ({
 							id: crypto.randomUUID(),
 							uid: userId,
@@ -208,9 +179,15 @@ function useCardStatusMutator(
 							stability: null,
 						}))
 					)
+					const revertCount = updatePhraseLearnerCount(
+						phrase.id,
+						undefined,
+						status
+					)
+					if (revertCount)
+						insertTx.isPersisted.promise.then(undefined, revertCount)
+					return insertTx
 				})()
-
-		const revertCount = updatePhraseCount(phrase.id, card?.status, status)
 
 		return tx.isPersisted.promise.then(
 			() => {
@@ -223,7 +200,6 @@ function useCardStatusMutator(
 				}
 			},
 			(err) => {
-				revertCount?.()
 				console.error('Card status mutation rolled back:', err)
 				if (options?.silent) throw err
 				toastError(

--- a/src/components/playlists/delete-playlist-dialog.tsx
+++ b/src/components/playlists/delete-playlist-dialog.tsx
@@ -11,6 +11,7 @@ import {
 	AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
+import { toastSuccess } from '@/components/ui/sonner'
 import { PhrasePlaylistType } from '@/features/playlists/schemas'
 import { phrasePlaylistsCollection } from '@/features/playlists/collections'
 import { useNavigate } from '@tanstack/react-router'
@@ -24,7 +25,13 @@ export function DeletePlaylistDialog({
 	const navigate = useNavigate()
 
 	const handleDelete = () => {
-		phrasePlaylistsCollection.delete(playlist.id)
+		const tx = phrasePlaylistsCollection.delete(playlist.id)
+		// Fire-and-forget: navigate immediately, confirm on settle. The error
+		// toast lives in the collection's onDelete handler.
+		tx.isPersisted.promise.then(
+			() => toastSuccess('Playlist deleted'),
+			() => {}
+		)
 		void navigate({
 			to: '/learn/$lang',
 			params: { lang: playlist.lang },

--- a/src/components/playlists/delete-playlist-dialog.tsx
+++ b/src/components/playlists/delete-playlist-dialog.tsx
@@ -1,6 +1,4 @@
 import { useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
-import { toastError, toastSuccess } from '@/components/ui/sonner'
 import { Trash2 } from 'lucide-react'
 import {
 	AlertDialog,
@@ -14,7 +12,6 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import { PhrasePlaylistType } from '@/features/playlists/schemas'
-import supabase from '@/lib/supabase-client'
 import { phrasePlaylistsCollection } from '@/features/playlists/collections'
 import { useNavigate } from '@tanstack/react-router'
 
@@ -26,29 +23,13 @@ export function DeletePlaylistDialog({
 	const [open, setOpen] = useState(false)
 	const navigate = useNavigate()
 
-	// Delete playlist mutation
-	const mutation = useMutation({
-		mutationFn: async () => {
-			const { error } = await supabase
-				.from('phrase_playlist')
-				.update({ deleted: true })
-				.eq('id', playlist.id)
-
-			if (error) throw error
-		},
-		onSuccess: () => {
-			phrasePlaylistsCollection.utils.writeDelete(playlist.id)
-			toastSuccess('Playlist deleted')
-			// Navigate away from the deleted playlist page
-			void navigate({
-				to: '/learn/$lang',
-				params: { lang: playlist.lang },
-			})
-		},
-		onError: (error: Error) => {
-			toastError(`Failed to delete playlist: ${error.message}`)
-		},
-	})
+	const handleDelete = () => {
+		phrasePlaylistsCollection.delete(playlist.id)
+		void navigate({
+			to: '/learn/$lang',
+			params: { lang: playlist.lang },
+		})
+	}
 	return (
 		<AlertDialog open={open} onOpenChange={setOpen}>
 			<Button
@@ -71,8 +52,7 @@ export function DeletePlaylistDialog({
 				<AlertDialogFooter>
 					<AlertDialogCancel>Cancel</AlertDialogCancel>
 					<AlertDialogAction
-						disabled={mutation.isPending}
-						onClick={() => mutation.mutate()}
+						onClick={handleDelete}
 						data-testid="confirm-delete-button"
 						className="bg-destructive text-destructive-foreground"
 					>

--- a/src/components/playlists/delete-playlist-dialog.tsx
+++ b/src/components/playlists/delete-playlist-dialog.tsx
@@ -11,7 +11,7 @@ import {
 	AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
-import { toastSuccess } from '@/components/ui/sonner'
+import { toastError, toastSuccess } from '@/components/ui/sonner'
 import { PhrasePlaylistType } from '@/features/playlists/schemas'
 import { phrasePlaylistsCollection } from '@/features/playlists/collections'
 import { useNavigate } from '@tanstack/react-router'
@@ -25,17 +25,23 @@ export function DeletePlaylistDialog({
 	const navigate = useNavigate()
 
 	const handleDelete = () => {
-		const tx = phrasePlaylistsCollection.delete(playlist.id)
-		// Fire-and-forget: navigate immediately, confirm on settle. The error
-		// toast lives in the collection's onDelete handler.
-		tx.isPersisted.promise.then(
-			() => toastSuccess('Playlist deleted'),
-			() => {}
-		)
-		void navigate({
-			to: '/learn/$lang',
-			params: { lang: playlist.lang },
+		setOpen(false)
+		const tx = phrasePlaylistsCollection.update(playlist.id, (draft) => {
+			draft.deleted = true
 		})
+		tx.isPersisted.promise.then(
+			() => {
+				toastSuccess('Playlist deleted')
+				void navigate({
+					to: '/learn/$lang',
+					params: { lang: playlist.lang },
+				})
+			},
+			(err: unknown) => {
+				const message = err instanceof Error ? err.message : 'unknown error'
+				toastError(`Failed to delete playlist: ${message}`)
+			}
+		)
 	}
 	return (
 		<AlertDialog open={open} onOpenChange={setOpen}>

--- a/src/components/playlists/update-playlist-dialog.tsx
+++ b/src/components/playlists/update-playlist-dialog.tsx
@@ -10,15 +10,11 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import {
-	PhrasePlaylistSchema,
 	PhrasePlaylistUpdateSchema,
 	type PhrasePlaylistType,
 	type PhrasePlaylistUpdateType,
 } from '@/features/playlists/schemas'
 import { phrasePlaylistsCollection } from '@/features/playlists/collections'
-import { toastError, toastSuccess } from '@/components/ui/sonner'
-import supabase from '@/lib/supabase-client'
-import { useMutation } from '@tanstack/react-query'
 import { CoverImageField } from '@/components/fields/cover-image-field'
 import { isEmbeddableUrl } from './playlist-embed'
 import { useAppForm } from '@/components/form'
@@ -41,41 +37,17 @@ export function UpdatePlaylistDialog({
 }) {
 	const [open, setOpen] = useState(false)
 
-	const mutation = useMutation({
-		mutationFn: async (values: PhrasePlaylistUpdateType) => {
-			const { data, error } = await supabase
-				.from('phrase_playlist')
-				.update({
-					title: values.title,
-					description: values.description || null,
-					href: values.href || null,
-					cover_image_path: values.cover_image_path || null,
-				})
-				.eq('id', playlist.id)
-				.select()
-				.single()
-
-			if (error) throw error
-			return data
-		},
-		onSuccess: (data: PhrasePlaylistType) => {
-			setOpen(false)
-			toastSuccess('Playlist updated!')
-			phrasePlaylistsCollection.utils.writeUpdate(
-				PhrasePlaylistSchema.parse(data)
-			)
-		},
-		onError: (error: Error) => {
-			toastError(`Failed to update playlist: ${error.message}`)
-			console.log('Error', error)
-		},
-	})
-
 	const form = useAppForm({
 		defaultValues: playlistDefaults(playlist),
 		validators: { onChange: PhrasePlaylistUpdateSchema },
-		onSubmit: async ({ value }) => {
-			await mutation.mutateAsync(value)
+		onSubmit: ({ value }) => {
+			phrasePlaylistsCollection.update(playlist.id, (draft) => {
+				draft.title = value.title
+				draft.description = value.description || null
+				draft.href = value.href || null
+				draft.cover_image_path = value.cover_image_path || null
+			})
+			setOpen(false)
 		},
 	})
 

--- a/src/components/playlists/update-playlist-dialog.tsx
+++ b/src/components/playlists/update-playlist-dialog.tsx
@@ -15,7 +15,7 @@ import {
 	type PhrasePlaylistUpdateType,
 } from '@/features/playlists/schemas'
 import { phrasePlaylistsCollection } from '@/features/playlists/collections'
-import { toastSuccess } from '@/components/ui/sonner'
+import { toastError, toastSuccess } from '@/components/ui/sonner'
 import { CoverImageField } from '@/components/fields/cover-image-field'
 import { isEmbeddableUrl } from './playlist-embed'
 import { useAppForm } from '@/components/form'
@@ -48,11 +48,12 @@ export function UpdatePlaylistDialog({
 				draft.href = value.href || null
 				draft.cover_image_path = value.cover_image_path || null
 			})
-			// Fire-and-forget: close immediately, confirm on settle. The error
-			// toast lives in the collection's onUpdate handler.
 			tx.isPersisted.promise.then(
 				() => toastSuccess('Playlist updated!'),
-				() => {}
+				(err: unknown) => {
+					const message = err instanceof Error ? err.message : 'unknown error'
+					toastError(`Failed to update playlist: ${message}`)
+				}
 			)
 			setOpen(false)
 		},

--- a/src/components/playlists/update-playlist-dialog.tsx
+++ b/src/components/playlists/update-playlist-dialog.tsx
@@ -15,6 +15,7 @@ import {
 	type PhrasePlaylistUpdateType,
 } from '@/features/playlists/schemas'
 import { phrasePlaylistsCollection } from '@/features/playlists/collections'
+import { toastSuccess } from '@/components/ui/sonner'
 import { CoverImageField } from '@/components/fields/cover-image-field'
 import { isEmbeddableUrl } from './playlist-embed'
 import { useAppForm } from '@/components/form'
@@ -41,12 +42,18 @@ export function UpdatePlaylistDialog({
 		defaultValues: playlistDefaults(playlist),
 		validators: { onChange: PhrasePlaylistUpdateSchema },
 		onSubmit: ({ value }) => {
-			phrasePlaylistsCollection.update(playlist.id, (draft) => {
+			const tx = phrasePlaylistsCollection.update(playlist.id, (draft) => {
 				draft.title = value.title
 				draft.description = value.description || null
 				draft.href = value.href || null
 				draft.cover_image_path = value.cover_image_path || null
 			})
+			// Fire-and-forget: close immediately, confirm on settle. The error
+			// toast lives in the collection's onUpdate handler.
+			tx.isPersisted.promise.then(
+				() => toastSuccess('Playlist updated!'),
+				() => {}
+			)
 			setOpen(false)
 		},
 	})

--- a/src/features/deck/card-status.ts
+++ b/src/features/deck/card-status.ts
@@ -1,0 +1,62 @@
+import * as z from 'zod'
+
+import { cardsCollection } from './collections'
+import { CardStatusEnumSchema } from './schemas'
+import { phrasesCollection } from '@/features/phrases/collections'
+
+export type LearningStatus = z.infer<typeof CardStatusEnumSchema>
+
+const isLearnerStatus = (s: LearningStatus | undefined) =>
+	s === 'active' || s === 'learned' ? 1 : 0
+
+/**
+ * count_learners is server-derived (aggregated in the phrase_meta view from
+ * user_card status), so phrasesCollection has no mutation handler for it. Apply
+ * the predicted delta optimistically and return a reverter to run if the card
+ * write rolls back.
+ */
+export function updatePhraseLearnerCount(
+	phraseId: string,
+	oldStatus: LearningStatus | undefined,
+	newStatus: LearningStatus
+): (() => void) | undefined {
+	if (oldStatus === newStatus) return
+	const previous = phrasesCollection.get(phraseId)
+	if (!previous) {
+		console.error(
+			`updatePhraseLearnerCount: no phrase ${phraseId} in collection`
+		)
+		return
+	}
+	phrasesCollection.utils.writeUpdate({
+		id: previous.id,
+		count_learners: Math.max(
+			(previous.count_learners ?? 0) -
+				isLearnerStatus(oldStatus) +
+				isLearnerStatus(newStatus),
+			0
+		),
+	})
+	return () => phrasesCollection.utils.writeUpdate(previous)
+}
+
+/**
+ * Set a phrase's cards (both directions) to `toStatus` in one optimistic
+ * transaction, keeping the denormalized count_learners in sync and reverting it
+ * on rollback. Callers own the toast UX via the returned tx's isPersisted.promise.
+ */
+export function updateCardsStatus(
+	cardIds: Array<string>,
+	phraseId: string,
+	fromStatus: LearningStatus | undefined,
+	toStatus: LearningStatus
+) {
+	const tx = cardsCollection.update(cardIds, (drafts) => {
+		drafts.forEach((draft) => {
+			draft.status = toStatus
+		})
+	})
+	const revertCount = updatePhraseLearnerCount(phraseId, fromStatus, toStatus)
+	if (revertCount) tx.isPersisted.promise.then(undefined, revertCount)
+	return tx
+}

--- a/src/features/playlists/collections.ts
+++ b/src/features/playlists/collections.ts
@@ -11,6 +11,8 @@ import {
 } from './schemas'
 import { queryClient } from '@/lib/query-client'
 import supabase from '@/lib/supabase-client'
+import { toastError } from '@/components/ui/sonner'
+import type { TablesUpdate } from '@/types/supabase'
 
 export const phrasePlaylistsCollection = createCollection(
 	queryCollectionOptions({
@@ -30,6 +32,42 @@ export const phrasePlaylistsCollection = createCollection(
 		schema: PhrasePlaylistSchema,
 		autoIndex: 'eager',
 		defaultIndexType: BasicIndex,
+		onUpdate: async ({ transaction }) => {
+			// { refetch: false } keeps the optimistic value; the edited columns are
+			// exactly what we send, so the local row already matches the server.
+			try {
+				await Promise.all(
+					transaction.mutations.map((m) =>
+						supabase
+							.from('phrase_playlist')
+							.update(m.changes as TablesUpdate<'phrase_playlist'>)
+							.eq('id', m.original.id)
+							.throwOnError()
+					)
+				)
+				return { refetch: false }
+			} catch (err) {
+				toastError('Failed to update playlist — please try again')
+				throw err
+			}
+		},
+		onDelete: async ({ transaction }) => {
+			// soft delete
+			try {
+				await supabase
+					.from('phrase_playlist')
+					.update({ deleted: true })
+					.in(
+						'id',
+						transaction.mutations.map((m) => m.original.id)
+					)
+					.throwOnError()
+				return { refetch: false }
+			} catch (err) {
+				toastError('Failed to delete playlist — please try again')
+				throw err
+			}
+		},
 	})
 )
 

--- a/src/features/playlists/collections.ts
+++ b/src/features/playlists/collections.ts
@@ -11,7 +11,6 @@ import {
 } from './schemas'
 import { queryClient } from '@/lib/query-client'
 import supabase from '@/lib/supabase-client'
-import { toastError } from '@/components/ui/sonner'
 import type { TablesUpdate } from '@/types/supabase'
 
 export const phrasePlaylistsCollection = createCollection(
@@ -25,48 +24,28 @@ export const phrasePlaylistsCollection = createCollection(
 				.select()
 				.throwOnError()
 
-			return data
+			return data?.map((p) => PhrasePlaylistSchema.parse(p)) ?? []
 		},
 		getKey: (item: PhrasePlaylistType) => item.id,
 		queryClient,
 		schema: PhrasePlaylistSchema,
 		autoIndex: 'eager',
 		defaultIndexType: BasicIndex,
+		// Delete is a soft delete (deleted: true) driven through onUpdate; the
+		// `deleted = false` filter in live queries hides the row. Call sites own
+		// the toast UX via tx.isPersisted.promise.
 		onUpdate: async ({ transaction }) => {
-			// { refetch: false } keeps the optimistic value; the edited columns are
-			// exactly what we send, so the local row already matches the server.
-			try {
-				await Promise.all(
-					transaction.mutations.map((m) =>
-						supabase
-							.from('phrase_playlist')
-							.update(m.changes as TablesUpdate<'phrase_playlist'>)
-							.eq('id', m.original.id)
-							.throwOnError()
-					)
+			await Promise.all(
+				transaction.mutations.map((m) =>
+					supabase
+						.from('phrase_playlist')
+						.update(m.changes as TablesUpdate<'phrase_playlist'>)
+						.eq('id', m.original.id)
+						.select()
+						.throwOnError()
 				)
-				return { refetch: false }
-			} catch (err) {
-				toastError('Failed to update playlist — please try again')
-				throw err
-			}
-		},
-		onDelete: async ({ transaction }) => {
-			// soft delete
-			try {
-				await supabase
-					.from('phrase_playlist')
-					.update({ deleted: true })
-					.in(
-						'id',
-						transaction.mutations.map((m) => m.original.id)
-					)
-					.throwOnError()
-				return { refetch: false }
-			} catch (err) {
-				toastError('Failed to delete playlist — please try again')
-				throw err
-			}
+			)
+			return { refetch: false }
 		},
 	})
 )

--- a/src/routes/_user/learn/$lang.manage-deck.tsx
+++ b/src/routes/_user/learn/$lang.manage-deck.tsx
@@ -18,7 +18,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { RequireAuth, useIsAuthenticated } from '@/components/require-auth'
 
 import { useDeckMeta, useDeckCards } from '@/features/deck/hooks'
-import { cardsCollection } from '@/features/deck/collections'
+import { updateCardsStatus } from '@/features/deck/card-status'
 import { useLangPhrasesRaw } from '@/features/phrases/hooks'
 import { type CardMetaType } from '@/features/deck/schemas'
 import { cn, sessionDaysDiff } from '@/lib/utils'
@@ -634,17 +634,10 @@ function DesktopCardRow({ row, lang }: { row: PhraseRow; lang: string }) {
 /* ── Shared: status change buttons ───────────────────────────── */
 
 function CardStatusActions({ row }: { row: PhraseRow }) {
-	// Update every card for this phrase (both directions) in one optimistic
-	// transaction. cardsCollection.onUpdate owns persistence; toasts are wired to
-	// the transaction here since the change is off-screen for skipped rows.
 	const setStatus = (status: 'active' | 'learned' | 'skipped') => {
 		const ids = row.cards.map((c) => c.id)
 		if (ids.length === 0) return
-		const tx = cardsCollection.update(ids, (drafts) => {
-			drafts.forEach((draft) => {
-				draft.status = status
-			})
-		})
+		const tx = updateCardsStatus(ids, row.phrase_id, row.status, status)
 		tx.isPersisted.promise.then(
 			() => toastSuccess(`Phrase status changed to "${status}"`),
 			(error) => {

--- a/src/routes/_user/learn/$lang.manage-deck.tsx
+++ b/src/routes/_user/learn/$lang.manage-deck.tsx
@@ -1,7 +1,5 @@
 import { CSSProperties, useMemo, useState } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { useMutation } from '@tanstack/react-query'
-import { PostgrestError } from '@supabase/supabase-js'
 import {
 	ArrowDown,
 	ArrowUp,
@@ -22,15 +20,9 @@ import { RequireAuth, useIsAuthenticated } from '@/components/require-auth'
 import { useDeckMeta, useDeckCards } from '@/features/deck/hooks'
 import { cardsCollection } from '@/features/deck/collections'
 import { useLangPhrasesRaw } from '@/features/phrases/hooks'
-import {
-	type CardMetaType,
-	CardStatusEnumSchema,
-} from '@/features/deck/schemas'
-import supabase from '@/lib/supabase-client'
-import { useUserId } from '@/lib/use-auth'
+import { type CardMetaType } from '@/features/deck/schemas'
 import { cn, sessionDaysDiff } from '@/lib/utils'
 import { calculateInterval } from '@/features/review'
-import { Tables } from '@/types/supabase'
 
 export const Route = createFileRoute('/_user/learn/$lang/manage-deck')({
 	component: ManageDeckPage,
@@ -642,39 +634,25 @@ function DesktopCardRow({ row, lang }: { row: PhraseRow; lang: string }) {
 /* ── Shared: status change buttons ───────────────────────────── */
 
 function CardStatusActions({ row }: { row: PhraseRow }) {
-	const userId = useUserId()
-
-	const mutation = useMutation<
-		Array<Tables<'user_card'>>,
-		PostgrestError,
-		{ status: 'active' | 'learned' | 'skipped' }
-	>({
-		mutationKey: ['manage-card-status', row.phrase_id],
-		mutationFn: async ({ status }) => {
-			const { data } = await supabase
-				.from('user_card')
-				.update({ status })
-				.eq('phrase_id', row.phrase_id)
-				.eq('uid', userId!)
-				.select()
-				.throwOnError()
-			return data
-		},
-		onSuccess: (data) => {
-			for (const c of data) {
-				cardsCollection.utils.writeUpdate({
-					id: c.id,
-					status: CardStatusEnumSchema.parse(c.status),
-					updated_at: c.updated_at!,
-				})
+	// Update every card for this phrase (both directions) in one optimistic
+	// transaction. cardsCollection.onUpdate owns persistence; toasts are wired to
+	// the transaction here since the change is off-screen for skipped rows.
+	const setStatus = (status: 'active' | 'learned' | 'skipped') => {
+		const ids = row.cards.map((c) => c.id)
+		if (ids.length === 0) return
+		const tx = cardsCollection.update(ids, (drafts) => {
+			drafts.forEach((draft) => {
+				draft.status = status
+			})
+		})
+		tx.isPersisted.promise.then(
+			() => toastSuccess(`Phrase status changed to "${status}"`),
+			(error) => {
+				console.log('Error', error)
+				toastError('Failed to update phrase status')
 			}
-			toastSuccess(`Phrase status changed to "${data[0]?.status}"`)
-		},
-		onError: (error) => {
-			toastError('Failed to update phrase status')
-			console.log('Error', error)
-		},
-	})
+		)
+	}
 
 	const buttons: Array<{
 		status: 'active' | 'learned' | 'skipped'
@@ -696,8 +674,7 @@ function CardStatusActions({ row }: { row: PhraseRow }) {
 						variant="ghost"
 						size="sm"
 						className="h-7 gap-1 px-2 text-xs"
-						disabled={mutation.isPending}
-						onClick={() => mutation.mutate({ status: b.status })}
+						onClick={() => setStatus(b.status)}
 						data-testid={`set-${b.status}-button`}
 					>
 						<b.Icon className="size-3" />

--- a/src/routes/_user/learn/-archived-deck-tile.tsx
+++ b/src/routes/_user/learn/-archived-deck-tile.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
 import { Archive, ArchiveRestore } from 'lucide-react'
 
 import { LangBadge } from '@/components/ui/badge'
@@ -14,44 +13,30 @@ import {
 } from '@/components/ui/dialog'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
 import { decksCollection } from '@/features/deck/collections'
-import { DeckMetaRawSchema, type DeckMetaType } from '@/features/deck/schemas'
+import { type DeckMetaType } from '@/features/deck/schemas'
 import { useDeckPids } from '@/features/deck/hooks'
 import { ago } from '@/lib/dayjs'
-import supabase from '@/lib/supabase-client'
-import { useUserId } from '@/lib/use-auth'
 
 export function ArchivedDeckTile({ deck }: { deck: DeckMetaType }) {
 	const [open, setOpen] = useState(false)
-	const userId = useUserId()
 	const { data: pids } = useDeckPids(deck.lang)
 
 	const totalCards = pids?.all.length ?? 0
 	const lastReviewed = ago(deck.most_recent_review_at)
 
-	const mutation = useMutation({
-		mutationFn: async () => {
-			const { data } = await supabase
-				.from('user_deck')
-				.update({ archived: false })
-				.eq('lang', deck.lang)
-				.eq('uid', userId!)
-				.select()
-				.maybeSingle()
-				.throwOnError()
-			return data
-		},
-		onSuccess: (data) => {
-			setOpen(false)
-			if (!data) return
-			decksCollection.utils.writeUpdate(DeckMetaRawSchema.parse(data))
-			toastSuccess('The deck has been re-activated!')
-		},
-		onError: (error) => {
-			toastError('Failed to restore the deck. Refreshing the page…')
-			console.log(error)
-			setTimeout(() => window.location.reload(), 1500)
-		},
-	})
+	const restoreDeck = () => {
+		const tx = decksCollection.update(deck.lang, (draft) => {
+			draft.archived = false
+		})
+		tx.isPersisted.promise.then(
+			() => toastSuccess('The deck has been re-activated!'),
+			(error) => {
+				console.log(error)
+				toastError('Failed to restore the deck')
+			}
+		)
+		setOpen(false)
+	}
 
 	return (
 		<>
@@ -109,15 +94,14 @@ export function ArchivedDeckTile({ deck }: { deck: DeckMetaType }) {
 					<div className="grid grid-cols-1 gap-3 @sm:grid-cols-2">
 						<button
 							type="button"
-							onClick={() => mutation.mutate()}
-							disabled={mutation.isPending}
+							onClick={restoreDeck}
 							data-testid="confirm-restore-button"
 							className="from-5-mhi-primary to-6-mid-primary text-primary-foreground hover:from-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 text-start shadow transition-transform hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-70"
 						>
 							<ArchiveRestore className="size-6" />
 							<div>
 								<div className="text-base leading-tight font-semibold">
-									{mutation.isPending ? 'Restoring…' : 'Yes, restore'}
+									Yes, restore
 								</div>
 								<div className="text-primary-foreground/80 text-xs">
 									Move back to your active decks


### PR DESCRIPTION
## Summary

Part of the #625 "transform" migration — replacing the deprecated `useMutation` + `collection.utils.writeInsert/writeUpdate/writeDelete` pattern with TanStack DB's collection-config pattern: persistence handlers (`onInsert/onUpdate/onDelete`) on the collection, optimistic intent (`collection.insert/update/delete`) at the call site, and success/error UX wired to `tx.isPersisted.promise`.

This batch clears the playlist edit/delete, deck-restore, and manage-deck card-status call sites — the single-call "low-hanging fruit" the weekly scans had flagged untouched for ~12 weeks — and along the way de-duplicates the card-status mutator into a shared module.

## Migrated call sites

- **`update-playlist-dialog.tsx`** — edit fires `phrasePlaylistsCollection.update(...)`; the dialog closes synchronously.
- **`delete-playlist-dialog.tsx`** — soft delete via `phrasePlaylistsCollection.update(draft.deleted = true)`, navigating away on persist.
- **`-archived-deck-tile.tsx`** — restore via `decksCollection.update(lang, draft.archived = false)` through the existing `onUpdate`; drops the old page-reload error recovery.
- **`manage-deck.tsx` (`CardStatusActions`)** — sets every card of a phrase in one optimistic transaction via the shared `updateCardsStatus()`.

## Collection changes

- **`phrasePlaylistsCollection`** gains an `onUpdate` handler (edits + soft-delete). Its `queryFn` now parses rows through `PhrasePlaylistSchema`, so the query cache stays schema-consistent with the validated optimistic rows written under `{ refetch: false }` — matching `phraseRequestsCollection`. (This consistency is what makes `isPersisted` resolve; the raw-row version left the two scenes hanging on their success toast.)

## Shared extraction — `src/features/deck/card-status.ts` (new)

`manage-deck` had reimplemented the card-status dropdown's mutator inline — and dropped its optimistic `count_learners` sync, so the phrase's learner count drifted until the next refetch. Pulled the kernel into one module both consume:

- `updateCardsStatus(cardIds, phraseId, fromStatus, toStatus)` — set a phrase's cards to a status in one optimistic tx, keep `count_learners` in sync, revert on rollback.
- `updatePhraseLearnerCount(...)` — the denormalized-count delta + reverter (the documented `write*` exception: a server-derived count with no normal handler).
- `LearningStatus` type.

`card-status-dropdown.tsx` now delegates its update path to `updateCardsStatus` (its insert-new-card path keeps its own inline count revert). Behavior there is unchanged; manage-deck gains the count sync it was missing.

## Deliberately not migrated

`features/deck/mutations.ts` deck-insert stays on the old pattern: a new `user_deck_plus` row's `daily_review_goal` / `review_answer_mode` come from a profile join, not the base table, so an accurate optimistic row can't be built client-side. (Same reason the already-migrated `StartLearningDialog` still uses `writeInsert` for deck creation.)

## Testing

- `pnpm scene scenetest/scenes/playlist-mutations.spec.ts scenetest/scenes/playlists.spec.md` — playlist edit & delete scenes.
- `pnpm check` + `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154TxrtG55ohyPmqs474h8e