### PR TITLE
Vendor OKLCH color system, remove tailwind-oklch npm dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ pnpm run seeds:schema   # regenerate base.sql — review the diff carefully
 - **New tests are scenetest markdown scenes** (`scenetest/scenes/*.spec.md`), never new `@playwright/test` specs — `e2e/` is deprecated (`transform` label). Navigate by clicking, not by reloading (`openTo` is for the entry point only).
 - **Format with oxfmt, never prettier** on TS/JS/CSS/MD/JSON (`npx oxfmt path/to/file.ts`); prettier is for SQL only. Tabs, not spaces. The pre-commit hook formats staged files automatically.
 - **Base UI, not Radix** for primitives: selected tabs get `data-active` (style with `data-[active]:`), not `data-state="active"`. Verify attribute names in `node_modules/@base-ui/react/esm/` types.
-- **Avoid `dark:` prefixes and opacity tints** (`bg-primary/10`) — the oklch color system auto-flips; use luminance steps (`bg-1-mlo-primary`). Full system: `docs/styling.md`.
+- **Avoid `dark:` prefixes and opacity tints** (`bg-primary/10`) — the oklch color system auto-flips; use luminance steps (`bg-lc-1`). Full system: `docs/styling.md`.
 
 ## Architecture
 
@@ -125,7 +125,7 @@ Route context carries `{ auth, queryClient }` — access auth via `Route.useRout
 - **`getKey` must return the row's real unique id.** Most collections use `item.id`, but not all (decks/languages → `item.lang`, profiles → `item.uid`, upvotes → the foreign key, link/composite-PK tables → composite strings) — always check the source table's unique constraint.
 - **Query keys** mirror collection ids (`['public', 'phrase_full']`).
 - **Dates**: `todayString()` (`@/lib/utils`) uses a 4am cutoff, not midnight — some people study after midnight; `ago()` and friends from `@/lib/dayjs`.
-- **UI**: always use the generic components (`<Input>`, `<Textarea>`, `<Button>`); toasts via `toastSuccess()`/`toastError()` from `@/components/ui/sonner`; `cn()` for conditional classes; `start`/`end` not `left`/`right` (RTL); `rounded-2xl` for interactive elements, `rounded` for cards; standard Tailwind classes over arbitrary values. oklch shorthand is `{prop}-{L}-{C}-{H}` (e.g. `bg-1-mlo-primary`) — full system and button-variant roles in `docs/styling.md`.
+- **UI**: always use the generic components (`<Input>`, `<Textarea>`, `<Button>`); toasts via `toastSuccess()`/`toastError()` from `@/components/ui/sonner`; `cn()` for conditional classes; `start`/`end` not `left`/`right` (RTL); `rounded-2xl` for interactive elements, `rounded` for cards; standard Tailwind classes over arbitrary values. oklch colors are single-axis and cascade-first: seed `hue-*`/`chroma-*` near a component's top, then state luminance per property (`bg-lc-1`, `text-lc-8`, `hover:bg-lc-up-1`) — full system and button-variant roles in `docs/styling.md`.
 - **DB**: singular table names, uuid primary keys, `created_at timestamptz default now()`, RLS on every `uid` table — never expose one without it. Workflow and seed conventions in `docs/database.md`.
 - **Test selectors**: use semantic `data-testid`s (`affirm-community-norms-button`), `data-key` for list items; register new ids in `scenetest/TEST_IDS.md`.
 - **Realtime**: subscribe in `useEffect`, parse the payload with the Zod schema, and `writeInsert` into the collection (see `docs/mutations.md`).

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -1,48 +1,67 @@
 # Styling
 
-## tailwind-oklch Color System
+## OKLCH Color System
 
-This project uses the **tailwind-oklch** plugin for composable, auto-flipping OKLCH colors. Every color is built from three axes: **luminance contrast** (L), **chroma** (C), and **hue** (H).
+This project uses a **vendored, single-axis OKLCH color system** — `src/styles/oklch.css` (forked from `mhsnook/tailwind-oklch@112de8e`, MIT; no npm dependency, no JS plugin). Every color is composed from three independent axes: **luminance contrast** (`lc`), **chroma** (`chroma`), and **hue** (`hue`). The system auto-flips between light and dark mode, so you almost never write `dark:`.
 
-### Shorthand syntax (preferred when setting all three axes)
+The guiding idea: **each class states one fact about one axis.** Hue and chroma flow _down the cascade_ from container seeders, so most elements only ever say what their luminance is.
+
+### Say each axis once, as low in the tree as it changes
+
+There are two kinds of class:
+
+**Cascade seeders** set an axis for _everything below them_ and apply no property themselves. Put them near a component's root:
 
 ```
-{prop}-{L}-{C}-{H}
+hue-primary · hue-danger · hue-success · …     seeds hue for descendants
+chroma-mlo · chroma-hi · …                     seeds chroma for descendants
 ```
 
-Examples:
+**Per-property setters** apply exactly one CSS property from one axis. Luminance is the one you set constantly; chroma and hue inherit from a seeder (or the `:root` default) unless set explicitly:
 
 ```typescript
-// Background: luminance 1, chroma mlo, hue primary
-className = 'bg-1-mlo-primary'
-
-// Text: luminance 6, chroma hi, hue info
-className = 'text-6-hi-info'
-
-// Border: luminance 4, chroma mid, hue danger
-className = 'border-4-mid-danger'
-
-// Works with variants:
-className = 'hover:bg-2-mlo-info'
+// A "generally green, generally lowkey" component: seed once at the top…
+;<div className="hue-success chroma-mlo">
+	{/* …then speak luminance inside */}
+	<div className="bg-lc-1">
+		<span className="text-lc-8">…</span>
+		<hr className="border-lc-3" />
+	</div>
+</div>
 ```
 
-**Always use the shorthand** when setting all three axes. Only use decomposed form (`bg-lc-* bg-c-* bg-h-*`) when overriding a single axis or using adjustment utilities.
+Because `:root` already seeds `hue-primary` + low chroma, a brand-colored surface often needs only `bg-lc-1`. Per-language dynamic theming keeps working automatically — it overrides the `--hue-*` variables everything resolves through.
 
-### Luminance contrast scale (L)
+Each property has the full trio; set only the axes that differ from what's inherited:
 
-The 0–10 scale auto-flips between light and dark mode:
+```typescript
+className = 'bg-lc-1 bg-chroma-mlo bg-hue-primary' // all three explicit
+className = 'text-lc-6 text-chroma-hi text-hue-info'
+className = 'border-lc-3 border-chroma-mlo border-hue-primary'
+className = 'hover:bg-lc-2' // luminance only; chroma+hue inherited
+```
+
+Property prefixes: `bg-`, `text-`, `border-`, `border-b-`, `from-`, `to-` (gradient stops).
+
+### Luminance contrast scale (`lc`)
+
+`{prop}-lc-{0–10 | base | fore | none | full}`. The scale auto-flips between light and dark mode:
 
 | Value         | Light mode        | Dark mode         | Meaning          |
 | ------------- | ----------------- | ----------------- | ---------------- |
 | `0` / `base`  | 0.95 (near white) | 0.12 (near black) | Blends with page |
-| `1`           | 0.87              | 0.20              | Subtle tint      |
-| `5`           | 0.55              | 0.52              | Mid-contrast     |
-| `7`           | 0.39              | 0.68              | Prominent        |
+| `1`           | 0.91              | 0.20              | Subtle tint      |
+| `5`           | 0.63              | 0.52              | Mid-contrast     |
+| `7`           | 0.44              | 0.68              | Prominent        |
 | `10` / `fore` | 0.15 (near black) | 0.92 (near white) | Maximum contrast |
 | `none`        | 1.0 (white)       | 0.0 (black)       | Beyond base      |
 | `full`        | 0.0 (black)       | 1.0 (white)       | Beyond fore      |
 
-### Chroma stops (C)
+Arbitrary luminance auto-flips too: `bg-lc-[93]` → L=0.93 in light, 0.07 in dark.
+
+### Chroma stops (`chroma`)
+
+`{prop}-chroma-{lo | mlo | mid | mhi | hi}`, or the seeder `chroma-{…}`:
 
 | Name  | Value | Use for                            |
 | ----- | ----- | ---------------------------------- |
@@ -52,32 +71,30 @@ The 0–10 scale auto-flips between light and dark mode:
 | `mhi` | 0.18  | Prominent accents                  |
 | `hi`  | 0.25  | Vivid, saturated colors            |
 
-### Available hues (H)
+Arbitrary chroma is `n/100`: `border-chroma-[6]` → chroma 0.06.
 
-`primary` (300), `accent` (175), `neutral` (270), `success` (145), `warning` (55), `danger` (15), `info` (220)
+### Available hues (`hue`)
 
-### Adjustment utilities (single-axis overrides)
+`{prop}-hue-{…}` or the seeder `hue-{…}`. App palette (overridden in `globals.css`): `primary` (300), `accent` (175), `neutral` (270); plus `success` (145), `warning` (55), `danger` (15), `info` (220). Dynamic per-language hue is applied as an inline `--hue-*` style variable, not a utility.
 
-Use these when you need to nudge ONE axis, inheriting the others from a parent or shorthand:
+### Relative adjustments
+
+Nudge off the _inherited/current_ luminance without rewriting it — ideal for hover/active states:
 
 ```typescript
-// Adjust luminance: more contrast (+) or less contrast (-)
-className = 'bg-1-mlo-primary group-hover:bg-lc-up-1'
-
-// Override just the hue on a child element
-className = 'bg-h-accent'
-
-// Override just the chroma
-className = 'text-c-hi'
+className = 'bg-lc-1 hover:bg-lc-up-1' // one step more contrast on hover
+className = 'text-lc-7 group-hover:text-lc-down-1' // one step less
 ```
+
+`{prop}-lc-up-{1|2|3}` / `{prop}-lc-down-{1|2|3}`. Adjustments **don't compound**: a grandchild's `lc-up-1` nudges from the nearest ancestor's _set_ luminance, not from a parent's already-nudged value.
 
 ### Semantic color tokens
 
-Defined in `globals.css`, these bridge the tailwind-oklch scale with traditional Tailwind tokens:
+Defined in `globals.css`, these bridge the OKLCH scale with traditional Tailwind tokens:
 
 | Token                                  | Definition                | Notes                                                                 |
 | -------------------------------------- | ------------------------- | --------------------------------------------------------------------- |
-| `primary`                              | L=5, C=hi, hue-primary    | Auto-flips via plugin                                                 |
+| `primary`                              | L=5, C=hi, hue-primary    | Auto-flips                                                            |
 | `primary-foresoft`                     | L=7, C=hi, hue-primary    | Auto-flips; the "interactive purple" for links, soft buttons, borders |
 | `primary-foreground`                   | Fixed L=0.93              | Always near-white — for text ON primary surfaces only                 |
 | `accent` / `accent-foresoft`           | L=5/7, C=hi, hue-accent   | Auto-flips                                                            |
@@ -86,11 +103,17 @@ Defined in `globals.css`, these bridge the tailwind-oklch scale with traditional
 
 ### When to use what
 
-- **Semantic tokens** (`text-primary`, `bg-card`, `border-border`): For UI primitives that use the same color everywhere
-- **Shorthand** (`bg-1-mlo-info`): For one-off colored elements — icon backgrounds, tinted surfaces, status indicators
-- **Decomposed** (`bg-lc-up-1`, `text-c-hi`): For hover/focus adjustments or overriding one axis of an inherited color
-- **Avoid `dark:` prefixes** — the oklch scale and semantic tokens auto-flip. Only use `dark:` for truly exceptional cases (e.g. marketing page with custom gradient backgrounds)
-- **Avoid opacity-based tints** (`bg-primary/10`) — use luminance steps instead (`bg-1-mlo-primary`) for consistent appearance across monitors
+- **Semantic tokens** (`text-primary`, `bg-card`, `border-border`): UI primitives that use the same color everywhere.
+- **Cascade seeder + `lc` inside** (`hue-success chroma-mlo` at the top, `bg-lc-1` / `text-lc-8` below): the default shape for a colored component — declare its character once, speak luminance within. Portable: drop it under a different seeder (a danger context, a lang-themed subtree) and it takes on that character.
+- **Explicit per-property axes** (`bg-lc-1 bg-chroma-mlo bg-hue-info`): one-off colored elements, or shared components used in many contexts where you want the color pinned rather than inherited.
+- **Adjustments** (`hover:bg-lc-up-1`): hover/focus/active state changes.
+- **Avoid `dark:` prefixes** — the scale and semantic tokens auto-flip. Reserve `dark:` for genuinely exceptional cases (e.g. a marketing page with custom gradients).
+- **Avoid opacity tints** (`bg-primary/10`) — the `lc/chroma/hue` utilities don't support the `/opacity` modifier; use a luminance step (`bg-lc-1`) instead for consistent appearance across monitors.
+
+### Caveats
+
+- **Portals break the cascade.** Base UI dialogs/popovers/dropdowns render into a portal, not under their trigger's DOM ancestor. Portal content must re-seed its own `hue`/`chroma`; never rely on inheritance across a portal boundary.
+- **Shared components inherit their context.** That's the feature (it's how `button.tsx` shares its `solids`/`softs` classes across hue variants), but when pruning axes from a shared component, check every render context — keep axes explicit unless the context-sensitivity is wanted.
 
 ## Styling Conventions
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
 		"react-markdown": "^10.1.0",
 		"recharts": "^3.7.0",
 		"sonner": "^1.7.0",
-		"tailwind-oklch": "github:mhsnook/tailwind-oklch#main",
 		"tailwindcss-animate": "^1.0.7",
 		"vaul": "^1.1.2",
 		"zod": "^4.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       sonner:
         specifier: ^1.7.0
         version: 1.7.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      tailwind-oklch:
-        specifier: github:mhsnook/tailwind-oklch#main
-        version: https://codeload.github.com/mhsnook/tailwind-oklch/tar.gz/112de8ee25571842520abcbea54a98f54cdb66f5(tailwindcss@4.3.0)
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.3.0)
@@ -3127,12 +3124,6 @@ packages:
 
   tailwind-merge@2.6.1:
     resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
-
-  tailwind-oklch@https://codeload.github.com/mhsnook/tailwind-oklch/tar.gz/112de8ee25571842520abcbea54a98f54cdb66f5:
-    resolution: {tarball: https://codeload.github.com/mhsnook/tailwind-oklch/tar.gz/112de8ee25571842520abcbea54a98f54cdb66f5}
-    version: 0.6.0
-    peerDependencies:
-      tailwindcss: '>=4.0.0'
 
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
@@ -6283,10 +6274,6 @@ snapshots:
   tabbable@6.4.0: {}
 
   tailwind-merge@2.6.1: {}
-
-  tailwind-oklch@https://codeload.github.com/mhsnook/tailwind-oklch/tar.gz/112de8ee25571842520abcbea54a98f54cdb66f5(tailwindcss@4.3.0):
-    dependencies:
-      tailwindcss: 4.3.0
 
   tailwindcss-animate@1.0.7(tailwindcss@4.3.0):
     dependencies:

--- a/src/components/browse-search-overlay.tsx
+++ b/src/components/browse-search-overlay.tsx
@@ -208,7 +208,7 @@ export default function BrowseSearchOverlay({
 									'rounded-full border px-2.5 py-1 text-xs font-medium transition-colors',
 									selectedLangs.includes(l.code)
 										? 'bg-primary-foresoft text-primary-foreground border-transparent'
-										: 'border-border text-muted-foreground hover:border-4-mlo-primary hover:text-foreground'
+										: 'border-border text-muted-foreground hover:border-lc-4 hover:border-chroma-mlo hover:border-hue-primary hover:text-foreground'
 								)}
 							>
 								{l.name}
@@ -223,7 +223,7 @@ export default function BrowseSearchOverlay({
 								// oxlint-disable-next-line jsx-no-jsx-as-prop
 								<button
 									type="button"
-									className="border-border text-muted-foreground hover:border-4-mlo-primary hover:text-foreground flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors"
+									className="border-border text-muted-foreground hover:border-lc-4 hover:border-chroma-mlo hover:border-hue-primary hover:text-foreground flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors"
 								>
 									<Plus className="size-3" />
 									more

--- a/src/components/card-pieces/card-status-dropdown.tsx
+++ b/src/components/card-pieces/card-status-dropdown.tsx
@@ -136,10 +136,10 @@ function StatusSpan({ choice }: { choice: ShowableActions }) {
 // one shape, one size, just hue swapping with the state.
 const triggerDotClass: Record<ShowableActions, string> = {
 	active: 'bg-primary',
-	learned: 'bg-5-hi-success',
-	skipped: 'bg-4-lo-neutral',
-	nocard: 'bg-3-lo-neutral',
-	nodeck: 'bg-3-lo-neutral',
+	learned: 'bg-lc-5 bg-chroma-hi bg-hue-success',
+	skipped: 'bg-lc-4 bg-chroma-lo bg-hue-neutral',
+	nocard: 'bg-lc-3 bg-chroma-lo bg-hue-neutral',
+	nodeck: 'bg-lc-3 bg-chroma-lo bg-hue-neutral',
 }
 
 function useCardStatusMutator(
@@ -282,21 +282,33 @@ export function CardStatusDropdown({
 						<>
 							<DropdownMenuItem
 								onClick={() => pickStatus('active')}
-								className={card.status === 'active' ? 'bg-0-mid-primary' : ''}
+								className={
+									card.status === 'active'
+										? 'bg-lc-0 bg-chroma-mid bg-hue-primary'
+										: ''
+								}
 								data-testid="activate-card-option"
 							>
 								<StatusSpan choice="active" />
 							</DropdownMenuItem>
 							<DropdownMenuItem
 								onClick={() => pickStatus('learned')}
-								className={card.status === 'learned' ? 'bg-0-mid-primary' : ''}
+								className={
+									card.status === 'learned'
+										? 'bg-lc-0 bg-chroma-mid bg-hue-primary'
+										: ''
+								}
 								data-testid="set-learned-option"
 							>
 								<StatusSpan choice="learned" />
 							</DropdownMenuItem>
 							<DropdownMenuItem
 								onClick={() => pickStatus('skipped')}
-								className={card.status === 'skipped' ? 'bg-0-mid-primary' : ''}
+								className={
+									card.status === 'skipped'
+										? 'bg-lc-0 bg-chroma-mid bg-hue-primary'
+										: ''
+								}
 								data-testid="ignore-card-option"
 							>
 								<StatusSpan choice="skipped" />
@@ -473,7 +485,7 @@ function StartLearningDialog({
 						onClick={() => void handleConfirm()}
 						disabled={pending}
 						data-testid="confirm-start-learning-button"
-						className="from-5-mhi-primary to-6-mid-primary text-primary-foreground hover:from-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 text-start shadow transition-transform hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-70"
+						className="from-lc-5 from-chroma-mhi from-hue-primary to-lc-6 to-chroma-mid to-hue-primary text-primary-foreground hover:from-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 text-start shadow transition-transform hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-70"
 					>
 						{isUnarchive ? (
 							<ArchiveRestore className="size-6" />
@@ -500,7 +512,7 @@ function StartLearningDialog({
 
 					<DialogClose
 						data-testid="cancel-start-learning-button"
-						className="border-2-lo-neutral bg-1-mlo-neutral text-7-mid-neutral hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl border p-4 text-start shadow transition-transform hover:-translate-y-0.5"
+						className="border-lc-2 border-chroma-lo border-hue-neutral bg-lc-1 bg-chroma-mlo bg-hue-neutral text-lc-7 text-chroma-mid text-hue-neutral hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl border p-4 text-start shadow transition-transform hover:-translate-y-0.5"
 					>
 						<Bookmark className="size-6" />
 						<div>

--- a/src/components/cards/tap-to-select.tsx
+++ b/src/components/cards/tap-to-select.tsx
@@ -29,7 +29,7 @@ export function TapCardToSelect({
 		<CardlikeFlashcard
 			onClick={() => toggleCardSelection(pid)}
 			key={pid}
-			className={`hover:bg-1-mlo-primary cursor-pointer transition-all ${isSelected ? 'border-primary bg-0-lo-primary' : ''}`}
+			className={`hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary cursor-pointer transition-all ${isSelected ? 'border-primary bg-lc-0 bg-chroma-lo bg-hue-primary' : ''}`}
 			style={{ viewTransitionName: `phrase-${pid}` } as CSSProperties}
 		>
 			<CardHeader className="p-3 pb-0">

--- a/src/components/comments/comment-dialog.tsx
+++ b/src/components/comments/comment-dialog.tsx
@@ -370,7 +370,7 @@ function AttachedPhraseCards({
 							...prev,
 							attaching: true,
 						})}
-						className="border-2-lo-primary text-muted-foreground hover:bg-1-lo-primary hover:text-7-mid-primary hover:border-4-mlo-primary flex h-30 min-w-50 basis-50 cursor-pointer items-center justify-center rounded-xl border-2 border-dashed transition-colors"
+						className="border-lc-2 border-chroma-lo border-hue-primary text-muted-foreground hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-primary hover:text-lc-7 hover:text-chroma-mid hover:text-hue-primary hover:border-lc-4 hover:border-chroma-mlo hover:border-hue-primary flex h-30 min-w-50 basis-50 cursor-pointer items-center justify-center rounded-xl border-2 border-dashed transition-colors"
 					>
 						<Plus className="h-6 w-6" />
 					</Link>

--- a/src/components/comments/comment-with-replies.tsx
+++ b/src/components/comments/comment-with-replies.tsx
@@ -62,7 +62,7 @@ export function CommentWithReplies({ comment, lang }: CommentThreadProps) {
 				isFocused
 					? 'border-primary bg-card/50 rounded border border-s-2'
 					: hasHighlightedReply
-						? 'border-3-mlo-primary bg-card/50 rounded border border-s-2'
+						? 'border-lc-3 border-chroma-mlo border-hue-primary bg-card/50 rounded border border-s-2'
 						: ''
 			} p-4`}
 			data-comment-id={comment.id}

