### PR TITLE
Migrate deck-insert to collection.insert + onInsert (#625)

### DIFF
--- a/src/components/card-pieces/card-status-dropdown.tsx
+++ b/src/components/card-pieces/card-status-dropdown.tsx
@@ -41,8 +41,8 @@ import {
 	updatePhraseLearnerCount,
 	type LearningStatus,
 } from '@/features/deck/card-status'
-import { postNewDeck } from '@/features/deck/mutations'
-import { DeckMetaSchema, type DeckMetaType } from '@/features/deck/schemas'
+import { optimisticNewDeck } from '@/features/deck/mutations'
+import { type DeckMetaType } from '@/features/deck/schemas'
 import {
 	PhraseFullFilteredType,
 	PhraseFullFullType,
@@ -417,11 +417,13 @@ function StartLearningDialog({
 	archivedDeck: DeckMetaType | null
 	onConfirmed: () => Promise<void>
 }) {
+	const userId = useUserId()
 	const [pending, setPending] = useState(false)
 	const language = languages[lang] ?? lang
 	const isUnarchive = !!archivedDeck
 
 	const handleConfirm = async () => {
+		if (!userId) return
 		setPending(true)
 		let deckReady = false
 		try {
@@ -431,10 +433,10 @@ function StartLearningDialog({
 				})
 				await tx.isPersisted.promise
 			} else {
-				const row = await postNewDeck(lang)
-				decksCollection.utils.writeInsert(
-					DeckMetaSchema.parse({ ...row, language })
-				)
+				// FK: user_card(uid, lang) → user_deck(uid, lang), so the deck must
+				// be persisted before onConfirmed() inserts the card.
+				const tx = decksCollection.insert(optimisticNewDeck(lang, userId))
+				await tx.isPersisted.promise
 			}
 			deckReady = true
 			await onConfirmed()

--- a/src/components/card-pieces/card-status-dropdown.tsx
+++ b/src/components/card-pieces/card-status-dropdown.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { failed } from '@scenetest/checks/react'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
 import {
 	ArchiveRestore,
@@ -427,14 +426,6 @@ function StartLearningDialog({
 		setPending(true)
 		let deckReady = false
 		try {
-			if (!userId) {
-				// The dropdown/heart render null when logged out, so reaching this
-				// dialog without a user is a broken invariant.
-				failed('StartLearningDialog confirmed without a logged-in user', {
-					lang,
-				})
-				throw new Error('Please log in to start a deck')
-			}
 			if (isUnarchive) {
 				const tx = decksCollection.update(lang, (draft) => {
 					draft.archived = false
@@ -443,7 +434,7 @@ function StartLearningDialog({
 			} else {
 				// FK: user_card(uid, lang) → user_deck(uid, lang), so the deck must
 				// be persisted before onConfirmed() inserts the card.
-				const tx = decksCollection.insert(optimisticNewDeck(lang, userId))
+				const tx = decksCollection.insert(optimisticNewDeck(lang, userId!))
 				await tx.isPersisted.promise
 			}
 			deckReady = true

--- a/src/components/card-pieces/card-status-dropdown.tsx
+++ b/src/components/card-pieces/card-status-dropdown.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { failed } from '@scenetest/checks/react'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
 import {
 	ArchiveRestore,
@@ -423,10 +424,17 @@ function StartLearningDialog({
 	const isUnarchive = !!archivedDeck
 
 	const handleConfirm = async () => {
-		if (!userId) return
 		setPending(true)
 		let deckReady = false
 		try {
+			if (!userId) {
+				// The dropdown/heart render null when logged out, so reaching this
+				// dialog without a user is a broken invariant.
+				failed('StartLearningDialog confirmed without a logged-in user', {
+					lang,
+				})
+				throw new Error('Please log in to start a deck')
+			}
 			if (isUnarchive) {
 				const tx = decksCollection.update(lang, (draft) => {
 					draft.archived = false

--- a/src/features/deck/collections.ts
+++ b/src/features/deck/collections.ts
@@ -37,6 +37,20 @@ export const decksCollection = createCollection(
 		queryClient,
 		startSync: false,
 		schema: DeckMetaSchema,
+		onInsert: async ({ transaction }) => {
+			// Insert only { lang }; uid, created_at and the rest take their
+			// base-table defaults, which optimisticNewDeck already mirrors — so the
+			// optimistic row is exact and { refetch: false } skips a reload.
+			await Promise.all(
+				transaction.mutations.map((m) =>
+					supabase
+						.from('user_deck')
+						.insert({ lang: m.modified.lang })
+						.throwOnError()
+				)
+			)
+			return { refetch: false }
+		},
 		onUpdate: async ({ transaction }) => {
 			await Promise.all(
 				transaction.mutations.map(async (m) => {

--- a/src/features/deck/collections.ts
+++ b/src/features/deck/collections.ts
@@ -38,17 +38,13 @@ export const decksCollection = createCollection(
 		startSync: false,
 		schema: DeckMetaSchema,
 		onInsert: async ({ transaction }) => {
-			// Insert only { lang }; uid, created_at and the rest take their
+			// One bulk insert of { lang } rows (uid, created_at and the rest take
 			// base-table defaults, which optimisticNewDeck already mirrors — so the
-			// optimistic row is exact and { refetch: false } skips a reload.
-			await Promise.all(
-				transaction.mutations.map((m) =>
-					supabase
-						.from('user_deck')
-						.insert({ lang: m.modified.lang })
-						.throwOnError()
-				)
-			)
+			// optimistic rows are exact and { refetch: false } skips a reload).
+			await supabase
+				.from('user_deck')
+				.insert(transaction.mutations.map((m) => ({ lang: m.modified.lang })))
+				.throwOnError()
 			return { refetch: false }
 		},
 		onUpdate: async ({ transaction }) => {

--- a/src/features/deck/collections.ts
+++ b/src/features/deck/collections.ts
@@ -38,9 +38,6 @@ export const decksCollection = createCollection(
 		startSync: false,
 		schema: DeckMetaSchema,
 		onInsert: async ({ transaction }) => {
-			// One bulk insert of { lang } rows (uid, created_at and the rest take
-			// base-table defaults, which optimisticNewDeck already mirrors — so the
-			// optimistic rows are exact and { refetch: false } skips a reload).
 			await supabase
 				.from('user_deck')
 				.insert(transaction.mutations.map((m) => ({ lang: m.modified.lang })))

--- a/src/features/deck/index.ts
+++ b/src/features/deck/index.ts
@@ -33,7 +33,7 @@ export {
 export { isDueCard } from './is-due-card'
 
 // Mutations
-export { useNewDeckMutation } from './mutations'
+export { useCreateDeck, optimisticNewDeck } from './mutations'
 
 // Utilities
 export { directionsForPhrase } from './card-directions'

--- a/src/features/deck/mutations.ts
+++ b/src/features/deck/mutations.ts
@@ -1,4 +1,5 @@
 import { useNavigate } from '@tanstack/react-router'
+import { failed } from '@scenetest/checks/react'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
 
 import { useUserId } from '@/lib/use-auth'
@@ -37,7 +38,12 @@ export function useCreateDeck() {
 	const userId = useUserId()
 
 	return (lang: string) => {
-		if (!userId) return
+		if (!userId) {
+			// Both entry points are auth-gated (add-deck is under RequireAuth), so
+			// this is a broken invariant, not a normal branch.
+			failed('createDeck called without a logged-in user', { lang })
+			throw new Error('Please log in to create a deck')
+		}
 		const tx = decksCollection.insert(optimisticNewDeck(lang, userId))
 		tx.isPersisted.promise.then(
 			() => toastSuccess(`Created a new deck to learn ${languages[lang]}`),

--- a/src/features/deck/mutations.ts
+++ b/src/features/deck/mutations.ts
@@ -1,66 +1,52 @@
-import type { Tables } from '@/types/supabase'
 import { useNavigate } from '@tanstack/react-router'
-import { useMutation } from '@tanstack/react-query'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
-import { should } from '@scenetest/checks/react'
 
-import supabase from '@/lib/supabase-client'
+import { useUserId } from '@/lib/use-auth'
 import languages from '@/lib/languages'
 import { decksCollection } from './collections'
-import { DeckMetaSchema } from './schemas'
+import { DeckMetaSchema, type DeckMetaType } from './schemas'
 
-export async function postNewDeck(lang: string) {
-	// console.log(`postNewDeck ${lang}`)
-	if (typeof lang !== 'string' || lang.length !== 3)
-		throw new Error('Form not right. Maybe refresh. Or tell the devs.')
-	const { data, error } = await supabase
-		.from('user_deck')
-		.insert({ lang })
-		.select()
-	// console.log(`postNewDeck`, data, error)
-	if (error) throw error
-	return data[0] as Tables<'user_deck'>
+/**
+ * The optimistic user_deck row for a brand-new deck. Every column has a fixed
+ * base-table default (learning_goal 'moving', archived false, daily_review_goal
+ * 15, preferred_translation_lang / review_answer_mode null), so the row is exact
+ * and decksCollection.onInsert can skip the reconciliation refetch.
+ */
+export function optimisticNewDeck(lang: string, uid: string): DeckMetaType {
+	return DeckMetaSchema.parse({
+		uid,
+		lang,
+		language: languages[lang] ?? lang,
+		learning_goal: 'moving',
+		archived: false,
+		daily_review_goal: 15,
+		preferred_translation_lang: null,
+		review_answer_mode: null,
+		created_at: new Date().toISOString(),
+	})
 }
 
-export const useNewDeckMutation = () => {
+/**
+ * Returns a `createDeck(lang)` that optimistically inserts the new deck and
+ * navigates to it immediately. Persistence lives on decksCollection.onInsert; on
+ * rollback the deck page's own "no deck" branch handles it and the error toast
+ * explains why.
+ */
+export function useCreateDeck() {
 	const navigate = useNavigate()
-	const mutation = useMutation({
-		mutationFn: async (variables: { lang: string }) => {
-			console.log(`mutationFn ${variables.lang}`)
+	const userId = useUserId()
 
-			return await postNewDeck(variables.lang)
-		},
-		mutationKey: ['new-deck'],
-		onSuccess: (deck, variables) => {
-			console.log(`onSuccess ${variables.lang}`)
-
-			const deck2 = {
-				...deck,
-				language: languages[deck.lang],
+	return (lang: string) => {
+		if (!userId) return
+		const tx = decksCollection.insert(optimisticNewDeck(lang, userId))
+		tx.isPersisted.promise.then(
+			() => toastSuccess(`Created a new deck to learn ${languages[lang]}`),
+			(err: unknown) => {
+				console.error('Error creating deck:', err)
+				const message = err instanceof Error ? err.message : 'unknown error'
+				toastError(`Error creating deck: ${message}`)
 			}
-
-			decksCollection.utils.writeInsert(DeckMetaSchema.parse(deck2))
-
-			// Confirm the server-created row carries the language we asked for.
-			// Stripped from production by the Vite plugin.
-			should(
-				'created user_deck row matches the requested language',
-				deck.lang === variables.lang,
-				{ requested: variables.lang, returned: deck }
-			)
-
-			void navigate({
-				to: `/learn/$lang`,
-				params: { lang: variables.lang },
-			}).then(() =>
-				toastSuccess(`Created a new deck to learn ${languages[variables.lang]}`)
-			)
-		},
-		onError: (error) => {
-			console.log(`Error creating deck:`, error)
-			toastError(`Error creating deck: ${error.message}`)
-		},
-	})
-
-	return mutation
+		)
+		void navigate({ to: `/learn/$lang`, params: { lang } })
+	}
 }

--- a/src/features/deck/mutations.ts
+++ b/src/features/deck/mutations.ts
@@ -1,5 +1,4 @@
 import { useNavigate } from '@tanstack/react-router'
-import { failed } from '@scenetest/checks/react'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
 
 import { useUserId } from '@/lib/use-auth'
@@ -38,13 +37,7 @@ export function useCreateDeck() {
 	const userId = useUserId()
 
 	return (lang: string) => {
-		if (!userId) {
-			// Both entry points are auth-gated (add-deck is under RequireAuth), so
-			// this is a broken invariant, not a normal branch.
-			failed('createDeck called without a logged-in user', { lang })
-			throw new Error('Please log in to create a deck')
-		}
-		const tx = decksCollection.insert(optimisticNewDeck(lang, userId))
+		const tx = decksCollection.insert(optimisticNewDeck(lang, userId!))
 		tx.isPersisted.promise.then(
 			() => toastSuccess(`Created a new deck to learn ${languages[lang]}`),
 			(err: unknown) => {

--- a/src/features/deck/mutations.ts
+++ b/src/features/deck/mutations.ts
@@ -6,12 +6,6 @@ import languages from '@/lib/languages'
 import { decksCollection } from './collections'
 import { DeckMetaSchema, type DeckMetaType } from './schemas'
 
-/**
- * The optimistic user_deck row for a brand-new deck. Every column has a fixed
- * base-table default (learning_goal 'moving', archived false, daily_review_goal
- * 15, preferred_translation_lang / review_answer_mode null), so the row is exact
- * and decksCollection.onInsert can skip the reconciliation refetch.
- */
 export function optimisticNewDeck(lang: string, uid: string): DeckMetaType {
 	return DeckMetaSchema.parse({
 		uid,
@@ -26,12 +20,6 @@ export function optimisticNewDeck(lang: string, uid: string): DeckMetaType {
 	})
 }
 
-/**
- * Returns a `createDeck(lang)` that optimistically inserts the new deck and
- * navigates to it immediately. Persistence lives on decksCollection.onInsert; on
- * rollback the deck page's own "no deck" branch handles it and the error toast
- * explains why.
- */
 export function useCreateDeck() {
 	const navigate = useNavigate()
 	const userId = useUserId()

--- a/src/routes/_user/learn/add-deck.tsx
+++ b/src/routes/_user/learn/add-deck.tsx
@@ -3,9 +3,8 @@ import * as z from 'zod'
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { LangBadge } from '@/components/ui/badge'
-import { ShowAndLogError } from '@/components/errors'
 import { LanguagePicker } from '@/components/fields/language-picker'
-import { useNewDeckMutation } from '@/features/deck/mutations'
+import { useCreateDeck } from '@/features/deck/mutations'
 import languages from '@/lib/languages'
 import { Loader } from '@/components/ui/loader'
 import { useDecks } from '@/features/deck/hooks'
@@ -35,7 +34,7 @@ function NewDeckForm() {
 }
 
 function NewDeckFormInner() {
-	const createNewDeck = useNewDeckMutation()
+	const createDeck = useCreateDeck()
 	const { data: decks, isLoading: decksLoading } = useDecks()
 	const deckLangs = useDeckLangs()
 	const search = Route.useSearch()
@@ -94,12 +93,8 @@ function NewDeckFormInner() {
 						discover
 						placeholder="Choose a language to learn…"
 						title={TITLE}
-						onConfirm={(lang) => createNewDeck.mutate({ lang })}
+						onConfirm={(lang) => createDeck(lang)}
 						confirmLabel={(lang) => `Start learning ${languages[lang]}`}
-					/>
-					<ShowAndLogError
-						text="Problem creating new deck"
-						error={createNewDeck.error}
 					/>
 				</CardContent>
 			</Card>


### PR DESCRIPTION
## Summary

The last deck mutation still on the deprecated `useMutation` + `collection.utils.writeInsert` pattern (#625). A fresh deck's every column is a known base-table default, so we can build an exact optimistic row and let the collection own persistence — no server round-trip before the UI advances.

No DB migration — pure app code, so this is a fast-track PR into `main`.

## Changes

- **`decksCollection.onInsert`** — inserts `{ lang }` (uid, created_at, and the rest take base-table defaults) and returns `{ refetch: false }`, since the optimistic row already matches.
- **`optimisticNewDeck(lang, uid)`** — builds the exact `DeckMetaType`: `learning_goal: 'moving'`, `archived: false`, `daily_review_goal: 15`, `preferred_translation_lang`/`review_answer_mode: null`, `language` computed client-side.
- **`useCreateDeck()`** replaces `useNewDeckMutation` — optimistic insert + immediate navigation to the new deck; toast on persist; rollback handled by the destination page's own "no deck" branch. Drops the now-dead `ShowAndLogError` (errors toast now).
- **`StartLearningDialog`** uses `decksCollection.insert(optimisticNewDeck(...))` too, still `await`ing `isPersisted` before adding the card (`user_card` FKs `user_deck`).
- Deletes `postNewDeck` and the `useMutation`/`writeInsert` deck path.

## History

This work was originally done on this branch pre-#737 but never got a PR opened; it then went stale when #737 slimmed `DeckMetaSchema` (the old `optimisticNewDeck` referenced `lang_total_phrases` and other now-removed columns). Re-applied fresh on current `main`, so the optimistic row carries only the base `user_deck` columns.

## Verification

- `pnpm check`, `pnpm lint`, `pnpm test:unit` (266 passing) all green.
- Not run here (no Docker): scenetest. The create-deck scene (`decks.spec.md`) navigates to `/learn/$lang` (the `beforeLoad` only validates the lang code, not deck existence) and the success toast fires on persist, so it should stay green — worth a scene run to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154TxrtG55ohyPmqs474h8e

---
_Generated by [Claude Code](https://claude.ai/code/session_0154TxrtG55ohyPmqs474h8e)_