### PR TITLE
Pass 2: OKLCH cascade pruning (incremental)

### DIFF
--- a/src/components/intro-callout.tsx
+++ b/src/components/intro-callout.tsx
@@ -24,7 +24,7 @@ export function IntroCallout({
 	return (
 		<div
 			className={cn(
-				'border-lc-3 border-chroma-mlo border-hue-primary bg-lc-1 bg-chroma-mlo bg-hue-primary flex items-start gap-2 rounded border px-3 py-2 text-sm',
+				'hue-primary chroma-mlo bg-lc-1 border-lc-3 flex items-start gap-2 rounded border px-3 py-2 text-sm',
 				className
 			)}
 		>

--- a/src/components/login-card-body.tsx
+++ b/src/components/login-card-body.tsx
@@ -34,12 +34,12 @@ function InvalidCredentialsError() {
 		<div
 			role="alert"
 			data-testid="login-error-invalid-credentials"
-			className="animate-shake flex items-center gap-2"
+			className="hue-danger chroma-mhi animate-shake flex items-center gap-2"
 		>
-			<span className="hue-danger bg-lc-5 bg-chroma-mhi flex size-7 shrink-0 items-center justify-center rounded-full">
+			<span className="bg-lc-5 flex size-7 shrink-0 items-center justify-center rounded-full">
 				<X className="size-4 text-white" aria-hidden={true} />
 			</span>
-			<strong className="text-lc-7 text-chroma-mhi text-hue-danger">
+			<strong className="text-lc-7">
 				Incorrect email or password. Try again?
 			</strong>
 		</div>

--- a/src/components/navs/active-review-callout.tsx
+++ b/src/components/navs/active-review-callout.tsx
@@ -113,7 +113,7 @@ export function ActiveReviewCallout({
 }
 
 const calloutCard =
-	'border-lc-[87] border-chroma-[6] border-hue-primary bg-lc-[93] bg-chroma-[4] bg-hue-primary mx-2 mb-2 rounded-xl border p-3'
+	'hue-primary border-lc-[87] border-chroma-[6] bg-lc-[93] bg-chroma-[4] mx-2 mb-2 rounded-xl border p-3'
 const iconCircle = 'rounded-lg bg-white p-1.5'
 
 function CalloutContent({
@@ -151,7 +151,7 @@ function CalloutContent({
 			<div className={calloutCard}>
 				<div className="flex items-center gap-2">
 					<div className={iconCircle}>
-						<Rocket className="text-lc-5 text-chroma-mid text-hue-primary h-4 w-4" />
+						<Rocket className="text-lc-5 text-chroma-mid h-4 w-4" />
 					</div>
 					<div className="flex-1">
 						<p className="text-sm font-semibold">{remaining} cards left</p>
@@ -181,7 +181,7 @@ function CalloutContent({
 		<div className={calloutCard}>
 			<div className="flex items-center gap-2">
 				<div className={iconCircle}>
-					<Rocket className="text-lc-5 text-chroma-mid text-hue-primary h-4 w-4" />
+					<Rocket className="text-lc-5 text-chroma-mid h-4 w-4" />
 				</div>
 				<span className="text-sm font-semibold">Finish your review</span>
 			</div>

--- a/src/components/navs/onboarding-nudge.tsx
+++ b/src/components/navs/onboarding-nudge.tsx
@@ -42,11 +42,11 @@ export function OnboardingNudge() {
 	return (
 		<div
 			data-testid="onboarding-nudge"
-			className="border-lc-[87] border-chroma-[6] border-hue-primary bg-lc-[93] bg-chroma-[4] bg-hue-primary mx-2 mb-2 rounded-xl border p-3"
+			className="hue-primary border-lc-[87] border-chroma-[6] bg-lc-[93] bg-chroma-[4] mx-2 mb-2 rounded-xl border p-3"
 		>
 			<div className="flex items-start gap-2">
 				<div className="rounded-lg bg-white p-1.5">
-					<Sparkles className="text-lc-5 text-chroma-mid text-hue-primary h-4 w-4" />
+					<Sparkles className="text-lc-5 text-chroma-mid h-4 w-4" />
 				</div>
 				<div className="flex-1">
 					<p className="text-sm font-semibold">Continue setup</p>

--- a/src/components/notifications/notification-item.tsx
+++ b/src/components/notifications/notification-item.tsx
@@ -28,38 +28,32 @@ const notificationConfig: Record<
 	request_commented: {
 		Icon: MessageSquareQuote,
 		action: 'commented on your request',
-		iconClass:
-			'text-lc-7 text-chroma-mid text-hue-primary bg-lc-1 bg-chroma-lo bg-hue-primary',
+		iconClass: 'hue-primary text-lc-7 text-chroma-mid bg-lc-1 bg-chroma-lo',
 	},
 	comment_replied: {
 		Icon: MessagesSquare,
 		action: 'replied to your comment',
-		iconClass:
-			'text-lc-7 text-chroma-mid text-hue-info bg-lc-1 bg-chroma-lo bg-hue-info',
+		iconClass: 'hue-info text-lc-7 text-chroma-mid bg-lc-1 bg-chroma-lo',
 	},
 	phrase_translated: {
 		Icon: Languages,
 		action: 'added a translation to your phrase',
-		iconClass:
-			'text-lc-7 text-chroma-mid text-hue-success bg-lc-1 bg-chroma-lo bg-hue-success',
+		iconClass: 'hue-success text-lc-7 text-chroma-mid bg-lc-1 bg-chroma-lo',
 	},
 	phrase_referenced: {
 		Icon: Link2,
 		action: 'referenced your phrase as an answer',
-		iconClass:
-			'text-lc-7 text-chroma-mid text-hue-accent bg-lc-1 bg-chroma-lo bg-hue-accent',
+		iconClass: 'hue-accent text-lc-7 text-chroma-mid bg-lc-1 bg-chroma-lo',
 	},
 	request_upvoted: {
 		Icon: ThumbsUp,
 		action: 'upvoted your request',
-		iconClass:
-			'text-lc-7 text-chroma-mid text-hue-warning bg-lc-1 bg-chroma-lo bg-hue-warning',
+		iconClass: 'hue-warning text-lc-7 text-chroma-mid bg-lc-1 bg-chroma-lo',
 	},
 	change_suggested: {
 		Icon: MessageSquareQuote,
 		action: 'suggested a change to your content',
-		iconClass:
-			'text-lc-7 text-chroma-mid text-hue-neutral bg-lc-1 bg-chroma-lo bg-hue-neutral',
+		iconClass: 'hue-neutral text-lc-7 text-chroma-mid bg-lc-1 bg-chroma-lo',
 	},
 }
 

--- a/src/components/playlists/playlist-embed.tsx
+++ b/src/components/playlists/playlist-embed.tsx
@@ -134,7 +134,7 @@ export function PlaylistEmbed({ href }: PlaylistEmbedProps) {
 				href={href}
 				target="_blank"
 				rel="noopener noreferrer"
-				className="bg-lc-1 bg-chroma-mlo bg-hue-neutral text-lc-7 text-chroma-mid text-hue-neutral hover:bg-lc-2 hover:bg-chroma-mlo hover:bg-hue-neutral flex items-center gap-2 rounded-2xl px-4 py-3 text-sm no-underline transition-colors"
+				className="hue-neutral bg-lc-1 bg-chroma-mlo text-lc-7 text-chroma-mid hover:bg-lc-2 hover:bg-chroma-mlo flex items-center gap-2 rounded-2xl px-4 py-3 text-sm no-underline transition-colors"
 			>
 				<ExternalLink className="size-4 shrink-0" />
 				<span>

--- a/src/components/share/friend-picker.tsx
+++ b/src/components/share/friend-picker.tsx
@@ -51,7 +51,7 @@ function highlight(text: string, query: string): ReactNode {
 	return (
 		<>
 			{text.slice(0, i)}
-			<mark className="bg-lc-2 bg-chroma-mid bg-hue-warning text-lc-8 text-chroma-hi text-hue-warning rounded-[3px] px-px">
+			<mark className="hue-warning bg-lc-2 bg-chroma-mid text-lc-8 text-chroma-hi rounded-[3px] px-px">
 				{text.slice(i, i + query.length)}
 			</mark>
 			{text.slice(i + query.length)}
@@ -96,7 +96,7 @@ function FriendRow({
 			</span>
 			<span className="flex shrink-0 flex-col items-end gap-1">
 				{friend.status === 'pending' ? (
-					<span className="bg-lc-2 bg-chroma-mid bg-hue-primary text-lc-7 text-chroma-hi text-hue-primary inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold tracking-wide uppercase">
+					<span className="hue-primary bg-lc-2 bg-chroma-mid text-lc-7 text-chroma-hi inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold tracking-wide uppercase">
 						<UserPlus className="size-2.5" /> Pending
 					</span>
 				) : timestamp ? (
@@ -225,7 +225,7 @@ function PickerBody({
 			<div className="flex flex-col">
 				{preview ? <div className="pt-1">{preview}</div> : null}
 				<div className="text-muted-foreground px-6 py-9 text-center">
-					<span className="bg-lc-2 bg-chroma-mlo bg-hue-primary text-lc-6 text-chroma-hi text-hue-primary mb-3.5 inline-flex size-14 items-center justify-center rounded-full">
+					<span className="hue-primary bg-lc-2 bg-chroma-mlo text-lc-6 text-chroma-hi mb-3.5 inline-flex size-14 items-center justify-center rounded-full">
 						<Users className="size-7" />
 					</span>
 					<h3 className="text-foreground mb-1.5 text-base font-bold">

--- a/src/components/ui/blockquote.tsx
+++ b/src/components/ui/blockquote.tsx
@@ -11,7 +11,7 @@ export function Blockquote({
 	return (
 		<blockquote
 			className={cn(
-				'border-lc-4 border-chroma-mlo border-hue-primary bg-lc-1 bg-chroma-mlo bg-hue-primary mb-4 rounded border-l-4 p-4 italic',
+				'hue-primary chroma-mlo bg-lc-1 border-lc-4 mb-4 rounded border-l-4 p-4 italic',
 				className
 			)}
 		>

--- a/src/components/ui/callout.tsx
+++ b/src/components/ui/callout.tsx
@@ -10,15 +10,16 @@ type CalloutProps = PropsWithChildren & {
 }
 
 const variants = {
-	default:
-		'bg-lc-1 bg-chroma-mlo bg-hue-primary border-lc-3 border-chroma-mlo border-hue-primary',
+	// Seed the component's character once (primary hue, low-key chroma); the
+	// interior — including the icon circle below — inherits it and speaks lc.
+	default: 'hue-primary chroma-mlo bg-lc-1 border-lc-3',
 	problem:
 		'hue-danger bg-lc-[97] bg-chroma-[3] border-lc-[88] border-chroma-[6]',
 	ghost: 'border text-muted-foreground bg-muted',
 }
 
 const iconCircleVariants = {
-	default: 'bg-lc-[95] bg-chroma-[6]',
+	default: 'bg-lc-[95]',
 	problem: 'border border-lc-[82] border-chroma-[9] bg-lc-none bg-chroma-lo',
 	ghost: 'bg-lc-1 bg-chroma-lo bg-hue-neutral',
 }

--- a/src/routes/_user/learn/-archived-deck-tile.tsx
+++ b/src/routes/_user/learn/-archived-deck-tile.tsx
@@ -97,7 +97,7 @@ export function ArchivedDeckTile({ deck }: { deck: DeckMetaType }) {
 							type="button"
 							onClick={restoreDeck}
 							data-testid="confirm-restore-button"
-							className="from-lc-5 from-chroma-mhi from-hue-primary to-lc-6 to-chroma-mid to-hue-primary text-primary-foreground hover:from-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 text-start shadow transition-transform hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-70"
+							className="hue-primary from-lc-5 from-chroma-mhi to-lc-6 to-chroma-mid text-primary-foreground hover:from-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 text-start shadow transition-transform hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-70"
 						>
 							<ArchiveRestore className="size-6" />
 							<div>
@@ -112,7 +112,7 @@ export function ArchivedDeckTile({ deck }: { deck: DeckMetaType }) {
 
 						<DialogClose
 							data-testid="cancel-restore-button"
-							className="border-lc-2 border-chroma-lo border-hue-neutral bg-lc-1 bg-chroma-mlo bg-hue-neutral text-lc-7 text-chroma-mid text-hue-neutral hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl border p-4 text-start shadow transition-transform hover:-translate-y-0.5"
+							className="hue-neutral border-lc-2 border-chroma-lo bg-lc-1 bg-chroma-mlo text-lc-7 text-chroma-mid hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl border p-4 text-start shadow transition-transform hover:-translate-y-0.5"
 						>
 							<Archive className="size-6" />
 							<div>

--- a/src/routes/_user/learn/-deck-tile.tsx
+++ b/src/routes/_user/learn/-deck-tile.tsx
@@ -104,7 +104,7 @@ export function DeckTile({ deck }: { deck: DeckMetaType }) {
 								to="/learn/$lang/review"
 								params={{ lang: deck.lang }}
 								data-testid="start-practice-link"
-								className="from-lc-5 from-chroma-mhi from-hue-primary to-lc-6 to-chroma-mid to-hue-primary text-primary-foreground hover:from-lc-up-1 flex h-full flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 shadow transition-transform hover:-translate-y-0.5"
+								className="hue-primary from-lc-5 from-chroma-mhi to-lc-6 to-chroma-mid text-primary-foreground hover:from-lc-up-1 flex h-full flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 shadow transition-transform hover:-translate-y-0.5"
 							>
 								{dueToday === 0 ? (
 									<CircleCheck className="size-6" />
@@ -129,7 +129,7 @@ export function DeckTile({ deck }: { deck: DeckMetaType }) {
 								to="/learn/$lang"
 								params={{ lang: deck.lang }}
 								data-testid="deck-link"
-								className="border-lc-2 border-chroma-lo border-hue-primary bg-lc-1 bg-chroma-mlo bg-hue-primary text-primary-foresoft hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full flex-col items-start gap-2 rounded-2xl border p-4 shadow transition-transform hover:-translate-y-0.5"
+								className="hue-primary border-lc-2 border-chroma-lo bg-lc-1 bg-chroma-mlo text-primary-foresoft hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full flex-col items-start gap-2 rounded-2xl border p-4 shadow transition-transform hover:-translate-y-0.5"
 							>
 								<Logs className="size-6" />
 								<div>


### PR DESCRIPTION
Follow-up to the OKLCH vendoring + pass-1 migration (#739). **Pass 2** — the cascade-pruning phase from the issue's step 7: seed `hue`/`chroma` once near a component's root and let the interior speak luminance.

Every change is **behavior-identical** — same emitted `oklch()` for every element; the point is readability. Verified visually on the preview and by matching emitted CSS; `pnpm check` / `lint` / `vite build` clean throughout.

### Components pruned (14, across 5 commits)
- **callout** (`default`): seed `hue-primary chroma-mlo`; `bg-lc-1 border-lc-3`; icon drops redundant chroma
- **deck-tile / archived-deck-tile**: hoist shared hue to `hue-primary`/`hue-neutral` (gradient wiring untouched — `from-lc-*`/`to-lc-*` still carry `--tw-gradient-*`)
- **intro-callout**: seed `hue-primary chroma-mlo`
- **login invalid-credentials**: hoist `hue-danger chroma-mhi` to the parent alert
- **blockquote**: seed `hue-primary chroma-mlo`
- **onboarding-nudge / active-review-callout**: seed `hue-primary` on the card; icons inherit it
- **notification-item** (×6 type variants): seed `hue-<type>`; the lucide icon inherits via currentColor
- **playlist-embed** external-link fallback: seed `hue-neutral`
- **friend-picker**: seed the shared hue on three self-contained text badges

### Deliberately left explicit
Generic containers with arbitrary children (choice-tile), shared-component `className` overrides (CopyLinkButton), single-property trios where a global seeder would bleed into a sibling `hover:bg-*`, and the themes showcase page (it demonstrates the axes on purpose). These follow the cascade convention opportunistically as files are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdrsNCcNMbQC4TbYHaeGsU