--- a/src/components/comments/select-phrases-for-comment.tsx
+++ b/src/components/comments/select-phrases-for-comment.tsx
@@ -82,31 +82,32 @@ export function SelectPhrasesForComment({
 	const isMaxReached = selectedPhraseIds.length >= effectiveMax
 
 	const countDisplay =
-		maxPhrases === null ?
-			`${selectedPhraseIds.length} selected`
-		:	`${selectedPhraseIds.length}/${maxPhrases}`
+		maxPhrases === null
+			? `${selectedPhraseIds.length} selected`
+			: `${selectedPhraseIds.length}/${maxPhrases}`
 
-	const triggerButton =
-		cardShape ?
-			<button
-				type="button"
-				disabled={isMaxReached}
-				data-testid="open-phrase-picker"
-				className="border-2-lo-primary text-muted-foreground hover:bg-1-lo-primary hover:text-7-mid-primary hover:border-4-mlo-primary flex h-30 min-w-50 basis-50 cursor-pointer items-center justify-center rounded-xl border-2 border-dashed transition-colors disabled:pointer-events-none disabled:opacity-50"
-			>
-				<Plus className="h-6 w-6" />
-			</button>
-		:	<Button
-				type="button"
-				variant="soft"
-				size="sm"
-				disabled={isMaxReached}
-				data-testid="open-phrase-picker"
-				className={className}
-			>
-				<Paperclip className="h-4 w-4" />
-				{isMaxReached ? triggerMaxText : triggerText}
-			</Button>
+	const triggerButton = cardShape ? (
+		<button
+			type="button"
+			disabled={isMaxReached}
+			data-testid="open-phrase-picker"
+			className="border-lc-2 border-chroma-lo border-hue-primary text-muted-foreground hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-primary hover:text-lc-7 hover:text-chroma-mid hover:text-hue-primary hover:border-lc-4 hover:border-chroma-mlo hover:border-hue-primary flex h-30 min-w-50 basis-50 cursor-pointer items-center justify-center rounded-xl border-2 border-dashed transition-colors disabled:pointer-events-none disabled:opacity-50"
+		>
+			<Plus className="h-6 w-6" />
+		</button>
+	) : (
+		<Button
+			type="button"
+			variant="soft"
+			size="sm"
+			disabled={isMaxReached}
+			data-testid="open-phrase-picker"
+			className={className}
+		>
+			<Paperclip className="h-4 w-4" />
+			{isMaxReached ? triggerMaxText : triggerText}
+		</Button>
+	)
 
 	return (
 		<Dialog open={phraseDialogOpen} onOpenChange={setPhraseDialogOpen}>
@@ -114,16 +115,16 @@ export function SelectPhrasesForComment({
 			<DialogContent className="grid max-h-[98dvh] grid-rows-[auto_minmax(0,1fr)] gap-0 overflow-hidden px-4 pt-0 pb-4 sm:px-6 sm:pb-6">
 				<DialogHeader className="flex-none border-b p-6 pb-4">
 					<DialogTitle>
-						{showCreateForm ?
-							'Create New Phrase'
-						:	`Select Flashcards (${countDisplay})`}
+						{showCreateForm
+							? 'Create New Phrase'
+							: `Select Flashcards (${countDisplay})`}
 					</DialogTitle>
 					<DialogDescription>
-						{showCreateForm ?
-							'Add a new phrase to the library'
-						: maxPhrases === null ?
-							'Select flashcards to add'
-						:	`Choose up to ${maxPhrases} flashcards`}
+						{showCreateForm
+							? 'Add a new phrase to the library'
+							: maxPhrases === null
+								? 'Select flashcards to add'
+								: `Choose up to ${maxPhrases} flashcards`}
 					</DialogDescription>
 					{!showCreateForm && (
 						<div className="relative mt-2">
@@ -143,13 +144,14 @@ export function SelectPhrasesForComment({
 				<div className="min-h-0 overflow-hidden">
 					<ScrollArea className="h-full">
 						<div className="flex flex-col gap-3 p-6">
-							{showCreateForm ?
+							{showCreateForm ? (
 								<InlinePhraseCreator
 									lang={lang}
 									onPhraseCreated={handlePhraseCreated}
 									onCancel={() => setShowCreateForm(false)}
 								/>
-							:	<>
+							) : (
+								<>
 									<Button
 										type="button"
 										variant="dashed-w-full"
@@ -159,11 +161,12 @@ export function SelectPhrasesForComment({
 										<Plus className="h-4 w-4" />
 										Create new phrase
 									</Button>
-									{!filteredPhrases?.length ?
+									{!filteredPhrases?.length ? (
 										<p className="text-muted-foreground py-8 text-center">
 											No phrases found
 										</p>
-									:	filteredPhrases
+									) : (
+										filteredPhrases
 											.filter(
 												(phrase) => !selectedPhraseIds.includes(phrase.id)
 											)
@@ -180,9 +183,9 @@ export function SelectPhrasesForComment({
 													<PhraseTinyCard pid={phrase.id} nonInteractive />
 												</button>
 											))
-									}
+									)}
 								</>
-							}
+							)}
 						</div>
 					</ScrollArea>
 				</div>

--- a/src/components/dev-identity-switcher.tsx
+++ b/src/components/dev-identity-switcher.tsx
@@ -162,9 +162,9 @@ function Switcher() {
 										disabled={busy || active}
 										onClick={() => void switchTo(a.email)}
 										className={cn(
-											'hover:bg-1-mlo-primary flex w-full items-baseline justify-between gap-2 rounded border-s-2 border-transparent px-2 py-1 text-start text-sm disabled:opacity-100',
+											'hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary flex w-full items-baseline justify-between gap-2 rounded border-s-2 border-transparent px-2 py-1 text-start text-sm disabled:opacity-100',
 											active &&
-												'bg-2-mlo-primary border-s-primary-foresoft font-medium'
+												'bg-lc-2 bg-chroma-mlo bg-hue-primary border-s-primary-foresoft font-medium'
 										)}
 									>
 										<span className="truncate">

--- a/src/components/errors.tsx
+++ b/src/components/errors.tsx
@@ -77,14 +77,9 @@ export const ShowErrorDontLog = memo(function ShowAndLogError({
 			Icon={DestructiveTriangle}
 		>
 			<strong>
-				{'status' in error ?
-					<> (Error {error.status}) </>
-				:	null}
+				{'status' in error ? <> (Error {error.status}) </> : null}
 				{/* Text is only for display purposes; not logged */}
-				{text}{' '}
-				{'cause' in error ?
-					<>({error.cause})</>
-				:	null}
+				{text} {'cause' in error ? <>({error.cause})</> : null}
 			</strong>
 			<p>{error.message} </p>
 		</Callout>
@@ -158,5 +153,7 @@ function Logger({
 }
 
 function DestructiveTriangle() {
-	return <TriangleAlert className="text-5-mhi" aria-hidden={true} />
+	return (
+		<TriangleAlert className="text-lc-5 text-chroma-mhi" aria-hidden={true} />
+	)
 }

--- a/src/components/feed/feed-composer.tsx
+++ b/src/components/feed/feed-composer.tsx
@@ -23,7 +23,7 @@ export function FeedComposer({ lang }: { lang: string }) {
 					<button
 						type="button"
 						data-testid="feed-composer-trigger"
-						className="border-3-mlo-primary hover:border-primary bg-card text-muted-foreground mb-3 flex h-10 w-full rounded-2xl border px-3 py-2 text-start text-sm inset-shadow-sm transition-colors"
+						className="border-lc-3 border-chroma-mlo border-hue-primary hover:border-primary bg-card text-muted-foreground mb-3 flex h-10 w-full rounded-2xl border px-3 py-2 text-start text-sm inset-shadow-sm transition-colors"
 					>
 						Ask the community for a phrase...
 					</button>

--- a/src/components/fields/cover-image-field.tsx
+++ b/src/components/fields/cover-image-field.tsx
@@ -30,7 +30,7 @@ export function CoverImageField({ label = 'Cover Image' }: { label?: string }) {
 				<Label
 					htmlFor="coverImageUploadInput"
 					className={cn(
-						'group border-3-mlo-primary hover:border-primary hover:bg-1-mlo-primary relative isolate flex h-32 flex-col items-center justify-center rounded-2xl border text-center',
+						'group border-lc-3 border-chroma-mlo border-hue-primary hover:border-primary hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary relative isolate flex h-32 flex-col items-center justify-center rounded-2xl border text-center',
 						url && 'h-auto'
 					)}
 				>

--- a/src/components/fields/language-picker.tsx
+++ b/src/components/fields/language-picker.tsx
@@ -133,7 +133,7 @@ function LangRow({
 		<button
 			type="button"
 			data-key={code}
-			className="hover:bg-1-lo-primary focus-visible:bg-1-lo-primary text-foreground flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2 text-left transition-colors outline-none"
+			className="hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-primary focus-visible:bg-lc-1 focus-visible:bg-chroma-lo focus-visible:bg-hue-primary text-foreground flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2 text-left transition-colors outline-none"
 			onClick={() => onPick(code)}
 		>
 			<span className="min-w-0 flex-1 truncate text-sm font-semibold">
@@ -397,7 +397,9 @@ export function LanguagePickerTrigger({
 				'flex w-full items-center gap-2.5 rounded-2xl border bg-card/50 px-3.5 py-2.5 text-left text-sm font-sans inset-shadow-sm',
 				'ring-offset-background cursor-pointer hover:border-primary',
 				'focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden',
-				hasError ? 'border-destructive' : 'border-3-mlo-primary',
+				hasError
+					? 'border-destructive'
+					: 'border-lc-3 border-chroma-mlo border-hue-primary',
 				!value && 'text-muted-foreground',
 				className
 			)}

--- a/src/components/friend-search-overlay.tsx
+++ b/src/components/friend-search-overlay.tsx
@@ -114,5 +114,5 @@ export default function FriendSearchOverlay({
 }
 
 const BigGarlic = () => (
-	<Garlic className="bg-2-mlo-primary w-20 rounded-full p-3 @xl:p-4" />
+	<Garlic className="bg-lc-2 bg-chroma-mlo bg-hue-primary w-20 rounded-full p-3 @xl:p-4" />
 )

--- a/src/components/intro-callout.tsx
+++ b/src/components/intro-callout.tsx
@@ -24,7 +24,7 @@ export function IntroCallout({
 	return (
 		<div
 			className={cn(
-				'border-3-mlo-primary bg-1-mlo-primary flex items-start gap-2 rounded border px-3 py-2 text-sm',
+				'border-lc-3 border-chroma-mlo border-hue-primary bg-lc-1 bg-chroma-mlo bg-hue-primary flex items-start gap-2 rounded border px-3 py-2 text-sm',
 				className
 			)}
 		>

--- a/src/components/intros/community-norms-intro.tsx
+++ b/src/components/intros/community-norms-intro.tsx
@@ -54,7 +54,7 @@ export function CommunityNormsIntro({
 					/>
 				</div>
 
-				<div className="bg-0-lo-primary rounded-lg border p-4 text-sm">
+				<div className="bg-lc-0 bg-chroma-lo bg-hue-primary rounded-lg border p-4 text-sm">
 					<p className="font-medium">What this means in practice:</p>
 					<ul className="text-muted-foreground mt-2 ml-4 list-disc space-y-1">
 						<li>Don't add joke translations or misleading content</li>
@@ -82,7 +82,7 @@ function NormItem({
 }) {
 	return (
 		<div className="flex gap-3">
-			<div className="bg-1-mlo-primary text-primary flex size-10 shrink-0 items-center justify-center rounded-full">
+			<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary text-primary flex size-10 shrink-0 items-center justify-center rounded-full">
 				<Icon className="size-5" />
 			</div>
 			<div>

--- a/src/components/intros/review-intro.tsx
+++ b/src/components/intros/review-intro.tsx
@@ -66,7 +66,7 @@ export function ReviewIntro({ open, onClose }: ReviewIntroProps) {
 					</ol>
 				</div>
 
-				<div className="bg-0-lo-primary rounded-lg border p-3 text-sm">
+				<div className="bg-lc-0 bg-chroma-lo bg-hue-primary rounded-lg border p-3 text-sm">
 					<p className="font-medium">Tip: Consistency beats intensity</p>
 					<p className="text-muted-foreground mt-1">
 						10 minutes every day is better than an hour once a week. Try to

--- a/src/components/login-card-body.tsx
+++ b/src/components/login-card-body.tsx
@@ -36,10 +36,10 @@ function InvalidCredentialsError() {
 			data-testid="login-error-invalid-credentials"
 			className="animate-shake flex items-center gap-2"
 		>
-			<span className="hue-danger bg-5-mhi flex size-7 shrink-0 items-center justify-center rounded-full">
+			<span className="hue-danger bg-lc-5 bg-chroma-mhi flex size-7 shrink-0 items-center justify-center rounded-full">
 				<X className="size-4 text-white" aria-hidden={true} />
 			</span>
-			<strong className="text-7-mhi-danger">
+			<strong className="text-lc-7 text-chroma-mhi text-hue-danger">
 				Incorrect email or password. Try again?
 			</strong>
 		</div>

--- a/src/components/navs/active-review-callout.tsx
+++ b/src/components/navs/active-review-callout.tsx
@@ -44,7 +44,7 @@ function ReviewRemainingLink({
 			<span className="text-xs font-medium group-hover:underline">
 				{languages[lang]}
 			</span>
-			<span className="text-5-mlo-primary group-hover:text-lc-up-1 text-xs font-bold">
+			<span className="text-lc-5 text-chroma-mlo text-hue-primary group-hover:text-lc-up-1 text-xs font-bold">
 				{remaining} left
 			</span>
 		</Link>
@@ -85,10 +85,9 @@ export function ActiveReviewCallout({
 	const lang = currentLang ? String(currentLang) : undefined
 	const currentLangHasActiveReview = lang && activeReviews.has(lang)
 
-	const activeList =
-		currentLangHasActiveReview ?
-			[{ lang, remaining: activeReviews.get(lang)! }]
-		:	Array.from(activeReviews.entries()).map(([lang, remaining]) => ({
+	const activeList = currentLangHasActiveReview
+		? [{ lang, remaining: activeReviews.get(lang)! }]
+		: Array.from(activeReviews.entries()).map(([lang, remaining]) => ({
 				lang,
 				remaining,
 			}))
@@ -114,7 +113,7 @@ export function ActiveReviewCallout({
 }
 
 const calloutCard =
-	'border-lc-[87] border-c-[6] border-h-primary bg-lc-[93] bg-c-[4] bg-h-primary mx-2 mb-2 rounded-xl border p-3'
+	'border-lc-[87] border-chroma-[6] border-hue-primary bg-lc-[93] bg-chroma-[4] bg-hue-primary mx-2 mb-2 rounded-xl border p-3'
 const iconCircle = 'rounded-lg bg-white p-1.5'
 
 function CalloutContent({
@@ -137,7 +136,7 @@ function CalloutContent({
 				to="/learn/$lang/review"
 				params={{ lang: activeReviews[0].lang }}
 				onClick={setClosedMobile}
-				className="text-5-mid-primary hover:bg-lc-up-1 mx-auto flex h-8 w-8 items-center justify-center rounded-lg bg-white transition-colors"
+				className="text-lc-5 text-chroma-mid text-hue-primary hover:bg-lc-up-1 mx-auto flex h-8 w-8 items-center justify-center rounded-lg bg-white transition-colors"
 				aria-label="Active review in progress"
 			>
 				<Rocket className="h-4 w-4" />
@@ -152,7 +151,7 @@ function CalloutContent({
 			<div className={calloutCard}>
 				<div className="flex items-center gap-2">
 					<div className={iconCircle}>
-						<Rocket className="text-5-mid-primary h-4 w-4" />
+						<Rocket className="text-lc-5 text-chroma-mid text-hue-primary h-4 w-4" />
 					</div>
 					<div className="flex-1">
 						<p className="text-sm font-semibold">{remaining} cards left</p>
@@ -182,7 +181,7 @@ function CalloutContent({
 		<div className={calloutCard}>
 			<div className="flex items-center gap-2">
 				<div className={iconCircle}>
-					<Rocket className="text-5-mid-primary h-4 w-4" />
+					<Rocket className="text-lc-5 text-chroma-mid text-hue-primary h-4 w-4" />
 				</div>
 				<span className="text-sm font-semibold">Finish your review</span>
 			</div>

--- a/src/components/navs/app-nav.tsx
+++ b/src/components/navs/app-nav.tsx
@@ -29,7 +29,7 @@ const activeOptions = { exact: true, includeSearch: false } as const
 const inexactOptions = { exact: false, includeSearch: false } as const
 const inactiveProps = {
 	className:
-		'border-transparent text-muted-foreground hover:text-7-mhi-primary',
+		'border-transparent text-muted-foreground hover:text-lc-7 hover:text-chroma-mhi hover:text-hue-primary',
 } as const
 
 export function AppNav() {
@@ -55,15 +55,15 @@ export function AppNav() {
 			<div ref={ref}></div>
 
 			<div
-				className={`bg-base-lo-neutral sticky z-30 mt-1 border-b transition-colors ${entry?.isIntersecting === false ? 'border-border' : 'border-transparent'} top-0 flex w-full flex-row items-center justify-between gap-2`}
+				className={`bg-lc-base bg-chroma-lo bg-hue-neutral sticky z-30 mt-1 border-b transition-colors ${entry?.isIntersecting === false ? 'border-border' : 'border-transparent'} top-0 flex w-full flex-row items-center justify-between gap-2`}
 				style={{ viewTransitionName: 'appnav' }}
 			>
-				<div className="scrollbar-none w-0 grow overflow-x-auto">
+				<div className="w-0 grow scrollbar-none overflow-x-auto">
 					<NavigationMenu className="mt-2 mb-1">
 						<NavigationMenuList className="flex w-full flex-row justify-start ps-2">
 							{links.map((l: LinkType) => (
 								<NavigationMenuItem
-									className="hover:bg-1-mlo-primary rounded-xl px-3"
+									className="hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary rounded-xl px-3"
 									key={l.link.to}
 								>
 									<NavigationMenuLink asChild>

--- a/src/components/navs/mode-toggle.tsx
+++ b/src/components/navs/mode-toggle.tsx
@@ -48,30 +48,42 @@ export function ModeToggle() {
 						sideOffset={4}
 					>
 						<DropdownMenuItem
-							className={theme === 'light' ? 'bg-1-mlo-primary' : ''}
+							className={
+								theme === 'light' ? 'bg-lc-1 bg-chroma-mlo bg-hue-primary' : ''
+							}
 							onClick={setLight}
 						>
-							{theme === 'light' ?
+							{theme === 'light' ? (
 								<Check className="mr-2 size-4" />
-							:	<Sun className="mr-2 size-4" />}
+							) : (
+								<Sun className="mr-2 size-4" />
+							)}
 							Light
 						</DropdownMenuItem>
 						<DropdownMenuItem
-							className={theme === 'dark' ? 'bg-1-mlo-primary' : ''}
+							className={
+								theme === 'dark' ? 'bg-lc-1 bg-chroma-mlo bg-hue-primary' : ''
+							}
 							onClick={setDark}
 						>
-							{theme === 'dark' ?
+							{theme === 'dark' ? (
 								<Check className="mr-2 size-4" />
-							:	<Moon className="mr-2 size-4" />}
+							) : (
+								<Moon className="mr-2 size-4" />
+							)}
 							Dark
 						</DropdownMenuItem>
 						<DropdownMenuItem
-							className={theme === 'system' ? 'bg-1-mlo-primary' : ''}
+							className={
+								theme === 'system' ? 'bg-lc-1 bg-chroma-mlo bg-hue-primary' : ''
+							}
 							onClick={setSystem}
 						>
-							{theme === 'system' ?
+							{theme === 'system' ? (
 								<Check className="mr-2 size-4" />
-							:	<MonitorCog className="mr-2 size-4" />}
+							) : (
+								<MonitorCog className="mr-2 size-4" />
+							)}
 							System
 						</DropdownMenuItem>
 					</DropdownMenuContent>

--- a/src/components/navs/nav-footer-actions.tsx
+++ b/src/components/navs/nav-footer-actions.tsx
@@ -13,7 +13,7 @@ export function NavFooterActions() {
 				href="https://github.com/mhsnook/sunlo"
 				target="_blank"
 				rel="noreferrer"
-				className="text-c-lo text-lc-5 hover:text-lc-7 flex items-center gap-2 text-xs"
+				className="text-chroma-lo text-lc-5 hover:text-lc-7 flex items-center gap-2 text-xs"
 				data-testid="sidebar-open-source-link"
 			>
 				<Github className="size-4" />

--- a/src/components/navs/onboarding-nudge.tsx
+++ b/src/components/navs/onboarding-nudge.tsx
@@ -31,7 +31,7 @@ export function OnboardingNudge() {
 				to="/getting-started"
 				onClick={setClosedMobile}
 				data-testid="onboarding-nudge"
-				className="text-5-mid-primary hover:bg-lc-up-1 mx-auto flex h-8 w-8 items-center justify-center rounded-lg bg-white transition-colors"
+				className="text-lc-5 text-chroma-mid text-hue-primary hover:bg-lc-up-1 mx-auto flex h-8 w-8 items-center justify-center rounded-lg bg-white transition-colors"
 				aria-label="Continue setting up your account"
 			>
 				<Sparkles className="h-4 w-4" />
@@ -42,11 +42,11 @@ export function OnboardingNudge() {
 	return (
 		<div
 			data-testid="onboarding-nudge"
-			className="border-lc-[87] border-c-[6] border-h-primary bg-lc-[93] bg-c-[4] bg-h-primary mx-2 mb-2 rounded-xl border p-3"
+			className="border-lc-[87] border-chroma-[6] border-hue-primary bg-lc-[93] bg-chroma-[4] bg-hue-primary mx-2 mb-2 rounded-xl border p-3"
 		>
 			<div className="flex items-start gap-2">
 				<div className="rounded-lg bg-white p-1.5">
-					<Sparkles className="text-5-mid-primary h-4 w-4" />
+					<Sparkles className="text-lc-5 text-chroma-mid text-hue-primary h-4 w-4" />
 				</div>
 				<div className="flex-1">
 					<p className="text-sm font-semibold">Continue setup</p>

--- a/src/components/notifications/notification-item.tsx
+++ b/src/components/notifications/notification-item.tsx
@@ -28,32 +28,38 @@ const notificationConfig: Record<
 	request_commented: {
 		Icon: MessageSquareQuote,
 		action: 'commented on your request',
-		iconClass: 'text-7-mid-primary bg-1-lo-primary',
+		iconClass:
+			'text-lc-7 text-chroma-mid text-hue-primary bg-lc-1 bg-chroma-lo bg-hue-primary',
 	},
 	comment_replied: {
 		Icon: MessagesSquare,
 		action: 'replied to your comment',
-		iconClass: 'text-7-mid-info bg-1-lo-info',
+		iconClass:
+			'text-lc-7 text-chroma-mid text-hue-info bg-lc-1 bg-chroma-lo bg-hue-info',
 	},
 	phrase_translated: {
 		Icon: Languages,
 		action: 'added a translation to your phrase',
-		iconClass: 'text-7-mid-success bg-1-lo-success',
+		iconClass:
+			'text-lc-7 text-chroma-mid text-hue-success bg-lc-1 bg-chroma-lo bg-hue-success',
 	},
 	phrase_referenced: {
 		Icon: Link2,
 		action: 'referenced your phrase as an answer',
-		iconClass: 'text-7-mid-accent bg-1-lo-accent',
+		iconClass:
+			'text-lc-7 text-chroma-mid text-hue-accent bg-lc-1 bg-chroma-lo bg-hue-accent',
 	},
 	request_upvoted: {
 		Icon: ThumbsUp,
 		action: 'upvoted your request',
-		iconClass: 'text-7-mid-warning bg-1-lo-warning',
+		iconClass:
+			'text-lc-7 text-chroma-mid text-hue-warning bg-lc-1 bg-chroma-lo bg-hue-warning',
 	},
 	change_suggested: {
 		Icon: MessageSquareQuote,
 		action: 'suggested a change to your content',
-		iconClass: 'text-7-mid-neutral bg-1-lo-neutral',
+		iconClass:
+			'text-lc-7 text-chroma-mid text-hue-neutral bg-lc-1 bg-chroma-lo bg-hue-neutral',
 	},
 }
 

--- a/src/components/notifications/notification-list.tsx
+++ b/src/components/notifications/notification-list.tsx
@@ -87,7 +87,7 @@ function EmptyState() {
 			data-testid="notifications-empty-state"
 		>
 			<CardContent className="flex flex-col items-center gap-3 py-12 text-center">
-				<div className="bg-1-lo-neutral flex h-16 w-16 items-center justify-center rounded-full">
+				<div className="bg-lc-1 bg-chroma-lo bg-hue-neutral flex h-16 w-16 items-center justify-center rounded-full">
 					<BellOff className="text-muted-foreground h-8 w-8" />
 				</div>
 				<h3 className="text-lg font-semibold">No notifications yet</h3>

--- a/src/components/playlists/playlist-embed.tsx
+++ b/src/components/playlists/playlist-embed.tsx
@@ -134,7 +134,7 @@ export function PlaylistEmbed({ href }: PlaylistEmbedProps) {
 				href={href}
 				target="_blank"
 				rel="noopener noreferrer"
-				className="bg-1-mlo-neutral text-7-mid-neutral hover:bg-2-mlo-neutral flex items-center gap-2 rounded-2xl px-4 py-3 text-sm no-underline transition-colors"
+				className="bg-lc-1 bg-chroma-mlo bg-hue-neutral text-lc-7 text-chroma-mid text-hue-neutral hover:bg-lc-2 hover:bg-chroma-mlo hover:bg-hue-neutral flex items-center gap-2 rounded-2xl px-4 py-3 text-sm no-underline transition-colors"
 			>
 				<ExternalLink className="size-4 shrink-0" />
 				<span>

--- a/src/components/practice-history-dialog.tsx
+++ b/src/components/practice-history-dialog.tsx
@@ -110,7 +110,7 @@ function RetrievabilityBar({ value }: { value: number }) {
 				</div>
 				<span className="text-3xl font-bold tabular-nums">{pct}%</span>
 			</div>
-			<div className="bg-1-lo-neutral h-2 w-full overflow-hidden rounded-full">
+			<div className="bg-lc-1 bg-chroma-lo bg-hue-neutral h-2 w-full overflow-hidden rounded-full">
 				<div
 					className={cn('h-full rounded-full transition-all', color)}
 					style={{ width: `${pct}%` }}
@@ -286,7 +286,7 @@ function StatTile({
 	return (
 		<div
 			className={cn(
-				'bg-1-lo-neutral flex flex-col gap-0.5 rounded p-3',
+				'bg-lc-1 bg-chroma-lo bg-hue-neutral flex flex-col gap-0.5 rounded p-3',
 				className
 			)}
 		>

--- a/src/components/requests/request-header.tsx
+++ b/src/components/requests/request-header.tsx
@@ -17,7 +17,7 @@ export function RequestHeader({ request }: { request: PhraseRequestType }) {
 	const isOwner = profile?.uid === request.requester_uid
 
 	return (
-		<CardHeader className="border-2-lo-primary py-3 @md:py-6">
+		<CardHeader className="border-lc-2 border-chroma-lo border-hue-primary py-3 @md:py-6">
 			<div className="flex flex-row items-center justify-between gap-2">
 				<UidPermalink
 					uid={request.requester_uid}

--- a/src/components/share/friend-picker.tsx
+++ b/src/components/share/friend-picker.tsx
@@ -51,7 +51,7 @@ function highlight(text: string, query: string): ReactNode {
 	return (
 		<>
 			{text.slice(0, i)}
-			<mark className="bg-2-mid-warning text-8-hi-warning rounded-[3px] px-px">
+			<mark className="bg-lc-2 bg-chroma-mid bg-hue-warning text-lc-8 text-chroma-hi text-hue-warning rounded-[3px] px-px">
 				{text.slice(i, i + query.length)}
 			</mark>
 			{text.slice(i + query.length)}
@@ -83,8 +83,9 @@ function FriendRow({
 			data-key={friend.uid}
 			onClick={() => onToggle(friend.uid)}
 			className={cn(
-				'group hover:bg-0-mlo-primary flex w-full items-center gap-3 rounded-2xl px-2.5 py-2 text-start outline -outline-offset-1 outline-transparent transition-colors',
-				selected && 'bg-1-mlo-primary outline-primary-foresoft/40'
+				'group hover:bg-lc-0 hover:bg-chroma-mlo hover:bg-hue-primary flex w-full items-center gap-3 rounded-2xl px-2.5 py-2 text-start outline -outline-offset-1 outline-transparent transition-colors',
+				selected &&
+					'bg-lc-1 bg-chroma-mlo bg-hue-primary outline-primary-foresoft/40'
 			)}
 		>
 			<UserAvatar profile={profile} className="size-10" />
@@ -95,7 +96,7 @@ function FriendRow({
 			</span>
 			<span className="flex shrink-0 flex-col items-end gap-1">
 				{friend.status === 'pending' ? (
-					<span className="bg-2-mid-primary text-7-hi-primary inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold tracking-wide uppercase">
+					<span className="bg-lc-2 bg-chroma-mid bg-hue-primary text-lc-7 text-chroma-hi text-hue-primary inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold tracking-wide uppercase">
 						<UserPlus className="size-2.5" /> Pending
 					</span>
 				) : timestamp ? (
@@ -132,8 +133,10 @@ export function SharePreviewChip({
 	subtitle?: ReactNode
 }) {
 	return (
-		<div className="bg-0-mlo-primary border-2-mlo-primary border-l-primary mx-3.5 flex items-center gap-2.5 rounded-lg border border-l-4 px-3 py-2.5">
-			<span className="text-6-hi-accent flex shrink-0">{icon}</span>
+		<div className="bg-lc-0 bg-chroma-mlo bg-hue-primary border-lc-2 border-chroma-mlo border-hue-primary border-l-primary mx-3.5 flex items-center gap-2.5 rounded-lg border border-l-4 px-3 py-2.5">
+			<span className="text-lc-6 text-chroma-hi text-hue-accent flex shrink-0">
+				{icon}
+			</span>
 			<span className="min-w-0 flex-1">
 				<span className="block truncate font-bold">{title}</span>
 				{subtitle ? (
@@ -222,7 +225,7 @@ function PickerBody({
 			<div className="flex flex-col">
 				{preview ? <div className="pt-1">{preview}</div> : null}
 				<div className="text-muted-foreground px-6 py-9 text-center">
-					<span className="bg-2-mlo-primary text-6-hi-primary mb-3.5 inline-flex size-14 items-center justify-center rounded-full">
+					<span className="bg-lc-2 bg-chroma-mlo bg-hue-primary text-lc-6 text-chroma-hi text-hue-primary mb-3.5 inline-flex size-14 items-center justify-center rounded-full">
 						<Users className="size-7" />
 					</span>
 					<h3 className="text-foreground mb-1.5 text-base font-bold">
@@ -248,7 +251,7 @@ function PickerBody({
 
 			{/* Sticky search */}
 			<div className="bg-popover sticky top-0 z-5 border-b px-3.5 pt-3 pb-2.5">
-				<div className="bg-0-lo-neutral focus-within:bg-card focus-within:border-ring focus-within:ring-ring/25 flex items-center gap-2.5 rounded-2xl border px-3 py-2 transition focus-within:ring-2">
+				<div className="bg-lc-0 bg-chroma-lo bg-hue-neutral focus-within:bg-card focus-within:border-ring focus-within:ring-ring/25 flex items-center gap-2.5 rounded-2xl border px-3 py-2 transition focus-within:ring-2">
 					<Search className="text-muted-foreground size-4 shrink-0" />
 					<input
 						ref={searchRef}
@@ -426,7 +429,7 @@ export function FriendPickerDialog({
 					{showPicker ? (
 						<>
 							{isMobile ? (
-								<div className="bg-3-mlo-neutral mx-auto mt-2 h-1 w-9 rounded-full" />
+								<div className="bg-lc-3 bg-chroma-mlo bg-hue-neutral mx-auto mt-2 h-1 w-9 rounded-full" />
 							) : null}
 							<div className="flex items-center gap-3 px-4.5 pt-3.5 pb-2">
 								<DialogPrimitive.Title className="text-base font-bold tracking-tight">
@@ -440,7 +443,7 @@ export function FriendPickerDialog({
 								<DialogPrimitive.Close
 									aria-label="Close"
 									data-testid="close-friend-picker"
-									className="bg-2-lo-neutral hover:bg-3-lo-neutral text-foreground ms-auto flex size-8 items-center justify-center rounded-md transition-colors"
+									className="bg-lc-2 bg-chroma-lo bg-hue-neutral hover:bg-lc-3 hover:bg-chroma-lo hover:bg-hue-neutral text-foreground ms-auto flex size-8 items-center justify-center rounded-md transition-colors"
 								>
 									<X className="size-4" />
 								</DialogPrimitive.Close>

--- a/src/components/spreadsheet-import-dialog.tsx
+++ b/src/components/spreadsheet-import-dialog.tsx
@@ -154,31 +154,37 @@ export function SpreadsheetImportDialog({
 								</p>
 								<div className="space-y-2 ps-1">
 									<p>
-										<strong className="text-7-mhi-primary">Phrase</strong>{' '}
+										<strong className="text-lc-7 text-chroma-mhi text-hue-primary">
+											Phrase
+										</strong>{' '}
 										&mdash; the word or sentence in your learning language.
 										Include the word &ldquo;phrase&rdquo; in the header (e.g.{' '}
-										<code className="bg-1-mlo-primary rounded px-1.5 py-0.5 text-sm">
+										<code className="bg-lc-1 bg-chroma-mlo bg-hue-primary rounded px-1.5 py-0.5 text-sm">
 											phrase
 										</code>
 										).
 									</p>
 									<p>
-										<strong className="text-7-mhi-accent">Translation</strong>{' '}
+										<strong className="text-lc-7 text-chroma-mhi text-hue-accent">
+											Translation
+										</strong>{' '}
 										&mdash; put the language name or 3-letter code in the header
 										(e.g.{' '}
-										<code className="bg-1-mlo-accent rounded px-1.5 py-0.5 text-sm">
+										<code className="bg-lc-1 bg-chroma-mlo bg-hue-accent rounded px-1.5 py-0.5 text-sm">
 											translation (eng)
 										</code>{' '}
 										or{' '}
-										<code className="bg-1-mlo-accent rounded px-1.5 py-0.5 text-sm">
+										<code className="bg-lc-1 bg-chroma-mlo bg-hue-accent rounded px-1.5 py-0.5 text-sm">
 											English
 										</code>
 										). You can have multiple translation columns.
 									</p>
 									<p>
-										<strong className="text-7-mhi-info">Tags</strong> &mdash;
-										optional. Include &ldquo;tag&rdquo; in the header. Separate
-										multiple tags with commas inside a cell.
+										<strong className="text-lc-7 text-chroma-mhi text-hue-info">
+											Tags
+										</strong>{' '}
+										&mdash; optional. Include &ldquo;tag&rdquo; in the header.
+										Separate multiple tags with commas inside a cell.
 									</p>
 								</div>
 								<p className="text-muted-foreground text-sm">

--- a/src/components/ui/avatar-icon.tsx
+++ b/src/components/ui/avatar-icon.tsx
@@ -13,7 +13,7 @@ export function AvatarIconRow({ children, ...profile }: AvatarIconRowProps) {
 			<Link
 				to="/friends/$uid"
 				params={{ uid: profile.uid }}
-				className="hover:bg-1-mlo-primary hover:border-2-mlo-primary flex grow flex-row items-center justify-start gap-4 rounded-2xl border border-transparent p-2"
+				className="hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary hover:border-lc-2 hover:border-chroma-mlo hover:border-hue-primary flex grow flex-row items-center justify-start gap-4 rounded-2xl border border-transparent p-2"
 			>
 				<UserAvatar profile={profile} className="size-8" />
 				<span>{profile.username}</span>

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -33,7 +33,9 @@ const AvatarFallback = ({
 		data-slot="avatar-fallback"
 		className={cn(
 			'flex h-full w-full items-center justify-center',
-			seed ? 'bg-5-mhi-primary text-primary-foreground' : 'bg-muted',
+			seed
+				? 'bg-lc-5 bg-chroma-mhi bg-hue-primary text-primary-foreground'
+				: 'bg-muted',
 			className
 		)}
 		style={

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -72,7 +72,7 @@ function LangBadge({ lang, className }: { lang: string; className?: string }) {
 			variant="lang"
 			className={cn(
 				!ready &&
-					'!bg-lc-1 bg-chroma-lo bg-hue-neutral !text-lc-7 text-chroma-mid text-hue-neutral !border-lc-2 border-chroma-lo border-hue-neutral',
+					'!bg-lc-1 !bg-chroma-lo !bg-hue-neutral !text-lc-7 !text-chroma-mid !text-hue-neutral !border-lc-2 !border-chroma-lo !border-hue-neutral',
 				className
 			)}
 			style={style}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -10,12 +10,14 @@ const badgeVariants = cva(
 		variants: {
 			variant: {
 				default: 'border-transparent bg-primary text-primary-foreground',
-				secondary: 'border-2-lo-neutral bg-1-lo-neutral text-5-mid-neutral',
+				secondary:
+					'border-lc-2 border-chroma-lo border-hue-neutral bg-lc-1 bg-chroma-lo bg-hue-neutral text-lc-5 text-chroma-mid text-hue-neutral',
 				destructive:
 					'border-transparent bg-destructive text-destructive-foreground',
 				success: 'border-transparent bg-green-600 text-green-100',
-				outline: 'text-primary-foresoft border-2-lo-primary bg-0-lo-primary',
-				lang: 'bg-1-mlo-primary text-fore-mlo-primary border-1-mlo-primary font-mono font-bold uppercase tracking-wider items-end w-fit transition-colors duration-700',
+				outline:
+					'text-primary-foresoft border-lc-2 border-chroma-lo border-hue-primary bg-lc-0 bg-chroma-lo bg-hue-primary',
+				lang: 'bg-lc-1 bg-chroma-mlo bg-hue-primary text-lc-fore text-chroma-mlo text-hue-primary border-lc-1 border-chroma-mlo border-hue-primary font-mono font-bold uppercase tracking-wider items-end w-fit transition-colors duration-700',
 			},
 			size: {
 				lg: 'px-3 py-1 gap-2 [&>svg]:h-4 [&>svg]:w-4 [&>button]:h-5 [&>button]:w-5',
@@ -69,7 +71,8 @@ function LangBadge({ lang, className }: { lang: string; className?: string }) {
 		<Badge
 			variant="lang"
 			className={cn(
-				!ready && '!bg-1-lo-neutral !text-7-mid-neutral !border-2-lo-neutral',
+				!ready &&
+					'!bg-lc-1 bg-chroma-lo bg-hue-neutral !text-lc-7 text-chroma-mid text-hue-neutral !border-lc-2 border-chroma-lo border-hue-neutral',
 				className
 			)}
 			style={style}

--- a/src/components/ui/blockquote.tsx
+++ b/src/components/ui/blockquote.tsx
@@ -11,7 +11,7 @@ export function Blockquote({
 	return (
 		<blockquote
 			className={cn(
-				'border-4-mlo-primary bg-1-mlo-primary mb-4 rounded border-l-4 p-4 italic',
+				'border-lc-4 border-chroma-mlo border-hue-primary bg-lc-1 bg-chroma-mlo bg-hue-primary mb-4 rounded border-l-4 p-4 italic',
 				className
 			)}
 		>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,8 +4,9 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 import { Slot } from '@/lib/slot'
 
-const solids = 'bg-7-mhi text-white hover:bg-lc-up-1'
-const softs = 'bg-1-mlo text-7-mid hover:bg-lc-down-1 hover:text-lc-up-1'
+const solids = 'bg-lc-7 bg-chroma-mhi text-white hover:bg-lc-up-1'
+const softs =
+	'bg-lc-1 bg-chroma-mlo text-lc-7 text-chroma-mid hover:bg-lc-down-1 hover:text-lc-up-1'
 
 const buttonVariants = cva(
 	'border border-transparent shadow inline-flex items-center justify-center whitespace-nowrap font-medium ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 cursor-pointer disabled:cursor-default transition-opacity [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
@@ -16,12 +17,13 @@ const buttonVariants = cva(
 				soft: `hue-primary ${softs}`,
 				red: `hue-danger ${solids}`,
 				'red-soft': `hue-danger ${softs}`,
-				neutral: 'hover:bg-lc-up-1 hover:bg-c-mlo',
-				ghost: 'text-c-lo text-lc-6 hover:bg-0-lo-primary hover:text-lc-7',
+				neutral: 'hover:bg-lc-up-1 hover:bg-chroma-mlo',
+				ghost:
+					'text-chroma-lo text-lc-6 hover:bg-lc-0 hover:bg-chroma-lo hover:bg-hue-primary hover:text-lc-7',
 				'badge-outline':
-					'rounded border-border text-8-mid-neutral bg-0-lo-neutral hover:border-primary',
+					'rounded border-border text-lc-8 text-chroma-mid text-hue-neutral bg-lc-0 bg-chroma-lo bg-hue-neutral hover:border-primary',
 				'dashed-w-full':
-					'w-full border-2 border-dashed border-2-lo-primary hover:border-border shadow-none hover:shadow',
+					'w-full border-2 border-dashed border-lc-2 border-chroma-lo border-hue-primary hover:border-border shadow-none hover:shadow',
 			},
 			size: {
 				default: 'h-10 rounded-2xl px-5 py-2 gap-2 text-md',

--- a/src/components/ui/callout.tsx
+++ b/src/components/ui/callout.tsx
@@ -10,15 +10,17 @@ type CalloutProps = PropsWithChildren & {
 }
 
 const variants = {
-	default: 'bg-1-mlo-primary border-3-mlo-primary',
-	problem: 'hue-danger bg-lc-[97] bg-c-[3] border-lc-[88] border-c-[6]',
+	default:
+		'bg-lc-1 bg-chroma-mlo bg-hue-primary border-lc-3 border-chroma-mlo border-hue-primary',
+	problem:
+		'hue-danger bg-lc-[97] bg-chroma-[3] border-lc-[88] border-chroma-[6]',
 	ghost: 'border text-muted-foreground bg-muted',
 }
 
 const iconCircleVariants = {
-	default: 'bg-lc-[95] bg-c-[6]',
-	problem: 'border border-lc-[82] border-c-[9] bg-none-lo',
-	ghost: 'bg-1-lo-neutral',
+	default: 'bg-lc-[95] bg-chroma-[6]',
+	problem: 'border border-lc-[82] border-chroma-[9] bg-lc-none bg-chroma-lo',
+	ghost: 'bg-lc-1 bg-chroma-lo bg-hue-neutral',
 }
 
 const sizes = {

--- a/src/components/ui/choice-tile.tsx
+++ b/src/components/ui/choice-tile.tsx
@@ -31,8 +31,8 @@ export function ChoiceTile({
 				'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
 				'disabled:cursor-not-allowed disabled:opacity-60',
 				selected
-					? 'bg-0-mlo-primary border-2-mlo-primary'
-					: 'border-input hover:bg-base-mlo-primary hover:border-4-mlo-primary',
+					? 'bg-lc-0 bg-chroma-mlo bg-hue-primary border-lc-2 border-chroma-mlo border-hue-primary'
+					: 'border-input hover:bg-lc-base hover:bg-chroma-mlo hover:bg-hue-primary hover:border-lc-4 hover:border-chroma-mlo hover:border-hue-primary',
 				className
 			)}
 			{...props}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -106,7 +106,7 @@ const CommandItem = ({
 	<CommandPrimitive.Item
 		data-slot="command-item"
 		className={cn(
-			"data-[selected='true']:bg-1-lo-accent data-[selected=true]:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+			"data-[selected='true']:bg-lc-1 data-[selected='true']:bg-chroma-lo data-[selected='true']:bg-hue-accent data-[selected=true]:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
 			className
 		)}
 		{...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -41,7 +41,7 @@ const DropdownMenuSubTrigger = ({
 	<MenuPrimitive.SubmenuTrigger
 		data-slot="dropdown-menu-sub-trigger"
 		className={cn(
-			'focus:bg-0-mlo-primary data-[popup-open]:bg-primary flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+			'focus:bg-lc-0 focus:bg-chroma-mlo focus:bg-hue-primary data-[popup-open]:bg-primary flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
 			inset && 'pl-8',
 			className
 		)}
@@ -107,7 +107,7 @@ const DropdownMenuItem = ({
 	inset?: boolean
 }) => {
 	const mergedClassName = cn(
-		'focus:bg-0-mlo-primary relative flex cursor-default items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-hidden transition-colors select-none focus:ring data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+		'focus:bg-lc-0 focus:bg-chroma-mlo focus:bg-hue-primary relative flex cursor-default items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-hidden transition-colors select-none focus:ring data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
 		inset && 'pl-8',
 		className
 	)
@@ -129,7 +129,7 @@ const DropdownMenuCheckboxItem = ({
 	<MenuPrimitive.CheckboxItem
 		data-slot="dropdown-menu-checkbox-item"
 		className={cn(
-			'focus:bg-0-mlo-primary relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50',
+			'focus:bg-lc-0 focus:bg-chroma-mlo focus:bg-hue-primary relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50',
 			className
 		)}
 		checked={checked}
@@ -152,7 +152,7 @@ const DropdownMenuRadioItem = ({
 	<MenuPrimitive.RadioItem
 		data-slot="dropdown-menu-radio-item"
 		className={cn(
-			'focus:bg-0-mlo-primary relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50',
+			'focus:bg-lc-0 focus:bg-chroma-mlo focus:bg-hue-primary relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50',
 			className
 		)}
 		{...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = ({
 		<input
 			type={type}
 			className={cn(
-				'border-3-mlo-primary hover:border-primary bg-card/50 ring-offset-background file:text-foreground placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-2xl border px-3 py-2 text-base inset-shadow-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+				'border-lc-3 border-chroma-mlo border-hue-primary hover:border-primary bg-card/50 ring-offset-background file:text-foreground placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-2xl border px-3 py-2 text-base inset-shadow-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
 				className
 			)}
 			data-slot="input"

--- a/src/components/ui/item.tsx
+++ b/src/components/ui/item.tsx
@@ -32,7 +32,7 @@ function ItemSeparator({
 }
 
 const itemVariants = cva(
-	'inset-shadow-sm group/item [a]:hover:bg-1-mlo-accent focus-visible:border-ring focus-visible:ring-ring/50 [a]:transition-colors flex flex-wrap items-center rounded-md border border-transparent text-sm outline-none transition-colors duration-100 focus-visible:ring-[3px]',
+	'inset-shadow-sm group/item [a]:hover:bg-lc-1 [a]:hover:bg-chroma-mlo [a]:hover:bg-hue-accent focus-visible:border-ring focus-visible:ring-ring/50 [a]:transition-colors flex flex-wrap items-center rounded-md border border-transparent text-sm outline-none transition-colors duration-100 focus-visible:ring-[3px]',
 	{
 		variants: {
 			variant: {

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -49,7 +49,7 @@ const NavigationMenuItem = ({
 )
 
 const navigationMenuTriggerStyle = cva(
-	'group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 data-active:bg-2-mid-accent data-[popup-open]:bg-2-mid-accent'
+	'group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 data-active:bg-lc-2 data-active:bg-chroma-mid data-active:bg-hue-accent data-[popup-open]:bg-lc-2 data-[popup-open]:bg-chroma-mid data-[popup-open]:bg-hue-accent'
 )
 
 const NavigationMenuTrigger = ({

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -12,7 +12,7 @@ function Progress({
 			value={value}
 			data-slot="progress"
 			className={cn(
-				'bg-2-mlo-primary relative h-2 w-full overflow-hidden rounded-full',
+				'bg-lc-2 bg-chroma-mlo bg-hue-primary relative h-2 w-full overflow-hidden rounded-full',
 				className
 			)}
 			{...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -127,7 +127,7 @@ const SelectItem = ({
 	<SelectPrimitive.Item
 		data-slot="select-item"
 		className={cn(
-			'focus:bg-1-lo-accent focus:text-accent-foreground relative flex w-full cursor-default items-center rounded-2xl py-1.5 pr-2 pl-8 text-sm outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+			'focus:bg-lc-1 focus:bg-chroma-lo focus:bg-hue-accent focus:text-accent-foreground relative flex w-full cursor-default items-center rounded-2xl py-1.5 pr-2 pl-8 text-sm outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
 			className
 		)}
 		{...props}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -11,7 +11,7 @@ const Separator = ({
 		data-slot="separator"
 		orientation={orientation}
 		className={cn(
-			'bg-3-mlo-primary shrink-0',
+			'bg-lc-3 bg-chroma-mlo bg-hue-primary shrink-0',
 			orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
 			className
 		)}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -309,7 +309,7 @@ const SidebarInset = ({
 		<main
 			data-slot="sidebar-inset"
 			className={cn(
-				'bg-base-lo-neutral relative flex min-h-svh flex-1 flex-col',
+				'bg-lc-base bg-chroma-lo bg-hue-neutral relative flex min-h-svh flex-1 flex-col',
 				'peer-data-[variant=inset]:min-h-[calc(100svh-(--spacing(4)))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
 				className
 			)}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -40,9 +40,9 @@ export function toastSuccess(message: string) {
 		() => (
 			<div
 				data-testid="toast-success"
-				className={`${ephemeralClass} border-4-mid-success bg-1-mlo-success text-8-mid-success`}
+				className={`${ephemeralClass} border-lc-4 border-chroma-mid border-hue-success bg-lc-1 bg-chroma-mlo bg-hue-success text-lc-8 text-chroma-mid text-hue-success`}
 			>
-				<CheckCircle className="text-6-mhi-success size-5 shrink-0" />
+				<CheckCircle className="text-lc-6 text-chroma-mhi text-hue-success size-5 shrink-0" />
 				<span className="flex-1 text-sm">{message}</span>
 			</div>
 		),
@@ -82,15 +82,15 @@ export function toastInfo(message: string) {
 		(t) => (
 			<div
 				data-testid="toast-info"
-				className={`${persistentClass} border-4-mid-info bg-1-mlo-info text-8-mid-info`}
+				className={`${persistentClass} border-lc-4 border-chroma-mid border-hue-info bg-lc-1 bg-chroma-mlo bg-hue-info text-lc-8 text-chroma-mid text-hue-info`}
 			>
-				<Info className="text-lc-6 text-c-mhi text-h-info size-5 shrink-0" />
+				<Info className="text-lc-6 text-chroma-mhi text-hue-info size-5 shrink-0" />
 				<span className="flex-1 text-sm">{message}</span>
 				<div className="flex shrink-0 items-center gap-1">
 					<Button
 						variant="ghost"
 						size="icon"
-						className="text-6-mhi-info hover:bg-2-mlo-info size-7"
+						className="text-lc-6 text-chroma-mhi text-hue-info hover:bg-lc-2 hover:bg-chroma-mlo hover:bg-hue-info size-7"
 						// eslint-disable-next-line @typescript-eslint/no-misused-promises
 						onClick={copyToClipboard(message)}
 						aria-label="Copy message"
@@ -100,7 +100,7 @@ export function toastInfo(message: string) {
 					<Button
 						variant="ghost"
 						size="icon"
-						className="text-6-mhi-info hover:bg-2-mlo-info size-7"
+						className="text-lc-6 text-chroma-mhi text-hue-info hover:bg-lc-2 hover:bg-chroma-mlo hover:bg-hue-info size-7"
 						onClick={() => toast.dismiss(t)}
 						aria-label="Dismiss"
 					>
@@ -123,15 +123,15 @@ export function toastError(message: string) {
 		(t) => (
 			<div
 				data-testid="toast-error"
-				className={`${persistentClass} border-4-mid-danger bg-1-mlo-danger text-8-mid-danger`}
+				className={`${persistentClass} border-lc-4 border-chroma-mid border-hue-danger bg-lc-1 bg-chroma-mlo bg-hue-danger text-lc-8 text-chroma-mid text-hue-danger`}
 			>
-				<AlertCircle className="text-lc-6 text-c-mhi text-h-danger size-5 shrink-0" />
+				<AlertCircle className="text-lc-6 text-chroma-mhi text-hue-danger size-5 shrink-0" />
 				<span className="flex-1 text-sm">{message}</span>
 				<div className="flex shrink-0 items-center gap-1">
 					<Button
 						variant="ghost"
 						size="icon"
-						className="text-6-mhi-danger hover:bg-2-mlo-danger size-7"
+						className="text-lc-6 text-chroma-mhi text-hue-danger hover:bg-lc-2 hover:bg-chroma-mlo hover:bg-hue-danger size-7"
 						// eslint-disable-next-line @typescript-eslint/no-misused-promises
 						onClick={copyToClipboard(message)}
 						aria-label="Copy error"
@@ -141,7 +141,7 @@ export function toastError(message: string) {
 					<Button
 						variant="ghost"
 						size="icon"
-						className="text-6-mhi-danger hover:bg-2-mlo-danger size-7"
+						className="text-lc-6 text-chroma-mhi text-hue-danger hover:bg-lc-2 hover:bg-chroma-mlo hover:bg-hue-danger size-7"
 						onClick={() => toast.dismiss(t)}
 						aria-label="Dismiss"
 					>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -6,7 +6,7 @@ const Switch = ({ className, ...props }: SwitchPrimitive.Root.Props) => (
 	<SwitchPrimitive.Root
 		data-slot="switch"
 		className={cn(
-			'peer ring-offset-background focus-visible:ring-ring inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full bg-1-mlo-neutral inset-shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+			'peer ring-offset-background focus-visible:ring-ring inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full bg-lc-1 bg-chroma-mlo bg-hue-neutral inset-shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
 			className
 		)}
 		{...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = ({
 	return (
 		<textarea
 			className={cn(
-				'border-3-mlo-primary hover:border-primary bg-card/50 ring-offset-background placeholder:text-muted-foreground text-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-2xl border px-3 py-2 text-sm inset-shadow-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+				'border-lc-3 border-chroma-mlo border-hue-primary hover:border-primary bg-card/50 ring-offset-background placeholder:text-muted-foreground text-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-2xl border px-3 py-2 text-sm inset-shadow-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
 				className
 			)}
 			data-slot="textarea"

--- a/src/features/chat/components/cart-button.tsx
+++ b/src/features/chat/components/cart-button.tsx
@@ -77,7 +77,7 @@ export function CartButton() {
 									key={phrase.id}
 									data-key={phrase.id}
 									data-testid="chat-cart-item"
-									className="hover:bg-1-mlo-primary flex flex-row items-start justify-between gap-2 rounded p-2 text-sm"
+									className="hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary flex flex-row items-start justify-between gap-2 rounded p-2 text-sm"
 								>
 									<div className="flex flex-col">
 										<span lang={phrase.lang} className="font-medium">

--- a/src/features/chat/components/chat-message.tsx
+++ b/src/features/chat/components/chat-message.tsx
@@ -18,7 +18,7 @@ export function ChatTurnView({ turn }: Props) {
 			<div className="flex justify-end">
 				<div
 					data-testid="chat-user-message"
-					className="bg-1-mlo-primary text-foreground max-w-[85%] rounded-2xl px-4 py-2 text-sm"
+					className="bg-lc-1 bg-chroma-mlo bg-hue-primary text-foreground max-w-[85%] rounded-2xl px-4 py-2 text-sm"
 				>
 					{turn.query.kind === 'text' ? (
 						turn.query.text

--- a/src/features/chat/components/phrase-result-card.tsx
+++ b/src/features/chat/components/phrase-result-card.tsx
@@ -22,7 +22,7 @@ export function PhraseResultCard({ phrase }: Props) {
 			data-in-cart={inCart ? '' : undefined}
 			className={cn(
 				'flex flex-row items-start gap-3 rounded border p-3',
-				inCart ? 'bg-1-mlo-primary' : 'bg-card/50'
+				inCart ? 'bg-lc-1 bg-chroma-mlo bg-hue-primary' : 'bg-card/50'
 			)}
 		>
 			<div className="flex flex-1 flex-col gap-1">

--- a/src/features/chat/components/selection-bar.tsx
+++ b/src/features/chat/components/selection-bar.tsx
@@ -22,7 +22,7 @@ export function SelectionBar() {
 	return (
 		<div
 			data-testid="chat-selection-bar"
-			className="bg-1-lo-primary flex flex-col gap-2 rounded border p-2"
+			className="bg-lc-1 bg-chroma-lo bg-hue-primary flex flex-col gap-2 rounded border p-2"
 		>
 			<div className="flex flex-row items-center justify-between gap-2">
 				<span className="text-muted-foreground text-xs font-medium">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,9 +1,55 @@
 import type { uuid } from '@/types/main'
 import { type ClassValue, clsx } from 'clsx'
-import { twMerge } from 'tailwind-merge'
+import { type ConfigExtension, extendTailwindMerge } from 'tailwind-merge'
 import type { DeckMetaType } from '@/features/deck/schemas'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
 import { useState } from 'react'
+
+/* ── OKLCH single-axis utilities × tailwind-merge ──────────────────────────
+   Our color utilities decompose into three same-prefix classes per property
+   (`bg-lc-7 bg-chroma-mhi bg-hue-primary`). Out of the box tailwind-merge
+   treats those as conflicting `bg-*` utilities and keeps only the last one,
+   silently dropping two of the three axes. Register each (property × axis) as
+   its own conflict group so the axes are independent: two `bg-lc-*` still
+   collapse to the last, but `bg-lc-*` and `bg-chroma-*` coexist. */
+const HUES = new Set([
+	'primary',
+	'accent',
+	'success',
+	'warning',
+	'danger',
+	'info',
+	'neutral',
+])
+const CHROMAS = new Set(['lo', 'mlo', 'mid', 'mhi', 'hi'])
+const isArbitrary = (v: string) => v.startsWith('[') && v.endsWith(']')
+const isHue = (v: string) => HUES.has(v) || isArbitrary(v)
+const isChroma = (v: string) => CHROMAS.has(v) || isArbitrary(v)
+const isLc = (v: string) =>
+	/^(?:\d+|base|fore|none|full|up-[123]|down-[123]|\[\d+\])$/.test(v)
+
+type ClassGroups = NonNullable<
+	ConfigExtension<string, string>['extend']
+>['classGroups']
+const oklchClassGroups: ClassGroups = {}
+for (const p of ['bg', 'text', 'border', 'from', 'to']) {
+	oklchClassGroups[`ok-${p}-lc`] = [{ [p]: [{ lc: [isLc] }] }]
+	oklchClassGroups[`ok-${p}-chroma`] = [{ [p]: [{ chroma: [isChroma] }] }]
+	oklchClassGroups[`ok-${p}-hue`] = [{ [p]: [{ hue: [isHue] }] }]
+}
+// border-b sets border-bottom-color — a separate property from border-color
+oklchClassGroups['ok-border-b-lc'] = [{ border: [{ b: [{ lc: [isLc] }] }] }]
+oklchClassGroups['ok-border-b-chroma'] = [
+	{ border: [{ b: [{ chroma: [isChroma] }] }] },
+]
+oklchClassGroups['ok-border-b-hue'] = [{ border: [{ b: [{ hue: [isHue] }] }] }]
+// cascade seeders (apply no property, set an axis for all descendants)
+oklchClassGroups['ok-seed-hue'] = [{ hue: [isHue] }]
+oklchClassGroups['ok-seed-chroma'] = [{ chroma: [isChroma] }]
+
+const twMerge = extendTailwindMerge({
+	extend: { classGroups: oklchClassGroups },
+})
 
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs))
@@ -65,10 +111,11 @@ export function round(num: number, places: number = 2): number {
  * precise elapsed time matters (e.g. computing retrievability decay).
  */
 export function dateDiff(prev_at: string | Date, later_at?: string | Date) {
-	const later: Date =
-		!later_at ? new Date()
-		: typeof later_at === 'string' ? new Date(later_at)
-		: later_at
+	const later: Date = !later_at
+		? new Date()
+		: typeof later_at === 'string'
+			? new Date(later_at)
+			: later_at
 	const prev: Date = typeof prev_at === 'string' ? new Date(prev_at) : prev_at
 	// @ts-expect-error it's actually fine to subract date objects like ints
 	return (later - prev) / 1000 / 24 / 60 / 60
@@ -82,10 +129,11 @@ export function sessionDaysDiff(
 	prev_at: string | Date,
 	later_at?: string | Date
 ): number {
-	const later =
-		!later_at ? new Date()
-		: typeof later_at === 'string' ? new Date(later_at)
-		: later_at
+	const later = !later_at
+		? new Date()
+		: typeof later_at === 'string'
+			? new Date(later_at)
+			: later_at
 	const prev = typeof prev_at === 'string' ? new Date(prev_at) : prev_at
 
 	// Shift both by -4 hours so 4am becomes the day boundary
@@ -171,22 +219,20 @@ export const sortDecksByCreation = (
 	a: Partial<DeckMetaType> & { created_at: string; lang: string },
 	b: Partial<DeckMetaType> & { created_at: string; lang: string }
 ) =>
-	a.created_at > b.created_at ? 1
-	: a.created_at < b.created_at ? -1
-	: a.lang > b.lang ? 1
-	: -1
+	a.created_at > b.created_at
+		? 1
+		: a.created_at < b.created_at
+			? -1
+			: a.lang > b.lang
+				? 1
+				: -1
 
 // sort DESC most recent first
 export const sortDecksByActivity = (a: DeckMetaType, b: DeckMetaType) => {
 	const aDate = a.most_recent_review_at ?? a.created_at
 	const bDate = b.most_recent_review_at ?? b.created_at
 
-	return (
-		aDate > bDate ? -1
-		: aDate < bDate ? 1
-		: a.lang > b.lang ? -1
-		: 1
-	)
+	return aDate > bDate ? -1 : aDate < bDate ? 1 : a.lang > b.lang ? -1 : 1
 }
 
 export const preventDefaultCallback = (e: { preventDefault: () => void }) =>

--- a/src/routes/_user.tsx
+++ b/src/routes/_user.tsx
@@ -175,7 +175,7 @@ function UserLayout() {
 								fallback={
 									<div
 										aria-hidden
-										className="bg-base-lo-neutral mt-1 -mb-[2px] h-12"
+										className="bg-lc-base bg-chroma-lo bg-hue-neutral mt-1 -mb-[2px] h-12"
 									/>
 								}
 							>

--- a/src/routes/_user/-browse-discover.tsx
+++ b/src/routes/_user/-browse-discover.tsx
@@ -95,7 +95,9 @@ function AddedPill({ added }: { added: boolean }) {
 		<span
 			className={cn(
 				'flex items-center gap-1 text-xs font-medium',
-				added ? 'text-5-hi-success' : 'text-primary-foresoft'
+				added
+					? 'text-lc-5 text-chroma-hi text-hue-success'
+					: 'text-primary-foresoft'
 			)}
 		>
 			{added ? (

--- a/src/routes/_user/-search-page.tsx
+++ b/src/routes/_user/-search-page.tsx
@@ -405,8 +405,8 @@ export function SearchPage({ rowExtras }: { rowExtras?: RowExtrasRenderer }) {
 function SystemMessage({ children }: { children: ReactNode }) {
 	return (
 		<div className="flex items-start gap-2.5">
-			<div className="bg-1-mlo-primary mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full">
-				<Sparkles className="text-7-hi-primary size-3.5" />
+			<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full">
+				<Sparkles className="text-lc-7 text-chroma-hi text-hue-primary size-3.5" />
 			</div>
 			<p className="text-muted-foreground pt-1 text-sm">{children}</p>
 		</div>
@@ -430,7 +430,7 @@ function FilterPill({
 				'inline-flex cursor-pointer items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors',
 				active
 					? 'bg-primary-foresoft text-primary-foreground border-transparent'
-					: 'border-border text-muted-foreground hover:border-4-mlo-primary hover:text-foreground'
+					: 'border-border text-muted-foreground hover:border-lc-4 hover:border-chroma-mlo hover:border-hue-primary hover:text-foreground'
 			)}
 		>
 			{children}
@@ -441,8 +441,8 @@ function FilterPill({
 function EmptyResults() {
 	return (
 		<div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
-			<div className="bg-1-mlo-neutral mx-auto flex size-24 items-center justify-center rounded-full">
-				<SearchX className="text-5-mid-neutral size-12" />
+			<div className="bg-lc-1 bg-chroma-mlo bg-hue-neutral mx-auto flex size-24 items-center justify-center rounded-full">
+				<SearchX className="text-lc-5 text-chroma-mid text-hue-neutral size-12" />
 			</div>
 			<div className="space-y-1">
 				<p className="text-lg font-semibold">No results found</p>
@@ -618,8 +618,8 @@ function WelcomeState({
 	return (
 		<div className="flex h-full flex-col items-center justify-center space-y-8 p-6">
 			<div className="space-y-3 text-center">
-				<div className="bg-1-mlo-primary mx-auto mb-4 flex size-16 items-center justify-center rounded-full">
-					<MessageCircle className="text-7-hi-primary size-8" />
+				<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary mx-auto mb-4 flex size-16 items-center justify-center rounded-full">
+					<MessageCircle className="text-lc-7 text-chroma-hi text-hue-primary size-8" />
 				</div>
 				<h2 className="h3">What are you looking for?</h2>
 				<p className="text-muted-foreground mx-auto max-w-sm text-sm">

--- a/src/routes/_user/admin/$lang.requests.$id.lazy.tsx
+++ b/src/routes/_user/admin/$lang.requests.$id.lazy.tsx
@@ -200,7 +200,7 @@ function MessageSection({
 								{isAdmin ? (
 									<button
 										type="button"
-										className="hover:text-c-hi ms-1 -me-1 inline-flex items-center"
+										className="hover:text-chroma-hi ms-1 -me-1 inline-flex items-center"
 										aria-label={`Remove ${tag.label}`}
 										onClick={() => detachTag(messageId, tag.slug)}
 									>
@@ -260,7 +260,7 @@ function AddTagPopover({
 						return (
 							<li key={tag.slug}>
 								<label
-									className="hover:bg-1-lo-neutral flex cursor-pointer items-center gap-2 rounded p-2 text-sm"
+									className="hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-neutral flex cursor-pointer items-center gap-2 rounded p-2 text-sm"
 									data-testid="admin-request-tag-option"
 									data-key={tag.slug}
 								>

--- a/src/routes/_user/admin/messages.$id.lazy.tsx
+++ b/src/routes/_user/admin/messages.$id.lazy.tsx
@@ -100,7 +100,7 @@ function AdminMessageDetail() {
 							{isAdmin ? (
 								<button
 									type="button"
-									className="hover:text-c-hi ms-1 -me-1 inline-flex items-center"
+									className="hover:text-chroma-hi ms-1 -me-1 inline-flex items-center"
 									aria-label={`Remove ${tag.label}`}
 									onClick={() => detachTag(message.id, tag.slug)}
 								>
@@ -196,7 +196,7 @@ function AddTagPopover({
 						return (
 							<li key={tag.slug}>
 								<label
-									className="hover:bg-1-lo-neutral flex cursor-pointer items-center gap-2 rounded p-2 text-sm"
+									className="hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-neutral flex cursor-pointer items-center gap-2 rounded p-2 text-sm"
 									data-testid="message-tag-option"
 									data-key={tag.slug}
 								>

--- a/src/routes/_user/admin/messages.index.lazy.tsx
+++ b/src/routes/_user/admin/messages.index.lazy.tsx
@@ -782,8 +782,8 @@ function BulkAddSection({
 								<button
 									type="button"
 									className={cn(
-										'hover:bg-1-lo-neutral block w-full rounded p-2 text-start text-sm',
-										tagSlug === null && 'bg-1-mlo-primary'
+										'hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-neutral block w-full rounded p-2 text-start text-sm',
+										tagSlug === null && 'bg-lc-1 bg-chroma-mlo bg-hue-primary'
 									)}
 									onClick={() => {
 										setTagSlug(null)
@@ -799,8 +799,9 @@ function BulkAddSection({
 											<button
 												type="button"
 												className={cn(
-													'hover:bg-1-lo-neutral block w-full rounded p-2 text-start text-sm',
-													tagSlug === tag.slug && 'bg-1-mlo-primary'
+													'hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-neutral block w-full rounded p-2 text-start text-sm',
+													tagSlug === tag.slug &&
+														'bg-lc-1 bg-chroma-mlo bg-hue-primary'
 												)}
 												onClick={() => {
 													setTagSlug(tag.slug)
@@ -916,7 +917,7 @@ function SelectionBar({
 
 	return (
 		<div
-			className="bg-1-mlo-primary flex flex-wrap items-center gap-3 rounded border p-3"
+			className="bg-lc-1 bg-chroma-mlo bg-hue-primary flex flex-wrap items-center gap-3 rounded border p-3"
 			data-testid="admin-messages-selection-bar"
 		>
 			<span className="text-sm font-semibold">
@@ -1005,7 +1006,7 @@ function MessagesTable({
 			data-name="message-row"
 		>
 			{isAdmin && (
-				<div className="bg-1-lo-neutral flex items-center gap-2 border-b px-3 py-2 text-xs">
+				<div className="bg-lc-1 bg-chroma-lo bg-hue-neutral flex items-center gap-2 border-b px-3 py-2 text-xs">
 					<Checkbox
 						checked={allVisibleSelected}
 						onCheckedChange={toggleVisibleAll}
@@ -1048,7 +1049,7 @@ function MessageRowItem({
 		<li
 			className={cn(
 				'flex items-start gap-3 p-3',
-				isSelected && 'bg-1-mlo-primary'
+				isSelected && 'bg-lc-1 bg-chroma-mlo bg-hue-primary'
 			)}
 			data-testid="message-row"
 			data-key={row.message_id}
@@ -1083,7 +1084,7 @@ function MessageRowItem({
 								{isAdmin ? (
 									<button
 										type="button"
-										className="hover:text-c-hi ms-1 -me-1 inline-flex items-center"
+										className="hover:text-chroma-hi ms-1 -me-1 inline-flex items-center"
 										onClick={() => detachTag(row.message_id, tag.slug)}
 										aria-label={`Remove ${tag.label}`}
 									>

--- a/src/routes/_user/admin/routes.lazy.tsx
+++ b/src/routes/_user/admin/routes.lazy.tsx
@@ -132,7 +132,7 @@ function RoutesIntrospection() {
 						{filtered.map((r) => (
 							<tr
 								key={r.id}
-								className="hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary border-b align-top"
+								className="border-b align-top"
 								data-name="admin-route-row"
 								data-key={r.id}
 							>

--- a/src/routes/_user/admin/routes.lazy.tsx
+++ b/src/routes/_user/admin/routes.lazy.tsx
@@ -132,7 +132,7 @@ function RoutesIntrospection() {
 						{filtered.map((r) => (
 							<tr
 								key={r.id}
-								className="hover:bg-1-mlo-primary/40 border-b align-top"
+								className="hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary border-b align-top"
 								data-name="admin-route-row"
 								data-key={r.id}
 							>
@@ -169,8 +169,8 @@ function LoadCell({ isLazy }: { isLazy: boolean }) {
 				className={cn(
 					'inline-block rounded px-1.5 py-0.5 font-mono',
 					isLazy
-						? 'bg-1-mlo-info text-7-hi-info'
-						: 'bg-1-mlo-neutral text-muted-foreground'
+						? 'bg-lc-1 bg-chroma-mlo bg-hue-info text-lc-7 text-chroma-hi text-hue-info'
+						: 'bg-lc-1 bg-chroma-mlo bg-hue-neutral text-muted-foreground'
 				)}
 			>
 				{isLazy ? 'lazy' : 'eager'}
@@ -184,7 +184,9 @@ function BoolCell({ on }: { on: boolean }) {
 		<td
 			className={cn(
 				'px-2 py-1.5 text-center',
-				on ? 'text-7-hi-success' : 'text-muted-foreground'
+				on
+					? 'text-lc-7 text-chroma-hi text-hue-success'
+					: 'text-muted-foreground'
 			)}
 		>
 			{on ? '✓' : '·'}
@@ -196,7 +198,7 @@ function SearchCell({ scope }: { scope: SearchScope | undefined }) {
 	if (scope === undefined)
 		return <td className="text-muted-foreground px-2 py-1.5 text-center">·</td>
 	return (
-		<td className="text-7-hi-success px-2 py-1.5 text-center font-mono text-xs">
+		<td className="text-lc-7 text-chroma-hi text-hue-success px-2 py-1.5 text-center font-mono text-xs">
 			{scope}
 		</td>
 	)

--- a/src/routes/_user/browse.$lang.tsx
+++ b/src/routes/_user/browse.$lang.tsx
@@ -287,7 +287,7 @@ function BrowseLanguagePage() {
 												'rounded-full px-4 py-1.5 text-sm transition-colors',
 												active
 													? 'bg-primary text-primary-foreground'
-													: 'bg-1-lo-neutral text-6-mid-neutral hover:bg-2-lo-neutral'
+													: 'bg-lc-1 bg-chroma-lo bg-hue-neutral text-lc-6 text-chroma-mid text-hue-neutral hover:bg-lc-2 hover:bg-chroma-lo hover:bg-hue-neutral'
 											)}
 										>
 											{tag.name}

--- a/src/routes/_user/browse.index.tsx
+++ b/src/routes/_user/browse.index.tsx
@@ -56,7 +56,7 @@ function BrowsePage() {
 						replace: true,
 					})
 				}
-				className="border-3-mlo-primary hover:border-primary bg-card/50 flex h-12 w-full items-center gap-3 rounded-2xl border px-4 transition-colors"
+				className="border-lc-3 border-chroma-mlo border-hue-primary hover:border-primary bg-card/50 flex h-12 w-full items-center gap-3 rounded-2xl border px-4 transition-colors"
 				data-testid="browse-search-trigger"
 			>
 				<Search className="text-muted-foreground size-5" />
@@ -154,7 +154,7 @@ function StatsSection() {
 			{stats.map((stat) => (
 				<Card key={stat.label} className="bg-card/30">
 					<CardContent className="flex flex-row items-center gap-4 p-6">
-						<div className="bg-1-mlo-primary text-primary rounded-full p-3">
+						<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary text-primary rounded-full p-3">
 							<stat.icon className="size-6" />
 						</div>
 						<div>
@@ -552,7 +552,7 @@ function PlaylistCard({
 
 function CTASection() {
 	return (
-		<section className="bg-0-lo-primary rounded-lg border p-8 text-center">
+		<section className="bg-lc-0 bg-chroma-lo bg-hue-primary rounded-lg border p-8 text-center">
 			<h2 className="text-2xl font-bold">Ready to start learning?</h2>
 			<p className="text-muted-foreground mt-2">
 				Join our community of language learners today

--- a/src/routes/_user/friends/-chats-sidebar.tsx
+++ b/src/routes/_user/friends/-chats-sidebar.tsx
@@ -9,7 +9,7 @@ import { avatarUrlify } from '@/lib/hooks'
 import { ago } from '@/lib/dayjs'
 
 const linkActiveProps = {
-	className: 'bg-1-mlo-accent text-accent-foreground',
+	className: 'bg-lc-1 bg-chroma-mlo bg-hue-accent text-accent-foreground',
 }
 
 export function ChatsSidebar() {
@@ -65,7 +65,7 @@ function ChatEntryItem({ entry }: { entry: ChatEntry }) {
 			data-key={uid}
 			to="/friends/chats/$friendUid"
 			params={{ friendUid: uid }}
-			className="hover:bg-1-mlo-accent hover:text-accent-foreground flex items-center gap-3 rounded-2xl px-3 py-2 transition-all"
+			className="hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-accent hover:text-accent-foreground flex items-center gap-3 rounded-2xl px-3 py-2 transition-all"
 			activeProps={linkActiveProps}
 		>
 			<Avatar className="h-8 w-8">

--- a/src/routes/_user/friends/-friends-feed.tsx
+++ b/src/routes/_user/friends/-friends-feed.tsx
@@ -205,7 +205,7 @@ function ActivityLine({ item }: { item: FeedActivityType }) {
 			<Link
 				to={meta.to}
 				params={meta.params}
-				className="hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary -mx-2 flex items-center gap-1.5 truncate rounded-lg px-2 py-0.5 text-sm"
+				className="-mx-2 flex items-center gap-1.5 truncate rounded-lg px-2 py-0.5 text-sm"
 			>
 				<Icon className="text-muted-foreground size-3.5 shrink-0" />
 				<span className="text-muted-foreground shrink-0">

--- a/src/routes/_user/friends/-friends-feed.tsx
+++ b/src/routes/_user/friends/-friends-feed.tsx
@@ -205,7 +205,7 @@ function ActivityLine({ item }: { item: FeedActivityType }) {
 			<Link
 				to={meta.to}
 				params={meta.params}
-				className="hover:bg-1-mlo-primary/40 -mx-2 flex items-center gap-1.5 truncate rounded-lg px-2 py-0.5 text-sm"
+				className="hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary -mx-2 flex items-center gap-1.5 truncate rounded-lg px-2 py-0.5 text-sm"
 			>
 				<Icon className="text-muted-foreground size-3.5 shrink-0" />
 				<span className="text-muted-foreground shrink-0">

--- a/src/routes/_user/friends/-playlist-preview.tsx
+++ b/src/routes/_user/friends/-playlist-preview.tsx
@@ -28,7 +28,7 @@ export function PlaylistPreview({ id }: { id: uuid }) {
 			params={{ lang: playlist.lang, playlistId: id }}
 		>
 			<div className="bg-card text-card-foreground @container relative z-10 flex flex-col gap-3 rounded-lg border py-0 shadow-sm">
-				<CardHeader className="border-b-3-mlo-primary mx-4 mb-0 border-b px-0 py-4">
+				<CardHeader className="border-b-lc-3 border-b-chroma-mlo border-b-hue-primary mx-4 mb-0 border-b px-0 py-4">
 					<CardTitle className="flex flex-row items-center justify-between gap-1 text-lg">
 						<span className="flex items-center gap-1">
 							<ListMusic className="text-muted-foreground" /> Playlist

--- a/src/routes/_user/friends/-request-preview.tsx
+++ b/src/routes/_user/friends/-request-preview.tsx
@@ -28,7 +28,7 @@ export function RequestPreview({ id }: { id: uuid }) {
 			data-key={id}
 		>
 			<CardlikeRequest className="relative z-10">
-				<CardHeader className="border-b-3-mlo-primary mx-4 mb-4 border-b px-0 py-4">
+				<CardHeader className="border-b-lc-3 border-b-chroma-mlo border-b-hue-primary mx-4 mb-4 border-b px-0 py-4">
 					<CardTitle className="flex flex-row items-center justify-between gap-1 text-lg">
 						<span className="flex items-center gap-1">
 							<MessageCircleHeart className="text-muted-foreground" /> Phrase

--- a/src/routes/_user/friends/invite.lazy.tsx
+++ b/src/routes/_user/friends/invite.lazy.tsx
@@ -39,7 +39,7 @@ function InviteFriendPage() {
 			data-testid="invite-friend-page"
 		>
 			<div className="text-center">
-				<div className="bg-1-mlo-primary text-primary mb-6 inline-flex items-center space-x-2 rounded-full px-4 py-2 text-sm font-medium">
+				<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary text-primary mb-6 inline-flex items-center space-x-2 rounded-full px-4 py-2 text-sm font-medium">
 					<Sparkles className="h-4 w-4" />
 					<span>Grow your learning network</span>
 				</div>
@@ -61,7 +61,7 @@ function InviteFriendPage() {
 						<Card className="group border-border/50 transition-all duration-300 hover:shadow-lg">
 							<CardContent className="p-8">
 								<div className="mb-6 flex items-center space-x-3">
-									<div className="bg-1-mlo-primary group-hover:bg-lc-up-1 flex aspect-square h-12 w-12 items-center justify-center rounded-xl transition-colors">
+									<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary group-hover:bg-lc-up-1 flex aspect-square h-12 w-12 items-center justify-center rounded-xl transition-colors">
 										<Share className="text-primary h-6 w-6" />
 									</div>
 									<div>
@@ -81,7 +81,7 @@ function InviteFriendPage() {
 						<Card className="group border-border/50 transition-all duration-300 hover:shadow-lg">
 							<CardContent className="p-8">
 								<div className="mb-6 flex items-center space-x-3">
-									<div className="bg-1-mlo-accent group-hover:bg-lc-up-1 flex aspect-square h-12 w-12 items-center justify-center rounded-xl transition-colors">
+									<div className="bg-lc-1 bg-chroma-mlo bg-hue-accent group-hover:bg-lc-up-1 flex aspect-square h-12 w-12 items-center justify-center rounded-xl transition-colors">
 										<Copy className="text-accent-foreground h-6 w-6" />
 									</div>
 									<div>
@@ -95,7 +95,7 @@ function InviteFriendPage() {
 								</div>
 								<CopyLinkButton
 									size="lg"
-									className="border-3-mid-accent bg-1-mlo-accent text-accent-foresoft hover:bg-lc-up-1 w-full"
+									className="border-lc-3 border-chroma-mid border-hue-accent bg-lc-1 bg-chroma-mlo bg-hue-accent text-accent-foresoft hover:bg-lc-up-1 w-full"
 									variant="soft"
 									url={share.url}
 								/>
@@ -121,8 +121,8 @@ function InviteFriendPage() {
 							className="group border-border/50 rounded-xl border p-6 text-left shadow transition-all duration-200 hover:shadow-lg"
 						>
 							<div className="flex items-center space-x-4">
-								<div className="bg-1-mlo-info group-hover:bg-lc-up-1 flex h-12 w-12 items-center justify-center rounded-xl transition-colors">
-									<Mail className="text-6-hi-info h-6 w-6" />
+								<div className="bg-lc-1 bg-chroma-mlo bg-hue-info group-hover:bg-lc-up-1 flex h-12 w-12 items-center justify-center rounded-xl transition-colors">
+									<Mail className="text-lc-6 text-chroma-hi text-hue-info h-6 w-6" />
 								</div>
 								<div>
 									<h3 className="text-foreground font-semibold">Email</h3>
@@ -140,8 +140,8 @@ function InviteFriendPage() {
 							className="group border-border/50 rounded-xl border p-6 text-left shadow transition-all duration-200 hover:shadow-lg"
 						>
 							<div className="flex items-center space-x-4">
-								<div className="bg-1-mlo-success group-hover:bg-lc-up-1 flex h-12 w-12 items-center justify-center rounded-xl transition-colors">
-									<MessageSquare className="text-6-hi-success h-6 w-6" />
+								<div className="bg-lc-1 bg-chroma-mlo bg-hue-success group-hover:bg-lc-up-1 flex h-12 w-12 items-center justify-center rounded-xl transition-colors">
+									<MessageSquare className="text-lc-6 text-chroma-hi text-hue-success h-6 w-6" />
 								</div>
 								<div>
 									<h3 className="text-foreground font-semibold">WhatsApp</h3>
@@ -158,8 +158,8 @@ function InviteFriendPage() {
 								className="group border-border/50 col-span-2 rounded-xl border p-6 text-left shadow transition-all duration-200 hover:shadow-lg"
 							>
 								<div className="flex items-center space-x-3">
-									<div className="bg-1-mlo-warning group-hover:bg-lc-up-1 flex aspect-square h-12 w-12 items-center justify-center rounded-xl transition-colors">
-										<Copy className="text-6-hi-warning h-6 w-6" />
+									<div className="bg-lc-1 bg-chroma-mlo bg-hue-warning group-hover:bg-lc-up-1 flex aspect-square h-12 w-12 items-center justify-center rounded-xl transition-colors">
+										<Copy className="text-lc-6 text-chroma-hi text-hue-warning h-6 w-6" />
 									</div>
 									<div>
 										<h3 className="text-foreground text-lg font-semibold">
@@ -192,7 +192,7 @@ function InviteFriendPage() {
 						/>
 					</div>
 					<div className="flex-1 space-y-3 text-center @lg:text-start">
-						<div className="bg-1-mlo-accent text-accent-foresoft inline-flex items-center space-x-2 rounded-full px-3 py-1 text-sm font-medium">
+						<div className="bg-lc-1 bg-chroma-mlo bg-hue-accent text-accent-foresoft inline-flex items-center space-x-2 rounded-full px-3 py-1 text-sm font-medium">
 							<QrCode className="h-4 w-4" />
 							<span>Scan to invite</span>
 						</div>

--- a/src/routes/_user/learn/$lang.deck-settings.tsx
+++ b/src/routes/_user/learn/$lang.deck-settings.tsx
@@ -206,7 +206,7 @@ function DailyGoalSection({
 							learners do well with 10-15 new cards per day.
 						</p>
 						<div className="mx-2 space-y-3">
-							<div className="bg-0-lo-primary flex items-start gap-3 rounded-2xl px-4 py-3">
+							<div className="bg-lc-0 bg-chroma-lo bg-hue-primary flex items-start gap-3 rounded-2xl px-4 py-3">
 								<Cat className="text-primary mt-0.5 size-7 shrink-0" />
 								<div>
 									<p className="font-semibold">Relaxed — 10 new cards</p>
@@ -215,7 +215,7 @@ function DailyGoalSection({
 									</p>
 								</div>
 							</div>
-							<div className="bg-0-lo-primary flex items-start gap-3 rounded-2xl px-4 py-3">
+							<div className="bg-lc-0 bg-chroma-lo bg-hue-primary flex items-start gap-3 rounded-2xl px-4 py-3">
 								<IceCreamBowl className="text-primary mt-0.5 size-7 shrink-0" />
 								<div>
 									<p className="font-semibold">Standard — 15 new cards</p>
@@ -224,7 +224,7 @@ function DailyGoalSection({
 									</p>
 								</div>
 							</div>
-							<div className="bg-0-lo-primary flex items-start gap-3 rounded-2xl px-4 py-3">
+							<div className="bg-lc-0 bg-chroma-lo bg-hue-primary flex items-start gap-3 rounded-2xl px-4 py-3">
 								<Rocket className="text-primary mt-0.5 size-7 shrink-0" />
 								<div>
 									<p className="font-semibold">Serious — 20 new cards</p>

--- a/src/routes/_user/learn/$lang.manage-deck.tsx
+++ b/src/routes/_user/learn/$lang.manage-deck.tsx
@@ -56,15 +56,15 @@ const statusIcon = {
 } as const
 
 const statusColors = {
-	active: 'text-7-hi-primary',
-	learned: 'text-7-hi-success',
-	skipped: 'text-5-mid-neutral',
+	active: 'text-lc-7 text-chroma-hi text-hue-primary',
+	learned: 'text-lc-7 text-chroma-hi text-hue-success',
+	skipped: 'text-lc-5 text-chroma-mid text-hue-neutral',
 } as const
 
 const statusBgColors = {
-	active: 'bg-1-lo-primary',
-	learned: 'bg-1-lo-success',
-	skipped: 'bg-1-lo-neutral',
+	active: 'bg-lc-1 bg-chroma-lo bg-hue-primary',
+	learned: 'bg-lc-1 bg-chroma-lo bg-hue-success',
+	skipped: 'bg-lc-1 bg-chroma-lo bg-hue-neutral',
 } as const
 
 const DEFAULT_RETENTION = 0.9
@@ -94,11 +94,14 @@ function getDueInfo(item: DueCheckable): {
 		const overdue = Math.abs(daysUntilDue)
 		return {
 			label: overdue === 1 ? 'Overdue 1d' : `Overdue ${overdue}d`,
-			color: 'text-7-hi-danger',
+			color: 'text-lc-7 text-chroma-hi text-hue-danger',
 		}
 	}
 	if (daysUntilDue === 0)
-		return { label: 'Due today', color: 'text-7-hi-warning' }
+		return {
+			label: 'Due today',
+			color: 'text-lc-7 text-chroma-hi text-hue-warning',
+		}
 	return {
 		label: daysUntilDue === 1 ? 'Due in 1d' : `Due in ${daysUntilDue}d`,
 		color: 'text-muted-foreground',
@@ -361,7 +364,7 @@ function ManageDeckTable({ lang }: { lang: string }) {
 			<div className="hidden overflow-x-auto rounded-lg border @md:block">
 				<table className="w-full text-sm">
 					<thead>
-						<tr className="bg-1-lo-neutral border-b">
+						<tr className="bg-lc-1 bg-chroma-lo bg-hue-neutral border-b">
 							<SortableHeader
 								label="Phrase"
 								field="phrase"
@@ -425,7 +428,9 @@ function MobileCardRow({ row, lang }: { row: PhraseRow; lang: string }) {
 		<div
 			className={cn(
 				'rounded-lg border transition-colors',
-				open ? 'bg-0-lo-neutral' : 'hover:bg-0-lo-neutral',
+				open
+					? 'bg-lc-0 bg-chroma-lo bg-hue-neutral'
+					: 'hover:bg-lc-0 hover:bg-chroma-lo hover:bg-hue-neutral',
 				isSkipped && 'opacity-50'
 			)}
 			data-testid="manage-deck-row"
@@ -565,7 +570,7 @@ function DesktopCardRow({ row, lang }: { row: PhraseRow; lang: string }) {
 	return (
 		<tr
 			className={cn(
-				'hover:bg-0-lo-neutral border-b transition-colors last:border-b-0',
+				'hover:bg-lc-0 hover:bg-chroma-lo hover:bg-hue-neutral border-b transition-colors last:border-b-0',
 				isSkipped && 'opacity-50'
 			)}
 			data-testid="manage-deck-row"

--- a/src/routes/_user/learn/-archived-deck-tile.tsx
+++ b/src/routes/_user/learn/-archived-deck-tile.tsx
@@ -96,7 +96,7 @@ export function ArchivedDeckTile({ deck }: { deck: DeckMetaType }) {
 							type="button"
 							onClick={restoreDeck}
 							data-testid="confirm-restore-button"
-							className="from-5-mhi-primary to-6-mid-primary text-primary-foreground hover:from-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 text-start shadow transition-transform hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-70"
+							className="from-lc-5 from-chroma-mhi from-hue-primary to-lc-6 to-chroma-mid to-hue-primary text-primary-foreground hover:from-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 text-start shadow transition-transform hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-70"
 						>
 							<ArchiveRestore className="size-6" />
 							<div>
@@ -111,7 +111,7 @@ export function ArchivedDeckTile({ deck }: { deck: DeckMetaType }) {
 
 						<DialogClose
 							data-testid="cancel-restore-button"
-							className="border-2-lo-neutral bg-1-mlo-neutral text-7-mid-neutral hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl border p-4 text-start shadow transition-transform hover:-translate-y-0.5"
+							className="border-lc-2 border-chroma-lo border-hue-neutral bg-lc-1 bg-chroma-mlo bg-hue-neutral text-lc-7 text-chroma-mid text-hue-neutral hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl border p-4 text-start shadow transition-transform hover:-translate-y-0.5"
 						>
 							<Archive className="size-6" />
 							<div>

--- a/src/routes/_user/learn/-deck-tile.tsx
+++ b/src/routes/_user/learn/-deck-tile.tsx
@@ -104,7 +104,7 @@ export function DeckTile({ deck }: { deck: DeckMetaType }) {
 								to="/learn/$lang/review"
 								params={{ lang: deck.lang }}
 								data-testid="start-practice-link"
-								className="from-5-mhi-primary to-6-mid-primary text-primary-foreground hover:from-lc-up-1 flex h-full flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 shadow transition-transform hover:-translate-y-0.5"
+								className="from-lc-5 from-chroma-mhi from-hue-primary to-lc-6 to-chroma-mid to-hue-primary text-primary-foreground hover:from-lc-up-1 flex h-full flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 shadow transition-transform hover:-translate-y-0.5"
 							>
 								{dueToday === 0 ? (
 									<CircleCheck className="size-6" />
@@ -129,7 +129,7 @@ export function DeckTile({ deck }: { deck: DeckMetaType }) {
 								to="/learn/$lang"
 								params={{ lang: deck.lang }}
 								data-testid="deck-link"
-								className="border-2-lo-primary bg-1-mlo-primary text-primary-foresoft hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full flex-col items-start gap-2 rounded-2xl border p-4 shadow transition-transform hover:-translate-y-0.5"
+								className="border-lc-2 border-chroma-lo border-hue-primary bg-lc-1 bg-chroma-mlo bg-hue-primary text-primary-foresoft hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full flex-col items-start gap-2 rounded-2xl border p-4 shadow transition-transform hover:-translate-y-0.5"
 							>
 								<Logs className="size-6" />
 								<div>
@@ -209,7 +209,7 @@ export function AddDeckTile() {
 			data-testid="add-deck-tile"
 			className="block h-full transition-all duration-200 hover:-translate-y-0.5"
 		>
-			<Card className="border-3-lo-primary text-muted-foreground hover:text-primary-foresoft hover:border-primary-foresoft flex h-full min-h-[6.5rem] flex-col items-center justify-center gap-1 border-2 border-dashed bg-transparent p-4 shadow-none hover:bg-transparent hover:shadow-none">
+			<Card className="border-lc-3 border-chroma-lo border-hue-primary text-muted-foreground hover:text-primary-foresoft hover:border-primary-foresoft flex h-full min-h-[6.5rem] flex-col items-center justify-center gap-1 border-2 border-dashed bg-transparent p-4 shadow-none hover:bg-transparent hover:shadow-none">
 				<span className="text-2xl leading-none">+</span>
 				<span className="text-xs font-medium">Start a new deck</span>
 			</Card>

--- a/src/routes/_user/learn/-review-banner.tsx
+++ b/src/routes/_user/learn/-review-banner.tsx
@@ -22,7 +22,7 @@ export function ReviewBanner({
 		<div
 			data-testid="review-ready-banner"
 			data-key={focus.lang}
-			className="bg-1-mlo-info border-2-lo-info border-s-6-mhi-primary @container relative overflow-hidden rounded-lg border border-s-4 p-4 shadow-sm @md:p-5"
+			className="bg-lc-1 bg-chroma-mlo bg-hue-info border-lc-2 border-chroma-lo border-hue-info border-s-6-mhi-primary @container relative overflow-hidden rounded-lg border border-s-4 p-4 shadow-sm @md:p-5"
 		>
 			<div className="flex flex-col items-start gap-4 @md:flex-row @md:items-center @md:justify-between">
 				<div className="flex items-center gap-4">

--- a/src/routes/_user/profile/-avatar-editor-field.tsx
+++ b/src/routes/_user/profile/-avatar-editor-field.tsx
@@ -30,7 +30,7 @@ export function AvatarEditorField() {
 			<div className="flex flex-col gap-2">
 				<Label
 					htmlFor="avatarUploadInput"
-					className="group border-3-mlo-primary hover:border-primary hover:bg-1-mlo-primary relative isolate flex h-40 flex-col items-center rounded-2xl border text-center"
+					className="group border-lc-3 border-chroma-mlo border-hue-primary hover:border-primary hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary relative isolate flex h-40 flex-col items-center rounded-2xl border text-center"
 				>
 					{!url ? null : (
 						<div className="z-10 mx-auto my-2 grid aspect-square size-36">

--- a/src/routes/_user/profile/index.tsx
+++ b/src/routes/_user/profile/index.tsx
@@ -111,7 +111,7 @@ function SignOutSection() {
 		<div className="flex justify-end pt-2">
 			<Button
 				variant="ghost"
-				className="text-7-mhi-danger hover:text-7-hi-danger"
+				className="text-lc-7 text-chroma-mhi text-hue-danger hover:text-lc-7 hover:text-chroma-hi hover:text-hue-danger"
 				onClick={() => signOut.mutate()}
 				data-testid="profile-signout-button"
 				disabled={signOut.isPending}

--- a/src/routes/_user/welcome.tsx
+++ b/src/routes/_user/welcome.tsx
@@ -88,7 +88,7 @@ function WelcomePage() {
 
 			{/* Welcome Header */}
 			<header className="space-y-4 text-center">
-				<div className="from-2-mlo-primary to-0-lo-primary mx-auto flex size-20 items-center justify-center rounded-full bg-gradient-to-br">
+				<div className="from-lc-2 from-chroma-mlo from-hue-primary to-lc-0 to-chroma-lo to-hue-primary mx-auto flex size-20 items-center justify-center rounded-full bg-gradient-to-br">
 					<Sparkles className="text-primary size-10" />
 				</div>
 				<div>
@@ -280,7 +280,7 @@ function FeatureItem({
 }) {
 	return (
 		<div className="flex gap-3">
-			<div className="bg-1-mlo-primary text-primary flex size-10 shrink-0 items-center justify-center rounded-full">
+			<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary text-primary flex size-10 shrink-0 items-center justify-center rounded-full">
 				<Icon className="size-5" />
 			</div>
 			<div>
@@ -328,7 +328,8 @@ function ActionCard({
 		<Card
 			className={cn(
 				'transition-shadow hover:shadow-md',
-				isPrimary && 'border-4-mlo-primary bg-0-lo-primary'
+				isPrimary &&
+					'border-lc-4 border-chroma-mlo border-hue-primary bg-lc-0 bg-chroma-lo bg-hue-primary'
 			)}
 		>
 			<CardHeader className="pb-2">
@@ -409,9 +410,9 @@ function BrowseRequestsDialog({
 							key={lang.lang}
 							type="button"
 							onClick={() => handleLang(lang.lang)}
-							className="bg-card hover:bg-1-lo-primary flex flex-col gap-2 rounded-lg border p-4 text-start transition-colors"
+							className="bg-card hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-primary flex flex-col gap-2 rounded-lg border p-4 text-start transition-colors"
 						>
-							<span className="from-5-mhi-primary to-6-mid-primary text-primary-foreground inline-flex w-fit items-center justify-center rounded-md bg-gradient-to-br px-2.5 py-1 font-mono text-sm font-semibold tracking-wider uppercase shadow-xs">
+							<span className="from-lc-5 from-chroma-mhi from-hue-primary to-lc-6 to-chroma-mid to-hue-primary text-primary-foreground inline-flex w-fit items-center justify-center rounded-md bg-gradient-to-br px-2.5 py-1 font-mono text-sm font-semibold tracking-wider uppercase shadow-xs">
 								{lang.lang.toUpperCase()}
 							</span>
 							<span className="text-sm leading-tight font-semibold">
@@ -428,7 +429,7 @@ function BrowseRequestsDialog({
 						trigger={
 							<button
 								type="button"
-								className="bg-card hover:bg-1-lo-primary flex flex-col gap-2 rounded-lg border border-dashed p-4 text-start transition-colors"
+								className="bg-card hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-primary flex flex-col gap-2 rounded-lg border border-dashed p-4 text-start transition-colors"
 							>
 								<span className="bg-muted text-muted-foreground inline-flex w-fit items-center justify-center rounded-md px-2.5 py-1">
 									<List className="size-4" />

--- a/src/routes/chats.index.lazy.tsx
+++ b/src/routes/chats.index.lazy.tsx
@@ -59,7 +59,7 @@ function ChatsIndexPage() {
 									params: { lang: language.lang },
 								})
 							}}
-							className="bg-card/50 hover:bg-1-mlo-primary block w-full rounded border p-3 text-left text-sm"
+							className="bg-card/50 hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary block w-full rounded border p-3 text-left text-sm"
 						>
 							<div className="font-medium">{language.name}</div>
 							<div className="text-muted-foreground font-mono text-xs uppercase">
@@ -75,7 +75,7 @@ function ChatsIndexPage() {
 							type="button"
 							data-testid="chats-search-trigger"
 							onClick={() => setSearchOpen(true)}
-							className="bg-1-lo-primary hover:bg-1-mlo-primary text-foresoft-primary flex w-full flex-col gap-1 rounded border border-dashed p-3 text-left text-sm"
+							className="bg-lc-1 bg-chroma-lo bg-hue-primary hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary text-foresoft-primary flex w-full flex-col gap-1 rounded border border-dashed p-3 text-left text-sm"
 						>
 							<div className="flex items-center gap-2 font-medium">
 								<Search className="h-4 w-4" />

--- a/src/routes/fsrs.lazy.tsx
+++ b/src/routes/fsrs.lazy.tsx
@@ -250,7 +250,7 @@ function ForgettingCurveChart({
 						x2={PAD.left + PLOT.w}
 						y1={toY(r)}
 						y2={toY(r)}
-						className="text-2-lo-neutral"
+						className="text-lc-2 text-chroma-lo text-hue-neutral"
 						stroke="currentColor"
 						strokeWidth={1}
 					/>
@@ -273,7 +273,7 @@ function ForgettingCurveChart({
 						x2={toX(s.endDay)}
 						y1={PAD.top}
 						y2={PAD.top + PLOT.h}
-						className="text-1-lo-neutral"
+						className="text-lc-1 text-chroma-lo text-hue-neutral"
 						stroke="currentColor"
 						strokeWidth={1}
 					/>
@@ -306,7 +306,7 @@ function ForgettingCurveChart({
 						key={`tail-${s.index}`}
 						d={buildPath(pts)}
 						fill="none"
-						className="text-3-mlo-accent"
+						className="text-lc-3 text-chroma-mlo text-hue-accent"
 						stroke="currentColor"
 						strokeWidth={1.5}
 					/>
@@ -600,7 +600,7 @@ function FsrsPage() {
 														'flex-1 rounded-2xl border px-1 py-1 text-xs transition-colors',
 														r.score === opt
 															? `${SCORE_META[opt].activeBtn} font-medium`
-															: 'border-border text-muted-foreground hover:bg-1-lo-neutral'
+															: 'border-border text-muted-foreground hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-neutral'
 													)}
 												>
 													{SCORE_META[opt].label}
@@ -612,7 +612,7 @@ function FsrsPage() {
 											onClick={() => removeReview(r.id)}
 											aria-label={`Remove review ${i}`}
 											disabled={reviews.length <= 1}
-											className="text-muted-foreground hover:text-5-hi-danger disabled:opacity-40"
+											className="text-muted-foreground hover:text-lc-5 hover:text-chroma-hi hover:text-hue-danger disabled:opacity-40"
 										>
 											<X className="size-4" />
 										</button>

--- a/src/routes/themes.index.lazy.tsx
+++ b/src/routes/themes.index.lazy.tsx
@@ -280,7 +280,7 @@ function ShowcaseRequestThread() {
 	return (
 		<div className="space-y-4" data-testid="showcase-request">
 			<CardlikeRequest>
-				<CardHeader className="border-2-lo-primary py-3 @md:py-6">
+				<CardHeader className="border-lc-2 border-chroma-lo border-hue-primary py-3 @md:py-6">
 					<div className="flex flex-row items-center justify-between gap-2">
 						<Byline
 							initials="PL"
@@ -432,7 +432,7 @@ function ShowcaseDeckDialog() {
 			</div>
 
 			<div className="grid grid-cols-1 gap-3 @sm:grid-cols-2">
-				<div className="from-5-mhi-primary to-6-mid-primary text-primary-foreground flex h-full flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 shadow">
+				<div className="from-lc-5 from-chroma-mhi from-hue-primary to-lc-6 to-chroma-mid to-hue-primary text-primary-foreground flex h-full flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 shadow">
 					<Rocket className="size-6" />
 					<div>
 						<div className="text-base leading-tight font-semibold">
@@ -443,7 +443,7 @@ function ShowcaseDeckDialog() {
 						</div>
 					</div>
 				</div>
-				<div className="border-2-lo-primary bg-1-mlo-primary text-primary-foresoft flex h-full flex-col items-start gap-2 rounded-2xl border p-4 shadow">
+				<div className="border-lc-2 border-chroma-lo border-hue-primary bg-lc-1 bg-chroma-mlo bg-hue-primary text-primary-foresoft flex h-full flex-col items-start gap-2 rounded-2xl border p-4 shadow">
 					<Logs className="size-6" />
 					<div>
 						<div className="text-base leading-tight font-semibold">
@@ -645,10 +645,10 @@ const cardStatusShowcaseStates: Array<{
 	soft?: boolean
 }> = [
 	{ choice: 'active', dot: 'bg-primary', soft: true },
-	{ choice: 'learned', dot: 'bg-5-hi-success' },
-	{ choice: 'skipped', dot: 'bg-4-lo-neutral' },
-	{ choice: 'nocard', dot: 'bg-3-lo-neutral' },
-	{ choice: 'nodeck', dot: 'bg-3-lo-neutral' },
+	{ choice: 'learned', dot: 'bg-lc-5 bg-chroma-hi bg-hue-success' },
+	{ choice: 'skipped', dot: 'bg-lc-4 bg-chroma-lo bg-hue-neutral' },
+	{ choice: 'nocard', dot: 'bg-lc-3 bg-chroma-lo bg-hue-neutral' },
+	{ choice: 'nodeck', dot: 'bg-lc-3 bg-chroma-lo bg-hue-neutral' },
 ]
 
 function CardStatusMenuItem({ choice }: { choice: ShowableActions }) {
@@ -1170,7 +1170,7 @@ function ProfilePill({
 }) {
 	return (
 		<div className="flex w-full flex-row items-center gap-4">
-			<div className="hover:bg-1-mlo-primary hover:border-2-mlo-primary flex grow flex-row items-center justify-start gap-4 rounded-2xl border border-transparent p-2">
+			<div className="hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary hover:border-lc-2 hover:border-chroma-mlo hover:border-hue-primary flex grow flex-row items-center justify-start gap-4 rounded-2xl border border-transparent p-2">
 				<Avatar className="size-8">
 					<AvatarFallback seed={seed} className="text-xs font-bold">
 						{username.slice(0, 2).toUpperCase()}
@@ -1234,7 +1234,7 @@ function ShowcaseProfilePills() {
 function ShowcaseIntroCallout() {
 	return (
 		<div className="space-y-2">
-			<div className="border-3-mlo-primary bg-1-mlo-primary flex items-start gap-2 rounded border px-3 py-2 text-sm">
+			<div className="border-lc-3 border-chroma-mlo border-hue-primary bg-lc-1 bg-chroma-mlo bg-hue-primary flex items-start gap-2 rounded border px-3 py-2 text-sm">
 				<Info className="text-primary mt-0.5 size-4 shrink-0" />
 				<div className="flex-1">
 					<span className="text-foreground/80">
@@ -1246,7 +1246,7 @@ function ShowcaseIntroCallout() {
 					</button>
 				</div>
 			</div>
-			<div className="border-3-mlo-primary bg-1-mlo-primary flex items-start gap-2 rounded border px-3 py-2 text-sm">
+			<div className="border-lc-3 border-chroma-mlo border-hue-primary bg-lc-1 bg-chroma-mlo bg-hue-primary flex items-start gap-2 rounded border px-3 py-2 text-sm">
 				<Info className="text-primary mt-0.5 size-4 shrink-0" />
 				<div className="flex-1">
 					<span className="text-foreground/80">
@@ -1569,7 +1569,7 @@ function ThemesPage() {
 								)}
 								style={{ '--hue-primary': s.hue } as CSSProperties}
 							>
-								<div className="bg-1-mlo-primary h-10 w-full rounded" />
+								<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary h-10 w-full rounded" />
 								<span className="flex flex-col items-center text-center leading-tight">
 									<span
 										className={cn(

--- a/src/routes/themes.typography.lazy.tsx
+++ b/src/routes/themes.typography.lazy.tsx
@@ -59,7 +59,7 @@ function SampleBlock({
 
 	return (
 		<Card className="overflow-hidden">
-			<div className="bg-1-mlo-primary border-b px-4 py-2">
+			<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary border-b px-4 py-2">
 				<div className="flex items-center justify-between">
 					<p className="text-sm font-medium">{label}</p>
 					<p className="text-muted-foreground text-xs">
@@ -69,9 +69,9 @@ function SampleBlock({
 			</div>
 			<CardContent className="space-y-5 p-5" style={baseStyle}>
 				{/* Request-card replica */}
-				<div className="bg-1-mlo-primary rounded-2xl border p-4">
+				<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary rounded-2xl border p-4">
 					<div className="flex items-start gap-3">
-						<div className="bg-3-mid-primary text-primary-foreground flex size-10 shrink-0 items-center justify-center rounded-full text-sm">
+						<div className="bg-lc-3 bg-chroma-mid bg-hue-primary text-primary-foreground flex size-10 shrink-0 items-center justify-center rounded-full text-sm">
 							Y
 						</div>
 						<div className="flex-1">
@@ -85,7 +85,7 @@ function SampleBlock({
 					<p className="mt-3">
 						hey, i&apos;m introducing my friend to coworkers, how do i say:
 					</p>
-					<blockquote className="bg-2-mid-primary mt-3 rounded-md border-s-4 px-4 py-3 italic">
+					<blockquote className="bg-lc-2 bg-chroma-mid bg-hue-primary mt-3 rounded-md border-s-4 px-4 py-3 italic">
 						<span style={boldStyle}>This is maria</span> hello
 					</blockquote>
 					<p className="mt-3">i want to be informal but polite.</p>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,12 +2,11 @@
 @import '@fontsource-variable/atkinson-hyperlegible-next/wght-italic.css';
 @import '@fontsource/opendyslexic/index.css';
 @import 'tailwindcss';
-@import 'tailwind-oklch';
+@import './oklch.css';
 
 @plugin '@tailwindcss/typography';
 @plugin '@tailwindcss/container-queries';
 @plugin 'tailwindcss-animate';
-@plugin 'tailwind-oklch/plugin';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -328,7 +327,7 @@
 		@apply border-border;
 	}
 	body {
-		@apply bg-base-lo-neutral text-foreground;
+		@apply bg-lc-base bg-chroma-lo bg-hue-neutral text-foreground;
 	}
 	body.font-dyslexic {
 		--font-sans: var(--font-dyslexic);

--- a/src/styles/oklch.css
+++ b/src/styles/oklch.css
@@ -1,0 +1,524 @@
+/* oklch.css — single-axis, cascade-first OKLCH color system for Tailwind v4
+ *
+ * Vendored from mhsnook/tailwind-oklch@112de8e (MIT). Reworked into a
+ * single-axis, cascade-first API with no JavaScript plugin:
+ *
+ *   - Cascade seeders set an axis for every color property at once and
+ *     apply no property themselves. They flow down the DOM tree:
+ *       hue-primary · hue-danger · …    seeds hue for everything below
+ *       chroma-mlo · chroma-hi · …      seeds chroma for everything below
+ *
+ *   - Per-property setters apply exactly one CSS property from one axis.
+ *     Hue and chroma inherit from a seeder (or the :root default) unless
+ *     set explicitly, so most elements only ever state their luminance:
+ *       bg-lc-1      bg-chroma-mlo     bg-hue-accent
+ *       text-lc-8    text-chroma-hi    text-hue-info
+ *       border-lc-3  border-chroma-[6] border-hue-primary
+ *       …plus border-b-*, from-*, to-*
+ *
+ *   - Relative adjustments nudge off the inherited/current luminance
+ *     without rewriting it (so they don't compound down the tree):
+ *       bg-lc-up-1 · bg-lc-down-1 · text-lc-up-1 · from-lc-up-1 · …
+ *
+ * Named and arbitrary values coexist per utility by stacking two
+ * @utility blocks of the same name: the one whose --value() resolves
+ * wins. Named luminance/chroma pull from the @theme scales; arbitrary
+ * integers are divided by 100 (chroma) and auto-flipped for dark mode
+ * (luminance: L = v + flip × (1 − 2v)).
+ *
+ * Luminance contrast scale: 0–10.
+ *   0 / base  = close to the page color (blends in)
+ *   10 / fore = high contrast with the page (stands out, like text)
+ *   1–9       = evenly distributed between those endpoints
+ *   none      = absolute minimum (pure white or pure black, per mode)
+ *   full      = absolute maximum (pure black or pure white, per mode)
+ */
+
+@theme {
+	/* ── Hue Definitions ─────────────────────────────────────────────────
+	   Change these to re-theme your entire app. Overridden per-app in
+	   globals.css and per-language via inline --hue-* style vars. */
+	--hue-primary: 233;
+	--hue-accent: 350;
+	--hue-success: 145;
+	--hue-warning: 55;
+	--hue-danger: 15;
+	--hue-info: 220;
+	--hue-neutral: 260;
+
+	/* ── Luminance Contrast Range ─────────────────────────────────────
+	   Defines the OKLCH lightness values at 0 (base) and 10 (fore).
+	   Light mode (default): base is near white, fore is near black.
+	   Dark mode flips them (see .dark below).
+	   Override --lc-range-start and --lc-range-end to shift the range. */
+	--lc-range-start: 0.95;
+	--lc-range-end: 0.15;
+
+	/* ── 0–10 Luminance Contrast Scale ────────────────────────────────
+	   Light mode uses a power curve (p≈1.3): smaller steps near the
+	   high-luminance base, growing toward the fore. Perception is
+	   more sensitive to differences near white, so subtle surfaces
+	   need finer L deltas there.
+	   Computed: step N = start + (end − start) × (N / 10)^1.3
+	   Light mode (default): 0→0.95, 1→0.91, 5→0.63, 10→0.15
+	   Dark mode stays linear (see .dark): 0→0.12, 5→0.52, 10→0.92 */
+	--l-0: 0.95;
+	--l-1: 0.91;
+	--l-2: 0.85;
+	--l-3: 0.78;
+	--l-4: 0.71;
+	--l-5: 0.63;
+	--l-6: 0.54;
+	--l-7: 0.44;
+	--l-8: 0.34;
+	--l-9: 0.23;
+	--l-10: 0.15;
+
+	/* Semantic aliases */
+	--l-base: 0.95;
+	--l-fore: 0.15;
+
+	/* Absolute extremes — escape the configured range entirely.
+	   none = beyond base (pure white in light, pure black in dark).
+	   full = beyond fore (pure black in light, pure white in dark). */
+	--l-none: 1;
+	--l-full: 0;
+
+	/* ── Named Chroma Stops ──────────────────────────────────────────────
+	   OKLCH chroma: practical range 0–0.25 */
+	--c-lo: 0.02;
+	--c-mlo: 0.06;
+	--c-mid: 0.12;
+	--c-mhi: 0.18;
+	--c-hi: 0.25;
+
+	/* ── LC Adjustment Steps ───────────────────────────────────────────
+	   Each step ≈ one position on the 0–10 scale (~0.08 OKLCH L). */
+	--lc-adj-1: 0.08;
+	--lc-adj-2: 0.16;
+	--lc-adj-3: 0.24;
+}
+
+/* ── Dark-mode luminance contrast range ──────────────────────────────
+   In dark mode the scale flips: 0/base is near black (blends with
+   the page), 10/fore is near white (high contrast, like text). */
+
+.dark {
+	--lc-dir: 1;
+	--lc-flip: 1;
+	--lc-range-start: 0.12;
+	--lc-range-end: 0.92;
+
+	--l-0: 0.12;
+	--l-1: 0.2;
+	--l-2: 0.28;
+	--l-3: 0.36;
+	--l-4: 0.44;
+	--l-5: 0.52;
+	--l-6: 0.6;
+	--l-7: 0.68;
+	--l-8: 0.76;
+	--l-9: 0.84;
+	--l-10: 0.92;
+
+	--l-base: 0.12;
+	--l-fore: 0.92;
+
+	--l-none: 0;
+	--l-full: 1;
+}
+
+/* ── Cascade Defaults ────────────────────────────────────────────────────
+   Sensible fallbacks so any single-axis setter immediately resolves.
+   These inherit down the DOM tree, so a parent's bg-hue-accent
+   naturally flows to children that only set bg-lc-* or bg-chroma-*. */
+
+:root {
+	--lc-dir: -1;
+	--lc-flip: 0;
+
+	--bg-l: var(--l-5);
+	--bg-c: var(--c-lo);
+	--bg-h: var(--hue-primary);
+
+	--tx-l: var(--l-fore);
+	--tx-c: var(--c-lo);
+	--tx-h: var(--hue-primary);
+
+	--bd-l: var(--l-3);
+	--bd-c: var(--c-lo);
+	--bd-h: var(--hue-primary);
+
+	--bdb-l: var(--l-3);
+	--bdb-c: var(--c-lo);
+	--bdb-h: var(--hue-primary);
+
+	--gf-l: var(--l-5);
+	--gf-c: var(--c-mid);
+	--gf-h: var(--hue-primary);
+
+	--gt-l: var(--l-5);
+	--gt-c: var(--c-mid);
+	--gt-h: var(--hue-primary);
+}
+
+/* ── Global Hue seeder ───────────────────────────────────────────────────
+   Set the hue for ALL color properties at once, applying no property.
+   Per-property hue utilities (bg-hue-*, text-hue-*, …) still override.
+   Usage: hue-primary, hue-accent, hue-danger, etc. */
+
+@utility hue-* {
+	--bg-h: --value(--hue-*);
+	--tx-h: --value(--hue-*);
+	--bd-h: --value(--hue-*);
+	--bdb-h: --value(--hue-*);
+	--gf-h: --value(--hue-*);
+	--gt-h: --value(--hue-*);
+}
+
+/* ── Global Chroma seeder ────────────────────────────────────────────────
+   Set the chroma for ALL color properties at once, applying no property.
+   Per-property chroma utilities (bg-chroma-*, …) still override.
+   Usage: chroma-lo, chroma-mid, chroma-hi, etc. */
+
+@utility chroma-* {
+	--bg-c: --value(--c-*);
+	--tx-c: --value(--c-*);
+	--bd-c: --value(--c-*);
+	--bdb-c: --value(--c-*);
+	--gf-c: --value(--c-*);
+	--gt-c: --value(--c-*);
+}
+
+/* ── Background ──────────────────────────────────────────────────────── */
+
+@utility bg-lc-* {
+	--bg-l: --value(--l-*);
+	background-color: oklch(var(--bg-l) var(--bg-c) var(--bg-h));
+}
+@utility bg-lc-* {
+	/* arbitrary bg-lc-[93]: auto-flip L = v + flip × (1 − 2v) */
+	--bg-lv: calc(--value([integer]) / 100);
+	--bg-l: calc(var(--bg-lv) + var(--lc-flip) * (1 - 2 * var(--bg-lv)));
+	background-color: oklch(var(--bg-l) var(--bg-c) var(--bg-h));
+}
+
+@utility bg-chroma-* {
+	--bg-c: --value(--c-*);
+	background-color: oklch(var(--bg-l) var(--bg-c) var(--bg-h));
+}
+@utility bg-chroma-* {
+	/* arbitrary bg-chroma-[6]: chroma = n / 100 */
+	--bg-c: calc(--value([integer]) / 100);
+	background-color: oklch(var(--bg-l) var(--bg-c) var(--bg-h));
+}
+
+@utility bg-hue-* {
+	--bg-h: --value(--hue-*);
+	background-color: oklch(var(--bg-l) var(--bg-c) var(--bg-h));
+}
+
+@utility bg-lc-up-* {
+	--bg-l-adj: --value(--lc-adj-*);
+	background-color: oklch(
+		clamp(0, calc(var(--bg-l) + var(--lc-dir) * var(--bg-l-adj)), 1) var(--bg-c)
+			var(--bg-h)
+	);
+}
+@utility bg-lc-down-* {
+	--bg-l-adj: --value(--lc-adj-*);
+	background-color: oklch(
+		clamp(0, calc(var(--bg-l) - var(--lc-dir) * var(--bg-l-adj)), 1) var(--bg-c)
+			var(--bg-h)
+	);
+}
+
+/* ── Text ────────────────────────────────────────────────────────────── */
+
+@utility text-lc-* {
+	--tx-l: --value(--l-*);
+	color: oklch(var(--tx-l) var(--tx-c) var(--tx-h));
+}
+@utility text-lc-* {
+	--tx-lv: calc(--value([integer]) / 100);
+	--tx-l: calc(var(--tx-lv) + var(--lc-flip) * (1 - 2 * var(--tx-lv)));
+	color: oklch(var(--tx-l) var(--tx-c) var(--tx-h));
+}
+
+@utility text-chroma-* {
+	--tx-c: --value(--c-*);
+	color: oklch(var(--tx-l) var(--tx-c) var(--tx-h));
+}
+@utility text-chroma-* {
+	--tx-c: calc(--value([integer]) / 100);
+	color: oklch(var(--tx-l) var(--tx-c) var(--tx-h));
+}
+
+@utility text-hue-* {
+	--tx-h: --value(--hue-*);
+	color: oklch(var(--tx-l) var(--tx-c) var(--tx-h));
+}
+
+@utility text-lc-up-* {
+	--tx-l-adj: --value(--lc-adj-*);
+	color: oklch(
+		clamp(0, calc(var(--tx-l) + var(--lc-dir) * var(--tx-l-adj)), 1) var(--tx-c)
+			var(--tx-h)
+	);
+}
+@utility text-lc-down-* {
+	--tx-l-adj: --value(--lc-adj-*);
+	color: oklch(
+		clamp(0, calc(var(--tx-l) - var(--lc-dir) * var(--tx-l-adj)), 1) var(--tx-c)
+			var(--tx-h)
+	);
+}
+
+/* ── Border ──────────────────────────────────────────────────────────── */
+
+@utility border-lc-* {
+	--bd-l: --value(--l-*);
+	border-color: oklch(var(--bd-l) var(--bd-c) var(--bd-h));
+}
+@utility border-lc-* {
+	--bd-lv: calc(--value([integer]) / 100);
+	--bd-l: calc(var(--bd-lv) + var(--lc-flip) * (1 - 2 * var(--bd-lv)));
+	border-color: oklch(var(--bd-l) var(--bd-c) var(--bd-h));
+}
+
+@utility border-chroma-* {
+	--bd-c: --value(--c-*);
+	border-color: oklch(var(--bd-l) var(--bd-c) var(--bd-h));
+}
+@utility border-chroma-* {
+	--bd-c: calc(--value([integer]) / 100);
+	border-color: oklch(var(--bd-l) var(--bd-c) var(--bd-h));
+}
+
+@utility border-hue-* {
+	--bd-h: --value(--hue-*);
+	border-color: oklch(var(--bd-l) var(--bd-c) var(--bd-h));
+}
+
+@utility border-lc-up-* {
+	--bd-l-adj: --value(--lc-adj-*);
+	border-color: oklch(
+		clamp(0, calc(var(--bd-l) + var(--lc-dir) * var(--bd-l-adj)), 1) var(--bd-c)
+			var(--bd-h)
+	);
+}
+@utility border-lc-down-* {
+	--bd-l-adj: --value(--lc-adj-*);
+	border-color: oklch(
+		clamp(0, calc(var(--bd-l) - var(--lc-dir) * var(--bd-l-adj)), 1) var(--bd-c)
+			var(--bd-h)
+	);
+}
+
+/* ── Border Bottom ───────────────────────────────────────────────────── */
+
+@utility border-b-lc-* {
+	--bdb-l: --value(--l-*);
+	border-bottom-color: oklch(var(--bdb-l) var(--bdb-c) var(--bdb-h));
+}
+@utility border-b-lc-* {
+	--bdb-lv: calc(--value([integer]) / 100);
+	--bdb-l: calc(var(--bdb-lv) + var(--lc-flip) * (1 - 2 * var(--bdb-lv)));
+	border-bottom-color: oklch(var(--bdb-l) var(--bdb-c) var(--bdb-h));
+}
+
+@utility border-b-chroma-* {
+	--bdb-c: --value(--c-*);
+	border-bottom-color: oklch(var(--bdb-l) var(--bdb-c) var(--bdb-h));
+}
+@utility border-b-chroma-* {
+	--bdb-c: calc(--value([integer]) / 100);
+	border-bottom-color: oklch(var(--bdb-l) var(--bdb-c) var(--bdb-h));
+}
+
+@utility border-b-hue-* {
+	--bdb-h: --value(--hue-*);
+	border-bottom-color: oklch(var(--bdb-l) var(--bdb-c) var(--bdb-h));
+}
+
+@utility border-b-lc-up-* {
+	--bdb-l-adj: --value(--lc-adj-*);
+	border-bottom-color: oklch(
+		clamp(0, calc(var(--bdb-l) + var(--lc-dir) * var(--bdb-l-adj)), 1)
+			var(--bdb-c) var(--bdb-h)
+	);
+}
+@utility border-b-lc-down-* {
+	--bdb-l-adj: --value(--lc-adj-*);
+	border-bottom-color: oklch(
+		clamp(0, calc(var(--bdb-l) - var(--lc-dir) * var(--bdb-l-adj)), 1)
+			var(--bdb-c) var(--bdb-h)
+	);
+}
+
+/* ── Gradient From ───────────────────────────────────────────────────────
+   Composes --tw-gradient-stops to match Tailwind v4's gradient plumbing. */
+
+@utility from-lc-* {
+	--gf-l: --value(--l-*);
+	--tw-gradient-from: oklch(var(--gf-l) var(--gf-c) var(--gf-h));
+	--tw-gradient-stops: var(
+		--tw-gradient-via-stops,
+		var(--tw-gradient-position),
+		var(--tw-gradient-from) var(--tw-gradient-from-position),
+		var(--tw-gradient-to) var(--tw-gradient-to-position)
+	);
+}
+@utility from-lc-* {
+	--gf-lv: calc(--value([integer]) / 100);
+	--gf-l: calc(var(--gf-lv) + var(--lc-flip) * (1 - 2 * var(--gf-lv)));
+	--tw-gradient-from: oklch(var(--gf-l) var(--gf-c) var(--gf-h));
+	--tw-gradient-stops: var(
+		--tw-gradient-via-stops,
+		var(--tw-gradient-position),
+		var(--tw-gradient-from) var(--tw-gradient-from-position),
+		var(--tw-gradient-to) var(--tw-gradient-to-position)
+	);
+}
+
+@utility from-chroma-* {
+	--gf-c: --value(--c-*);
+	--tw-gradient-from: oklch(var(--gf-l) var(--gf-c) var(--gf-h));
+	--tw-gradient-stops: var(
+		--tw-gradient-via-stops,
+		var(--tw-gradient-position),
+		var(--tw-gradient-from) var(--tw-gradient-from-position),
+		var(--tw-gradient-to) var(--tw-gradient-to-position)
+	);
+}
+@utility from-chroma-* {
+	--gf-c: calc(--value([integer]) / 100);
+	--tw-gradient-from: oklch(var(--gf-l) var(--gf-c) var(--gf-h));
+	--tw-gradient-stops: var(
+		--tw-gradient-via-stops,
+		var(--tw-gradient-position),
+		var(--tw-gradient-from) var(--tw-gradient-from-position),
+		var(--tw-gradient-to) var(--tw-gradient-to-position)
+	);
+}
+
+@utility from-hue-* {
+	--gf-h: --value(--hue-*);
+	--tw-gradient-from: oklch(var(--gf-l) var(--gf-c) var(--gf-h));
+	--tw-gradient-stops: var(
+		--tw-gradient-via-stops,
+		var(--tw-gradient-position),
+		var(--tw-gradient-from) var(--tw-gradient-from-position),
+		var(--tw-gradient-to) var(--tw-gradient-to-position)
+	);
+}
+
+@utility from-lc-up-* {
+	--gf-l-adj: --value(--lc-adj-*);
+	--tw-gradient-from: oklch(
+		clamp(0, calc(var(--gf-l) + var(--lc-dir) * var(--gf-l-adj)), 1) var(--gf-c)
+			var(--gf-h)
+	);
+	--tw-gradient-stops: var(
+		--tw-gradient-via-stops,
+		var(--tw-gradient-position),
+		var(--tw-gradient-from) var(--tw-gradient-from-position),
+		var(--tw-gradient-to) var(--tw-gradient-to-position)
+	);
+}
+@utility from-lc-down-* {
+	--gf-l-adj: --value(--lc-adj-*);
+	--tw-gradient-from: oklch(
+		clamp(0, calc(var(--gf-l) - var(--lc-dir) * var(--gf-l-adj)), 1) var(--gf-c)
+			var(--gf-h)
+	);
+	--tw-gradient-stops: var(
+		--tw-gradient-via-stops,
+		var(--tw-gradient-position),
+		var(--tw-gradient-from) var(--tw-gradient-from-position),
+		var(--tw-gradient-to) var(--tw-gradient-to-position)
+	);
+}
+
+/* ── Gradient To ─────────────────────────────────────────────────────── */
+
+@utility to-lc-* {
+	--gt-l: --value(--l-*);
+	--tw-gradient-to: oklch(var(--gt-l) var(--gt-c) var(--gt-h));
+	--tw-gradient-stops: var(
+		--tw-gradient-via-stops,
+		var(--tw-gradient-position),
+		var(--tw-gradient-from) var(--tw-gradient-from-position),
+		var(--tw-gradient-to) var(--tw-gradient-to-position)
+	);
+}
+@utility to-lc-* {
+	--gt-lv: calc(--value([integer]) / 100);
+	--gt-l: calc(var(--gt-lv) + var(--lc-flip) * (1 - 2 * var(--gt-lv)));
+	--tw-gradient-to: oklch(var(--gt-l) var(--gt-c) var(--gt-h));
+	--tw-gradient-stops: var(
+		--tw-gradient-via-stops,
+		var(--tw-gradient-position),
+		var(--tw-gradient-from) var(--tw-gradient-from-position),
+		var(--tw-gradient-to) var(--tw-gradient-to-position)
+	);
+}
+
+@utility to-chroma-* {
+	--gt-c: --value(--c-*);
+	--tw-gradient-to: oklch(var(--gt-l) var(--gt-c) var(--gt-h));
+	--tw-gradient-stops: var(
+		--tw-gradient-via-stops,
+		var(--tw-gradient-position),
+		var(--tw-gradient-from) var(--tw-gradient-from-position),
+		var(--tw-gradient-to) var(--tw-gradient-to-position)
+	);
+}
+@utility to-chroma-* {
+	--gt-c: calc(--value([integer]) / 100);
+	--tw-gradient-to: oklch(var(--gt-l) var(--gt-c) var(--gt-h));
+	--tw-gradient-stops: var(
+		--tw-gradient-via-stops,
+		var(--tw-gradient-position),
+		var(--tw-gradient-from) var(--tw-gradient-from-position),
+		var(--tw-gradient-to) var(--tw-gradient-to-position)
+	);
+}
+
+@utility to-hue-* {
+	--gt-h: --value(--hue-*);
+	--tw-gradient-to: oklch(var(--gt-l) var(--gt-c) var(--gt-h));
+	--tw-gradient-stops: var(
+		--tw-gradient-via-stops,
+		var(--tw-gradient-position),
+		var(--tw-gradient-from) var(--tw-gradient-from-position),
+		var(--tw-gradient-to) var(--tw-gradient-to-position)
+	);
+}
+
+@utility to-lc-up-* {
+	--gt-l-adj: --value(--lc-adj-*);
+	--tw-gradient-to: oklch(
+		clamp(0, calc(var(--gt-l) + var(--lc-dir) * var(--gt-l-adj)), 1) var(--gt-c)
+			var(--gt-h)
+	);
+	--tw-gradient-stops: var(
+		--tw-gradient-via-stops,
+		var(--tw-gradient-position),
+		var(--tw-gradient-from) var(--tw-gradient-from-position),
+		var(--tw-gradient-to) var(--tw-gradient-to-position)
+	);
+}
+@utility to-lc-down-* {
+	--gt-l-adj: --value(--lc-adj-*);
+	--tw-gradient-to: oklch(
+		clamp(0, calc(var(--gt-l) - var(--lc-dir) * var(--gt-l-adj)), 1) var(--gt-c)
+			var(--gt-h)
+	);
+	--tw-gradient-stops: var(
+		--tw-gradient-via-stops,
+		var(--tw-gradient-position),
+		var(--tw-gradient-from) var(--tw-gradient-from-position),
+		var(--tw-gradient-to) var(--tw-gradient-to-position)
+	);
+}


### PR DESCRIPTION
Replaces the `tailwind-oklch` npm package with a vendored, single-axis OKLCH color system (`src/styles/oklch.css`). This eliminates an external dependency while improving the API and documentation.

## Summary

The tailwind-oklch plugin has been forked into the codebase as a pure CSS utility system with no JavaScript plugin required. The new system uses a cascade-first, single-axis design where hue and chroma flow down the DOM tree via seeders, and most elements only specify luminance.

## Key Changes

- **Added `src/styles/oklch.css`** (524 lines): Complete OKLCH color system with:
  - Cascade seeders (`hue-*`, `chroma-*`) that set axes for all descendants without applying properties
  - Per-property setters (`bg-lc-*`, `text-lc-*`, `border-lc-*`, `from-*`, `to-*`) that apply one axis
  - Relative adjustments (`bg-lc-up-*`, `bg-lc-down-*`) for luminance nudges
  - Auto-flipping between light/dark mode via CSS variables
  - Support for named values (0–10 scale, `base`, `fore`, `none`, `full`) and arbitrary integers

- **Updated `docs/styling.md`**: Comprehensive guide explaining the new API, with examples showing how to seed hue/chroma once at a component root and speak only luminance inside

- **Migrated all component classNames** across 60+ files from old shorthand (`bg-1-mlo-primary`) to new explicit form (`bg-lc-1 bg-chroma-mlo bg-hue-primary`), enabling per-axis overrides and better cascade inheritance

- **Updated `src/styles/globals.css`**: Changed import from `@import 'tailwind-oklch'` to `@import './oklch.css'`

- **Removed `tailwind-oklch` from `package.json`**: Eliminated npm dependency

## Implementation Details

The system uses CSS custom properties to cascade axes down the tree:
- `:root` sets defaults for all properties (`--bg-h`, `--bg-c`, `--bg-l`, etc.)
- Seeders (`hue-primary`, `chroma-mlo`) override only the axis they control
- Per-property utilities read from inherited/seeded values and apply the color
- Dark mode flips the luminance scale and sets `--lc-flip: 1` for auto-inversion of arbitrary values
- Relative adjustments use `clamp()` to prevent out-of-bounds values

All existing color usage patterns continue to work; the explicit three-axis form is more verbose but enables fine-grained control and better documents intent.

https://claude.ai/code/session_01UdrsNCcNMbQC4TbYHaeGsU