### PR TITLE
Aggressive OKLCH colorspace prune (experiment — review & pull back)

### DIFF
--- a/src/components/browse-search-overlay.tsx
+++ b/src/components/browse-search-overlay.tsx
@@ -208,7 +208,7 @@ export default function BrowseSearchOverlay({
 									'rounded-full border px-2.5 py-1 text-xs font-medium transition-colors',
 									selectedLangs.includes(l.code)
 										? 'bg-primary-foresoft text-primary-foreground border-transparent'
-										: 'border-border text-muted-foreground hover:border-lc-4 hover:border-chroma-mlo hover:border-hue-primary hover:text-foreground'
+										: 'border-border text-muted-foreground hover:border-lc-4 hover:border-chroma-mlo hover:text-foreground'
 								)}
 							>
 								{l.name}
@@ -223,7 +223,7 @@ export default function BrowseSearchOverlay({
 								// oxlint-disable-next-line jsx-no-jsx-as-prop
 								<button
 									type="button"
-									className="border-border text-muted-foreground hover:border-lc-4 hover:border-chroma-mlo hover:border-hue-primary hover:text-foreground flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors"
+									className="border-border text-muted-foreground hover:border-lc-4 hover:border-chroma-mlo hover:text-foreground flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors"
 								>
 									<Plus className="size-3" />
 									more

--- a/src/components/card-pieces/card-status-dropdown.tsx
+++ b/src/components/card-pieces/card-status-dropdown.tsx
@@ -136,10 +136,10 @@ function StatusSpan({ choice }: { choice: ShowableActions }) {
 // one shape, one size, just hue swapping with the state.
 const triggerDotClass: Record<ShowableActions, string> = {
 	active: 'bg-primary',
-	learned: 'bg-lc-5 bg-chroma-hi bg-hue-success',
-	skipped: 'bg-lc-4 bg-chroma-lo bg-hue-neutral',
-	nocard: 'bg-lc-3 bg-chroma-lo bg-hue-neutral',
-	nodeck: 'bg-lc-3 bg-chroma-lo bg-hue-neutral',
+	learned: 'hue-success bg-lc-5 bg-chroma-hi',
+	skipped: 'hue-neutral bg-lc-4',
+	nocard: 'hue-neutral bg-lc-3',
+	nodeck: 'hue-neutral bg-lc-3',
 }
 
 function useCardStatusMutator(
@@ -283,9 +283,7 @@ export function CardStatusDropdown({
 							<DropdownMenuItem
 								onClick={() => pickStatus('active')}
 								className={
-									card.status === 'active'
-										? 'bg-lc-0 bg-chroma-mid bg-hue-primary'
-										: ''
+									card.status === 'active' ? 'bg-lc-0 bg-chroma-mid' : ''
 								}
 								data-testid="activate-card-option"
 							>
@@ -294,9 +292,7 @@ export function CardStatusDropdown({
 							<DropdownMenuItem
 								onClick={() => pickStatus('learned')}
 								className={
-									card.status === 'learned'
-										? 'bg-lc-0 bg-chroma-mid bg-hue-primary'
-										: ''
+									card.status === 'learned' ? 'bg-lc-0 bg-chroma-mid' : ''
 								}
 								data-testid="set-learned-option"
 							>
@@ -305,9 +301,7 @@ export function CardStatusDropdown({
 							<DropdownMenuItem
 								onClick={() => pickStatus('skipped')}
 								className={
-									card.status === 'skipped'
-										? 'bg-lc-0 bg-chroma-mid bg-hue-primary'
-										: ''
+									card.status === 'skipped' ? 'bg-lc-0 bg-chroma-mid' : ''
 								}
 								data-testid="ignore-card-option"
 							>
@@ -485,7 +479,7 @@ function StartLearningDialog({
 						onClick={() => void handleConfirm()}
 						disabled={pending}
 						data-testid="confirm-start-learning-button"
-						className="from-lc-5 from-chroma-mhi from-hue-primary to-lc-6 to-chroma-mid to-hue-primary text-primary-foreground hover:from-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 text-start shadow transition-transform hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-70"
+						className="from-lc-5 from-chroma-mhi to-lc-6 text-primary-foreground hover:from-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 text-start shadow transition-transform hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-70"
 					>
 						{isUnarchive ? (
 							<ArchiveRestore className="size-6" />
@@ -512,7 +506,7 @@ function StartLearningDialog({
 
 					<DialogClose
 						data-testid="cancel-start-learning-button"
-						className="border-lc-2 border-chroma-lo border-hue-neutral bg-lc-1 bg-chroma-mlo bg-hue-neutral text-lc-7 text-chroma-mid text-hue-neutral hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl border p-4 text-start shadow transition-transform hover:-translate-y-0.5"
+						className="hue-neutral border-lc-2 bg-lc-1 bg-chroma-mlo text-lc-7 text-chroma-mid hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl border p-4 text-start shadow transition-transform hover:-translate-y-0.5"
 					>
 						<Bookmark className="size-6" />
 						<div>

--- a/src/components/cards/tap-to-select.tsx
+++ b/src/components/cards/tap-to-select.tsx
@@ -29,7 +29,7 @@ export function TapCardToSelect({
 		<CardlikeFlashcard
 			onClick={() => toggleCardSelection(pid)}
 			key={pid}
-			className={`hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary cursor-pointer transition-all ${isSelected ? 'border-primary bg-lc-0 bg-chroma-lo bg-hue-primary' : ''}`}
+			className={`hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary cursor-pointer transition-all ${isSelected ? 'border-primary bg-lc-0' : ''}`}
 			style={{ viewTransitionName: `phrase-${pid}` } as CSSProperties}
 		>
 			<CardHeader className="p-3 pb-0">

--- a/src/components/comments/comment-dialog.tsx
+++ b/src/components/comments/comment-dialog.tsx
@@ -370,7 +370,7 @@ function AttachedPhraseCards({
 							...prev,
 							attaching: true,
 						})}
-						className="border-lc-2 border-chroma-lo border-hue-primary text-muted-foreground hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-primary hover:text-lc-7 hover:text-chroma-mid hover:text-hue-primary hover:border-lc-4 hover:border-chroma-mlo hover:border-hue-primary flex h-30 min-w-50 basis-50 cursor-pointer items-center justify-center rounded-xl border-2 border-dashed transition-colors"
+						className="border-lc-2 text-muted-foreground hover:bg-lc-1 hover:text-lc-7 hover:text-chroma-mid hover:border-lc-4 hover:border-chroma-mlo flex h-30 min-w-50 basis-50 cursor-pointer items-center justify-center rounded-xl border-2 border-dashed transition-colors"
 					>
 						<Plus className="h-6 w-6" />
 					</Link>

--- a/src/components/comments/comment-with-replies.tsx
+++ b/src/components/comments/comment-with-replies.tsx
@@ -62,7 +62,7 @@ export function CommentWithReplies({ comment, lang }: CommentThreadProps) {
 				isFocused
 					? 'border-primary bg-card/50 rounded border border-s-2'
 					: hasHighlightedReply
-						? 'border-lc-3 border-chroma-mlo border-hue-primary bg-card/50 rounded border border-s-2'
+						? 'border-lc-3 border-chroma-mlo bg-card/50 rounded border border-s-2'
 						: ''
 			} p-4`}
 			data-comment-id={comment.id}

--- a/src/components/comments/select-phrases-for-comment.tsx
+++ b/src/components/comments/select-phrases-for-comment.tsx
@@ -91,7 +91,7 @@ export function SelectPhrasesForComment({
 			type="button"
 			disabled={isMaxReached}
 			data-testid="open-phrase-picker"
-			className="border-lc-2 border-chroma-lo border-hue-primary text-muted-foreground hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-primary hover:text-lc-7 hover:text-chroma-mid hover:text-hue-primary hover:border-lc-4 hover:border-chroma-mlo hover:border-hue-primary flex h-30 min-w-50 basis-50 cursor-pointer items-center justify-center rounded-xl border-2 border-dashed transition-colors disabled:pointer-events-none disabled:opacity-50"
+			className="border-lc-2 text-muted-foreground hover:bg-lc-1 hover:text-lc-7 hover:text-chroma-mid hover:border-lc-4 hover:border-chroma-mlo flex h-30 min-w-50 basis-50 cursor-pointer items-center justify-center rounded-xl border-2 border-dashed transition-colors disabled:pointer-events-none disabled:opacity-50"
 		>
 			<Plus className="h-6 w-6" />
 		</button>

--- a/src/components/dev-identity-switcher.tsx
+++ b/src/components/dev-identity-switcher.tsx
@@ -162,9 +162,9 @@ function Switcher() {
 										disabled={busy || active}
 										onClick={() => void switchTo(a.email)}
 										className={cn(
-											'hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary flex w-full items-baseline justify-between gap-2 rounded border-s-2 border-transparent px-2 py-1 text-start text-sm disabled:opacity-100',
+											'hover:bg-lc-1 hover:bg-chroma-mlo flex w-full items-baseline justify-between gap-2 rounded border-s-2 border-transparent px-2 py-1 text-start text-sm disabled:opacity-100',
 											active &&
-												'bg-lc-2 bg-chroma-mlo bg-hue-primary border-s-primary-foresoft font-medium'
+												'bg-lc-2 bg-chroma-mlo border-s-primary-foresoft font-medium'
 										)}
 									>
 										<span className="truncate">

--- a/src/components/feed/feed-composer.tsx
+++ b/src/components/feed/feed-composer.tsx
@@ -23,7 +23,7 @@ export function FeedComposer({ lang }: { lang: string }) {
 					<button
 						type="button"
 						data-testid="feed-composer-trigger"
-						className="border-lc-3 border-chroma-mlo border-hue-primary hover:border-primary bg-card text-muted-foreground mb-3 flex h-10 w-full rounded-2xl border px-3 py-2 text-start text-sm inset-shadow-sm transition-colors"
+						className="border-lc-3 border-chroma-mlo hover:border-primary bg-card text-muted-foreground mb-3 flex h-10 w-full rounded-2xl border px-3 py-2 text-start text-sm inset-shadow-sm transition-colors"
 					>
 						Ask the community for a phrase...
 					</button>

--- a/src/components/fields/cover-image-field.tsx
+++ b/src/components/fields/cover-image-field.tsx
@@ -30,7 +30,7 @@ export function CoverImageField({ label = 'Cover Image' }: { label?: string }) {
 				<Label
 					htmlFor="coverImageUploadInput"
 					className={cn(
-						'group border-lc-3 border-chroma-mlo border-hue-primary hover:border-primary hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary relative isolate flex h-32 flex-col items-center justify-center rounded-2xl border text-center',
+						'group border-lc-3 border-chroma-mlo hover:border-primary hover:bg-lc-1 hover:bg-chroma-mlo relative isolate flex h-32 flex-col items-center justify-center rounded-2xl border text-center',
 						url && 'h-auto'
 					)}
 				>

--- a/src/components/fields/language-picker.tsx
+++ b/src/components/fields/language-picker.tsx
@@ -133,7 +133,7 @@ function LangRow({
 		<button
 			type="button"
 			data-key={code}
-			className="hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-primary focus-visible:bg-lc-1 focus-visible:bg-chroma-lo focus-visible:bg-hue-primary text-foreground flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2 text-left transition-colors outline-none"
+			className="hover:bg-lc-1 focus-visible:bg-lc-1 text-foreground flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2 text-left transition-colors outline-none"
 			onClick={() => onPick(code)}
 		>
 			<span className="min-w-0 flex-1 truncate text-sm font-semibold">
@@ -397,9 +397,7 @@ export function LanguagePickerTrigger({
 				'flex w-full items-center gap-2.5 rounded-2xl border bg-card/50 px-3.5 py-2.5 text-left text-sm font-sans inset-shadow-sm',
 				'ring-offset-background cursor-pointer hover:border-primary',
 				'focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden',
-				hasError
-					? 'border-destructive'
-					: 'border-lc-3 border-chroma-mlo border-hue-primary',
+				hasError ? 'border-destructive' : 'border-lc-3 border-chroma-mlo',
 				!value && 'text-muted-foreground',
 				className
 			)}

--- a/src/components/friend-search-overlay.tsx
+++ b/src/components/friend-search-overlay.tsx
@@ -114,5 +114,5 @@ export default function FriendSearchOverlay({
 }
 
 const BigGarlic = () => (
-	<Garlic className="bg-lc-2 bg-chroma-mlo bg-hue-primary w-20 rounded-full p-3 @xl:p-4" />
+	<Garlic className="bg-lc-2 bg-chroma-mlo w-20 rounded-full p-3 @xl:p-4" />
 )

--- a/src/components/intro-callout.tsx
+++ b/src/components/intro-callout.tsx
@@ -24,7 +24,7 @@ export function IntroCallout({
 	return (
 		<div
 			className={cn(
-				'hue-primary chroma-mlo bg-lc-1 border-lc-3 flex items-start gap-2 rounded border px-3 py-2 text-sm',
+				'chroma-mlo bg-lc-1 border-lc-3 flex items-start gap-2 rounded border px-3 py-2 text-sm',
 				className
 			)}
 		>

--- a/src/components/intros/community-norms-intro.tsx
+++ b/src/components/intros/community-norms-intro.tsx
@@ -82,7 +82,7 @@ function NormItem({
 }) {
 	return (
 		<div className="flex gap-3">
-			<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary text-primary flex size-10 shrink-0 items-center justify-center rounded-full">
+			<div className="bg-lc-1 bg-chroma-mlo text-primary flex size-10 shrink-0 items-center justify-center rounded-full">
 				<Icon className="size-5" />
 			</div>
 			<div>

--- a/src/components/intros/review-intro.tsx
+++ b/src/components/intros/review-intro.tsx
@@ -66,7 +66,7 @@ export function ReviewIntro({ open, onClose }: ReviewIntroProps) {
 					</ol>
 				</div>
 
-				<div className="bg-lc-0 bg-chroma-lo bg-hue-primary rounded-lg border p-3 text-sm">
+				<div className="bg-lc-0 rounded-lg border p-3 text-sm">
 					<p className="font-medium">Tip: Consistency beats intensity</p>
 					<p className="text-muted-foreground mt-1">
 						10 minutes every day is better than an hour once a week. Try to

--- a/src/components/navs/active-review-callout.tsx
+++ b/src/components/navs/active-review-callout.tsx
@@ -44,7 +44,7 @@ function ReviewRemainingLink({
 			<span className="text-xs font-medium group-hover:underline">
 				{languages[lang]}
 			</span>
-			<span className="text-lc-5 text-chroma-mlo text-hue-primary group-hover:text-lc-up-1 text-xs font-bold">
+			<span className="text-lc-5 text-chroma-mlo group-hover:text-lc-up-1 text-xs font-bold">
 				{remaining} left
 			</span>
 		</Link>
@@ -113,7 +113,7 @@ export function ActiveReviewCallout({
 }
 
 const calloutCard =
-	'hue-primary border-lc-[87] border-chroma-[6] bg-lc-[93] bg-chroma-[4] mx-2 mb-2 rounded-xl border p-3'
+	'border-lc-[87] border-chroma-[6] bg-lc-[93] bg-chroma-[4] mx-2 mb-2 rounded-xl border p-3'
 const iconCircle = 'rounded-lg bg-white p-1.5'
 
 function CalloutContent({
@@ -136,7 +136,7 @@ function CalloutContent({
 				to="/learn/$lang/review"
 				params={{ lang: activeReviews[0].lang }}
 				onClick={setClosedMobile}
-				className="text-lc-5 text-chroma-mid text-hue-primary hover:bg-lc-up-1 mx-auto flex h-8 w-8 items-center justify-center rounded-lg bg-white transition-colors"
+				className="text-lc-5 text-chroma-mid hover:bg-lc-up-1 mx-auto flex h-8 w-8 items-center justify-center rounded-lg bg-white transition-colors"
 				aria-label="Active review in progress"
 			>
 				<Rocket className="h-4 w-4" />

--- a/src/components/navs/app-nav.tsx
+++ b/src/components/navs/app-nav.tsx
@@ -29,7 +29,7 @@ const activeOptions = { exact: true, includeSearch: false } as const
 const inexactOptions = { exact: false, includeSearch: false } as const
 const inactiveProps = {
 	className:
-		'border-transparent text-muted-foreground hover:text-lc-7 hover:text-chroma-mhi hover:text-hue-primary',
+		'border-transparent text-muted-foreground hover:text-lc-7 hover:text-chroma-mhi',
 } as const
 
 export function AppNav() {
@@ -63,7 +63,7 @@ export function AppNav() {
 						<NavigationMenuList className="flex w-full flex-row justify-start ps-2">
 							{links.map((l: LinkType) => (
 								<NavigationMenuItem
-									className="hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary rounded-xl px-3"
+									className="hover:bg-lc-1 hover:bg-chroma-mlo rounded-xl px-3"
 									key={l.link.to}
 								>
 									<NavigationMenuLink asChild>

--- a/src/components/navs/mode-toggle.tsx
+++ b/src/components/navs/mode-toggle.tsx
@@ -48,9 +48,7 @@ export function ModeToggle() {
 						sideOffset={4}
 					>
 						<DropdownMenuItem
-							className={
-								theme === 'light' ? 'bg-lc-1 bg-chroma-mlo bg-hue-primary' : ''
-							}
+							className={theme === 'light' ? 'bg-lc-1 bg-chroma-mlo' : ''}
 							onClick={setLight}
 						>
 							{theme === 'light' ? (
@@ -61,9 +59,7 @@ export function ModeToggle() {
 							Light
 						</DropdownMenuItem>
 						<DropdownMenuItem
-							className={
-								theme === 'dark' ? 'bg-lc-1 bg-chroma-mlo bg-hue-primary' : ''
-							}
+							className={theme === 'dark' ? 'bg-lc-1 bg-chroma-mlo' : ''}
 							onClick={setDark}
 						>
 							{theme === 'dark' ? (
@@ -74,9 +70,7 @@ export function ModeToggle() {
 							Dark
 						</DropdownMenuItem>
 						<DropdownMenuItem
-							className={
-								theme === 'system' ? 'bg-lc-1 bg-chroma-mlo bg-hue-primary' : ''
-							}
+							className={theme === 'system' ? 'bg-lc-1 bg-chroma-mlo' : ''}
 							onClick={setSystem}
 						>
 							{theme === 'system' ? (

--- a/src/components/navs/nav-footer-actions.tsx
+++ b/src/components/navs/nav-footer-actions.tsx
@@ -13,7 +13,7 @@ export function NavFooterActions() {
 				href="https://github.com/mhsnook/sunlo"
 				target="_blank"
 				rel="noreferrer"
-				className="text-chroma-lo text-lc-5 hover:text-lc-7 flex items-center gap-2 text-xs"
+				className="text-lc-5 hover:text-lc-7 flex items-center gap-2 text-xs"
 				data-testid="sidebar-open-source-link"
 			>
 				<Github className="size-4" />

--- a/src/components/navs/onboarding-nudge.tsx
+++ b/src/components/navs/onboarding-nudge.tsx
@@ -31,7 +31,7 @@ export function OnboardingNudge() {
 				to="/getting-started"
 				onClick={setClosedMobile}
 				data-testid="onboarding-nudge"
-				className="text-lc-5 text-chroma-mid text-hue-primary hover:bg-lc-up-1 mx-auto flex h-8 w-8 items-center justify-center rounded-lg bg-white transition-colors"
+				className="text-lc-5 text-chroma-mid hover:bg-lc-up-1 mx-auto flex h-8 w-8 items-center justify-center rounded-lg bg-white transition-colors"
 				aria-label="Continue setting up your account"
 			>
 				<Sparkles className="h-4 w-4" />
@@ -42,7 +42,7 @@ export function OnboardingNudge() {
 	return (
 		<div
 			data-testid="onboarding-nudge"
-			className="hue-primary border-lc-[87] border-chroma-[6] bg-lc-[93] bg-chroma-[4] mx-2 mb-2 rounded-xl border p-3"
+			className="border-lc-[87] border-chroma-[6] bg-lc-[93] bg-chroma-[4] mx-2 mb-2 rounded-xl border p-3"
 		>
 			<div className="flex items-start gap-2">
 				<div className="rounded-lg bg-white p-1.5">

--- a/src/components/notifications/notification-item.tsx
+++ b/src/components/notifications/notification-item.tsx
@@ -28,32 +28,32 @@ const notificationConfig: Record<
 	request_commented: {
 		Icon: MessageSquareQuote,
 		action: 'commented on your request',
-		iconClass: 'hue-primary text-lc-7 text-chroma-mid bg-lc-1 bg-chroma-lo',
+		iconClass: 'text-lc-7 text-chroma-mid bg-lc-1',
 	},
 	comment_replied: {
 		Icon: MessagesSquare,
 		action: 'replied to your comment',
-		iconClass: 'hue-info text-lc-7 text-chroma-mid bg-lc-1 bg-chroma-lo',
+		iconClass: 'hue-info text-lc-7 text-chroma-mid bg-lc-1',
 	},
 	phrase_translated: {
 		Icon: Languages,
 		action: 'added a translation to your phrase',
-		iconClass: 'hue-success text-lc-7 text-chroma-mid bg-lc-1 bg-chroma-lo',
+		iconClass: 'hue-success text-lc-7 text-chroma-mid bg-lc-1',
 	},
 	phrase_referenced: {
 		Icon: Link2,
 		action: 'referenced your phrase as an answer',
-		iconClass: 'hue-accent text-lc-7 text-chroma-mid bg-lc-1 bg-chroma-lo',
+		iconClass: 'hue-accent text-lc-7 text-chroma-mid bg-lc-1',
 	},
 	request_upvoted: {
 		Icon: ThumbsUp,
 		action: 'upvoted your request',
-		iconClass: 'hue-warning text-lc-7 text-chroma-mid bg-lc-1 bg-chroma-lo',
+		iconClass: 'hue-warning text-lc-7 text-chroma-mid bg-lc-1',
 	},
 	change_suggested: {
 		Icon: MessageSquareQuote,
 		action: 'suggested a change to your content',
-		iconClass: 'hue-neutral text-lc-7 text-chroma-mid bg-lc-1 bg-chroma-lo',
+		iconClass: 'hue-neutral text-lc-7 text-chroma-mid bg-lc-1',
 	},
 }
 

--- a/src/components/notifications/notification-list.tsx
+++ b/src/components/notifications/notification-list.tsx
@@ -87,7 +87,7 @@ function EmptyState() {
 			data-testid="notifications-empty-state"
 		>
 			<CardContent className="flex flex-col items-center gap-3 py-12 text-center">
-				<div className="bg-lc-1 bg-chroma-lo bg-hue-neutral flex h-16 w-16 items-center justify-center rounded-full">
+				<div className="hue-neutral bg-lc-1 flex h-16 w-16 items-center justify-center rounded-full">
 					<BellOff className="text-muted-foreground h-8 w-8" />
 				</div>
 				<h3 className="text-lg font-semibold">No notifications yet</h3>

--- a/src/components/practice-history-dialog.tsx
+++ b/src/components/practice-history-dialog.tsx
@@ -110,7 +110,7 @@ function RetrievabilityBar({ value }: { value: number }) {
 				</div>
 				<span className="text-3xl font-bold tabular-nums">{pct}%</span>
 			</div>
-			<div className="bg-lc-1 bg-chroma-lo bg-hue-neutral h-2 w-full overflow-hidden rounded-full">
+			<div className="hue-neutral bg-lc-1 h-2 w-full overflow-hidden rounded-full">
 				<div
 					className={cn('h-full rounded-full transition-all', color)}
 					style={{ width: `${pct}%` }}
@@ -286,7 +286,7 @@ function StatTile({
 	return (
 		<div
 			className={cn(
-				'bg-lc-1 bg-chroma-lo bg-hue-neutral flex flex-col gap-0.5 rounded p-3',
+				'hue-neutral bg-lc-1 flex flex-col gap-0.5 rounded p-3',
 				className
 			)}
 		>

--- a/src/components/requests/request-header.tsx
+++ b/src/components/requests/request-header.tsx
@@ -17,7 +17,7 @@ export function RequestHeader({ request }: { request: PhraseRequestType }) {
 	const isOwner = profile?.uid === request.requester_uid
 
 	return (
-		<CardHeader className="border-lc-2 border-chroma-lo border-hue-primary py-3 @md:py-6">
+		<CardHeader className="border-lc-2 py-3 @md:py-6">
 			<div className="flex flex-row items-center justify-between gap-2">
 				<UidPermalink
 					uid={request.requester_uid}

--- a/src/components/share/friend-picker.tsx
+++ b/src/components/share/friend-picker.tsx
@@ -83,9 +83,8 @@ function FriendRow({
 			data-key={friend.uid}
 			onClick={() => onToggle(friend.uid)}
 			className={cn(
-				'group hover:bg-lc-0 hover:bg-chroma-mlo hover:bg-hue-primary flex w-full items-center gap-3 rounded-2xl px-2.5 py-2 text-start outline -outline-offset-1 outline-transparent transition-colors',
-				selected &&
-					'bg-lc-1 bg-chroma-mlo bg-hue-primary outline-primary-foresoft/40'
+				'group hover:bg-lc-0 hover:bg-chroma-mlo flex w-full items-center gap-3 rounded-2xl px-2.5 py-2 text-start outline -outline-offset-1 outline-transparent transition-colors',
+				selected && 'bg-lc-1 bg-chroma-mlo outline-primary-foresoft/40'
 			)}
 		>
 			<UserAvatar profile={profile} className="size-10" />
@@ -96,7 +95,7 @@ function FriendRow({
 			</span>
 			<span className="flex shrink-0 flex-col items-end gap-1">
 				{friend.status === 'pending' ? (
-					<span className="hue-primary bg-lc-2 bg-chroma-mid text-lc-7 text-chroma-hi inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold tracking-wide uppercase">
+					<span className="bg-lc-2 bg-chroma-mid text-lc-7 text-chroma-hi inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold tracking-wide uppercase">
 						<UserPlus className="size-2.5" /> Pending
 					</span>
 				) : timestamp ? (
@@ -133,8 +132,8 @@ export function SharePreviewChip({
 	subtitle?: ReactNode
 }) {
 	return (
-		<div className="bg-lc-0 bg-chroma-mlo bg-hue-primary border-lc-2 border-chroma-mlo border-hue-primary border-l-primary mx-3.5 flex items-center gap-2.5 rounded-lg border border-l-4 px-3 py-2.5">
-			<span className="text-lc-6 text-chroma-hi text-hue-accent flex shrink-0">
+		<div className="bg-lc-0 bg-chroma-mlo border-lc-2 border-chroma-mlo border-l-primary mx-3.5 flex items-center gap-2.5 rounded-lg border border-l-4 px-3 py-2.5">
+			<span className="hue-accent text-lc-6 text-chroma-hi flex shrink-0">
 				{icon}
 			</span>
 			<span className="min-w-0 flex-1">
@@ -225,7 +224,7 @@ function PickerBody({
 			<div className="flex flex-col">
 				{preview ? <div className="pt-1">{preview}</div> : null}
 				<div className="text-muted-foreground px-6 py-9 text-center">
-					<span className="hue-primary bg-lc-2 bg-chroma-mlo text-lc-6 text-chroma-hi mb-3.5 inline-flex size-14 items-center justify-center rounded-full">
+					<span className="bg-lc-2 bg-chroma-mlo text-lc-6 text-chroma-hi mb-3.5 inline-flex size-14 items-center justify-center rounded-full">
 						<Users className="size-7" />
 					</span>
 					<h3 className="text-foreground mb-1.5 text-base font-bold">
@@ -251,7 +250,7 @@ function PickerBody({
 
 			{/* Sticky search */}
 			<div className="bg-popover sticky top-0 z-5 border-b px-3.5 pt-3 pb-2.5">
-				<div className="bg-lc-0 bg-chroma-lo bg-hue-neutral focus-within:bg-card focus-within:border-ring focus-within:ring-ring/25 flex items-center gap-2.5 rounded-2xl border px-3 py-2 transition focus-within:ring-2">
+				<div className="hue-neutral bg-lc-0 focus-within:bg-card focus-within:border-ring focus-within:ring-ring/25 flex items-center gap-2.5 rounded-2xl border px-3 py-2 transition focus-within:ring-2">
 					<Search className="text-muted-foreground size-4 shrink-0" />
 					<input
 						ref={searchRef}
@@ -429,7 +428,7 @@ export function FriendPickerDialog({
 					{showPicker ? (
 						<>
 							{isMobile ? (
-								<div className="bg-lc-3 bg-chroma-mlo bg-hue-neutral mx-auto mt-2 h-1 w-9 rounded-full" />
+								<div className="hue-neutral bg-lc-3 bg-chroma-mlo mx-auto mt-2 h-1 w-9 rounded-full" />
 							) : null}
 							<div className="flex items-center gap-3 px-4.5 pt-3.5 pb-2">
 								<DialogPrimitive.Title className="text-base font-bold tracking-tight">
@@ -443,7 +442,7 @@ export function FriendPickerDialog({
 								<DialogPrimitive.Close
 									aria-label="Close"
 									data-testid="close-friend-picker"
-									className="bg-lc-2 bg-chroma-lo bg-hue-neutral hover:bg-lc-3 hover:bg-chroma-lo hover:bg-hue-neutral text-foreground ms-auto flex size-8 items-center justify-center rounded-md transition-colors"
+									className="hue-neutral hover:hue-neutral bg-lc-2 hover:bg-lc-3 text-foreground ms-auto flex size-8 items-center justify-center rounded-md transition-colors"
 								>
 									<X className="size-4" />
 								</DialogPrimitive.Close>

--- a/src/components/spreadsheet-import-dialog.tsx
+++ b/src/components/spreadsheet-import-dialog.tsx
@@ -154,33 +154,33 @@ export function SpreadsheetImportDialog({
 								</p>
 								<div className="space-y-2 ps-1">
 									<p>
-										<strong className="text-lc-7 text-chroma-mhi text-hue-primary">
+										<strong className="text-lc-7 text-chroma-mhi">
 											Phrase
 										</strong>{' '}
 										&mdash; the word or sentence in your learning language.
 										Include the word &ldquo;phrase&rdquo; in the header (e.g.{' '}
-										<code className="bg-lc-1 bg-chroma-mlo bg-hue-primary rounded px-1.5 py-0.5 text-sm">
+										<code className="bg-lc-1 bg-chroma-mlo rounded px-1.5 py-0.5 text-sm">
 											phrase
 										</code>
 										).
 									</p>
 									<p>
-										<strong className="text-lc-7 text-chroma-mhi text-hue-accent">
+										<strong className="hue-accent text-lc-7 text-chroma-mhi">
 											Translation
 										</strong>{' '}
 										&mdash; put the language name or 3-letter code in the header
 										(e.g.{' '}
-										<code className="bg-lc-1 bg-chroma-mlo bg-hue-accent rounded px-1.5 py-0.5 text-sm">
+										<code className="hue-accent bg-lc-1 bg-chroma-mlo rounded px-1.5 py-0.5 text-sm">
 											translation (eng)
 										</code>{' '}
 										or{' '}
-										<code className="bg-lc-1 bg-chroma-mlo bg-hue-accent rounded px-1.5 py-0.5 text-sm">
+										<code className="hue-accent bg-lc-1 bg-chroma-mlo rounded px-1.5 py-0.5 text-sm">
 											English
 										</code>
 										). You can have multiple translation columns.
 									</p>
 									<p>
-										<strong className="text-lc-7 text-chroma-mhi text-hue-info">
+										<strong className="hue-info text-lc-7 text-chroma-mhi">
 											Tags
 										</strong>{' '}
 										&mdash; optional. Include &ldquo;tag&rdquo; in the header.

--- a/src/components/ui/avatar-icon.tsx
+++ b/src/components/ui/avatar-icon.tsx
@@ -13,7 +13,7 @@ export function AvatarIconRow({ children, ...profile }: AvatarIconRowProps) {
 			<Link
 				to="/friends/$uid"
 				params={{ uid: profile.uid }}
-				className="hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary hover:border-lc-2 hover:border-chroma-mlo hover:border-hue-primary flex grow flex-row items-center justify-start gap-4 rounded-2xl border border-transparent p-2"
+				className="hover:bg-lc-1 hover:bg-chroma-mlo hover:border-lc-2 hover:border-chroma-mlo flex grow flex-row items-center justify-start gap-4 rounded-2xl border border-transparent p-2"
 			>
 				<UserAvatar profile={profile} className="size-8" />
 				<span>{profile.username}</span>

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -33,9 +33,7 @@ const AvatarFallback = ({
 		data-slot="avatar-fallback"
 		className={cn(
 			'flex h-full w-full items-center justify-center',
-			seed
-				? 'bg-lc-5 bg-chroma-mhi bg-hue-primary text-primary-foreground'
-				: 'bg-muted',
+			seed ? 'bg-lc-5 bg-chroma-mhi text-primary-foreground' : 'bg-muted',
 			className
 		)}
 		style={

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -10,14 +10,12 @@ const badgeVariants = cva(
 		variants: {
 			variant: {
 				default: 'border-transparent bg-primary text-primary-foreground',
-				secondary:
-					'border-lc-2 border-chroma-lo border-hue-neutral bg-lc-1 bg-chroma-lo bg-hue-neutral text-lc-5 text-chroma-mid text-hue-neutral',
+				secondary: 'hue-neutral border-lc-2 bg-lc-1 text-lc-5 text-chroma-mid',
 				destructive:
 					'border-transparent bg-destructive text-destructive-foreground',
 				success: 'border-transparent bg-green-600 text-green-100',
-				outline:
-					'text-primary-foresoft border-lc-2 border-chroma-lo border-hue-primary bg-lc-0 bg-chroma-lo bg-hue-primary',
-				lang: 'bg-lc-1 bg-chroma-mlo bg-hue-primary text-lc-fore text-chroma-mlo text-hue-primary border-lc-1 border-chroma-mlo border-hue-primary font-mono font-bold uppercase tracking-wider items-end w-fit transition-colors duration-700',
+				outline: 'text-primary-foresoft border-lc-2 bg-lc-0',
+				lang: 'bg-lc-1 bg-chroma-mlo text-lc-fore text-chroma-mlo border-lc-1 border-chroma-mlo font-mono font-bold uppercase tracking-wider items-end w-fit transition-colors duration-700',
 			},
 			size: {
 				lg: 'px-3 py-1 gap-2 [&>svg]:h-4 [&>svg]:w-4 [&>button]:h-5 [&>button]:w-5',

--- a/src/components/ui/blockquote.tsx
+++ b/src/components/ui/blockquote.tsx
@@ -11,7 +11,7 @@ export function Blockquote({
 	return (
 		<blockquote
 			className={cn(
-				'hue-primary chroma-mlo bg-lc-1 border-lc-4 mb-4 rounded border-l-4 p-4 italic',
+				'chroma-mlo bg-lc-1 border-lc-4 mb-4 rounded border-l-4 p-4 italic',
 				className
 			)}
 		>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,12 +18,11 @@ const buttonVariants = cva(
 				red: `hue-danger ${solids}`,
 				'red-soft': `hue-danger ${softs}`,
 				neutral: 'hover:bg-lc-up-1 hover:bg-chroma-mlo',
-				ghost:
-					'text-chroma-lo text-lc-6 hover:bg-lc-0 hover:bg-chroma-lo hover:bg-hue-primary hover:text-lc-7',
+				ghost: 'text-lc-6 hover:bg-lc-0 hover:text-lc-7',
 				'badge-outline':
-					'rounded border-border text-lc-8 text-chroma-mid text-hue-neutral bg-lc-0 bg-chroma-lo bg-hue-neutral hover:border-primary',
+					'hue-neutral rounded border-border text-lc-8 text-chroma-mid bg-lc-0 hover:border-primary',
 				'dashed-w-full':
-					'w-full border-2 border-dashed border-lc-2 border-chroma-lo border-hue-primary hover:border-border shadow-none hover:shadow',
+					'w-full border-2 border-dashed border-lc-2 hover:border-border shadow-none hover:shadow',
 			},
 			size: {
 				default: 'h-10 rounded-2xl px-5 py-2 gap-2 text-md',

--- a/src/components/ui/choice-tile.tsx
+++ b/src/components/ui/choice-tile.tsx
@@ -31,8 +31,8 @@ export function ChoiceTile({
 				'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
 				'disabled:cursor-not-allowed disabled:opacity-60',
 				selected
-					? 'bg-lc-0 bg-chroma-mlo bg-hue-primary border-lc-2 border-chroma-mlo border-hue-primary'
-					: 'border-input hover:bg-lc-base hover:bg-chroma-mlo hover:bg-hue-primary hover:border-lc-4 hover:border-chroma-mlo hover:border-hue-primary',
+					? 'bg-lc-0 bg-chroma-mlo border-lc-2 border-chroma-mlo'
+					: 'border-input hover:bg-lc-base hover:bg-chroma-mlo hover:border-lc-4 hover:border-chroma-mlo',
 				className
 			)}
 			{...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -41,7 +41,7 @@ const DropdownMenuSubTrigger = ({
 	<MenuPrimitive.SubmenuTrigger
 		data-slot="dropdown-menu-sub-trigger"
 		className={cn(
-			'focus:bg-lc-0 focus:bg-chroma-mlo focus:bg-hue-primary data-[popup-open]:bg-primary flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+			'focus:bg-lc-0 focus:bg-chroma-mlo data-[popup-open]:bg-primary flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
 			inset && 'pl-8',
 			className
 		)}
@@ -107,7 +107,7 @@ const DropdownMenuItem = ({
 	inset?: boolean
 }) => {
 	const mergedClassName = cn(
-		'focus:bg-lc-0 focus:bg-chroma-mlo focus:bg-hue-primary relative flex cursor-default items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-hidden transition-colors select-none focus:ring data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+		'focus:bg-lc-0 focus:bg-chroma-mlo relative flex cursor-default items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-hidden transition-colors select-none focus:ring data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
 		inset && 'pl-8',
 		className
 	)
@@ -129,7 +129,7 @@ const DropdownMenuCheckboxItem = ({
 	<MenuPrimitive.CheckboxItem
 		data-slot="dropdown-menu-checkbox-item"
 		className={cn(
-			'focus:bg-lc-0 focus:bg-chroma-mlo focus:bg-hue-primary relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50',
+			'focus:bg-lc-0 focus:bg-chroma-mlo relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50',
 			className
 		)}
 		checked={checked}
@@ -152,7 +152,7 @@ const DropdownMenuRadioItem = ({
 	<MenuPrimitive.RadioItem
 		data-slot="dropdown-menu-radio-item"
 		className={cn(
-			'focus:bg-lc-0 focus:bg-chroma-mlo focus:bg-hue-primary relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50',
+			'focus:bg-lc-0 focus:bg-chroma-mlo relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50',
 			className
 		)}
 		{...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = ({
 		<input
 			type={type}
 			className={cn(
-				'border-lc-3 border-chroma-mlo border-hue-primary hover:border-primary bg-card/50 ring-offset-background file:text-foreground placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-2xl border px-3 py-2 text-base inset-shadow-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+				'border-lc-3 border-chroma-mlo hover:border-primary bg-card/50 ring-offset-background file:text-foreground placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-2xl border px-3 py-2 text-base inset-shadow-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
 				className
 			)}
 			data-slot="input"

--- a/src/components/ui/item.tsx
+++ b/src/components/ui/item.tsx
@@ -32,7 +32,7 @@ function ItemSeparator({
 }
 
 const itemVariants = cva(
-	'inset-shadow-sm group/item [a]:hover:bg-lc-1 [a]:hover:bg-chroma-mlo [a]:hover:bg-hue-accent focus-visible:border-ring focus-visible:ring-ring/50 [a]:transition-colors flex flex-wrap items-center rounded-md border border-transparent text-sm outline-none transition-colors duration-100 focus-visible:ring-[3px]',
+	'[a]:hover:hue-accent inset-shadow-sm group/item [a]:hover:bg-lc-1 [a]:hover:bg-chroma-mlo focus-visible:border-ring focus-visible:ring-ring/50 [a]:transition-colors flex flex-wrap items-center rounded-md border border-transparent text-sm outline-none transition-colors duration-100 focus-visible:ring-[3px]',
 	{
 		variants: {
 			variant: {

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -49,7 +49,7 @@ const NavigationMenuItem = ({
 )
 
 const navigationMenuTriggerStyle = cva(
-	'group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 data-active:bg-lc-2 data-active:bg-chroma-mid data-active:bg-hue-accent data-[popup-open]:bg-lc-2 data-[popup-open]:bg-chroma-mid data-[popup-open]:bg-hue-accent'
+	'data-[popup-open]:hue-accent data-active:hue-accent group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 data-active:bg-lc-2 data-active:bg-chroma-mid data-[popup-open]:bg-lc-2 data-[popup-open]:bg-chroma-mid'
 )
 
 const NavigationMenuTrigger = ({

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -12,7 +12,7 @@ function Progress({
 			value={value}
 			data-slot="progress"
 			className={cn(
-				'bg-lc-2 bg-chroma-mlo bg-hue-primary relative h-2 w-full overflow-hidden rounded-full',
+				'bg-lc-2 bg-chroma-mlo relative h-2 w-full overflow-hidden rounded-full',
 				className
 			)}
 			{...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -127,7 +127,7 @@ const SelectItem = ({
 	<SelectPrimitive.Item
 		data-slot="select-item"
 		className={cn(
-			'focus:bg-lc-1 focus:bg-chroma-lo focus:bg-hue-accent focus:text-accent-foreground relative flex w-full cursor-default items-center rounded-2xl py-1.5 pr-2 pl-8 text-sm outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+			'focus:hue-accent focus:bg-lc-1 focus:text-accent-foreground relative flex w-full cursor-default items-center rounded-2xl py-1.5 pr-2 pl-8 text-sm outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
 			className
 		)}
 		{...props}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -11,7 +11,7 @@ const Separator = ({
 		data-slot="separator"
 		orientation={orientation}
 		className={cn(
-			'bg-lc-3 bg-chroma-mlo bg-hue-primary shrink-0',
+			'bg-lc-3 bg-chroma-mlo shrink-0',
 			orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
 			className
 		)}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -309,7 +309,7 @@ const SidebarInset = ({
 		<main
 			data-slot="sidebar-inset"
 			className={cn(
-				'bg-lc-base bg-chroma-lo bg-hue-neutral relative flex min-h-svh flex-1 flex-col',
+				'hue-neutral bg-lc-base relative flex min-h-svh flex-1 flex-col',
 				'peer-data-[variant=inset]:min-h-[calc(100svh-(--spacing(4)))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
 				className
 			)}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -42,7 +42,7 @@ export function toastSuccess(message: string) {
 				data-testid="toast-success"
 				className={`${ephemeralClass} border-lc-4 border-chroma-mid border-hue-success bg-lc-1 bg-chroma-mlo bg-hue-success text-lc-8 text-chroma-mid text-hue-success`}
 			>
-				<CheckCircle className="text-lc-6 text-chroma-mhi text-hue-success size-5 shrink-0" />
+				<CheckCircle className="hue-success text-lc-6 text-chroma-mhi size-5 shrink-0" />
 				<span className="flex-1 text-sm">{message}</span>
 			</div>
 		),
@@ -84,13 +84,13 @@ export function toastInfo(message: string) {
 				data-testid="toast-info"
 				className={`${persistentClass} border-lc-4 border-chroma-mid border-hue-info bg-lc-1 bg-chroma-mlo bg-hue-info text-lc-8 text-chroma-mid text-hue-info`}
 			>
-				<Info className="text-lc-6 text-chroma-mhi text-hue-info size-5 shrink-0" />
+				<Info className="hue-info text-lc-6 text-chroma-mhi size-5 shrink-0" />
 				<span className="flex-1 text-sm">{message}</span>
 				<div className="flex shrink-0 items-center gap-1">
 					<Button
 						variant="ghost"
 						size="icon"
-						className="text-lc-6 text-chroma-mhi text-hue-info hover:bg-lc-2 hover:bg-chroma-mlo hover:bg-hue-info size-7"
+						className="hue-info hover:hue-info text-lc-6 text-chroma-mhi hover:bg-lc-2 hover:bg-chroma-mlo size-7"
 						// eslint-disable-next-line @typescript-eslint/no-misused-promises
 						onClick={copyToClipboard(message)}
 						aria-label="Copy message"
@@ -100,7 +100,7 @@ export function toastInfo(message: string) {
 					<Button
 						variant="ghost"
 						size="icon"
-						className="text-lc-6 text-chroma-mhi text-hue-info hover:bg-lc-2 hover:bg-chroma-mlo hover:bg-hue-info size-7"
+						className="hue-info hover:hue-info text-lc-6 text-chroma-mhi hover:bg-lc-2 hover:bg-chroma-mlo size-7"
 						onClick={() => toast.dismiss(t)}
 						aria-label="Dismiss"
 					>
@@ -125,13 +125,13 @@ export function toastError(message: string) {
 				data-testid="toast-error"
 				className={`${persistentClass} border-lc-4 border-chroma-mid border-hue-danger bg-lc-1 bg-chroma-mlo bg-hue-danger text-lc-8 text-chroma-mid text-hue-danger`}
 			>
-				<AlertCircle className="text-lc-6 text-chroma-mhi text-hue-danger size-5 shrink-0" />
+				<AlertCircle className="hue-danger text-lc-6 text-chroma-mhi size-5 shrink-0" />
 				<span className="flex-1 text-sm">{message}</span>
 				<div className="flex shrink-0 items-center gap-1">
 					<Button
 						variant="ghost"
 						size="icon"
-						className="text-lc-6 text-chroma-mhi text-hue-danger hover:bg-lc-2 hover:bg-chroma-mlo hover:bg-hue-danger size-7"
+						className="hue-danger hover:hue-danger text-lc-6 text-chroma-mhi hover:bg-lc-2 hover:bg-chroma-mlo size-7"
 						// eslint-disable-next-line @typescript-eslint/no-misused-promises
 						onClick={copyToClipboard(message)}
 						aria-label="Copy error"
@@ -141,7 +141,7 @@ export function toastError(message: string) {
 					<Button
 						variant="ghost"
 						size="icon"
-						className="text-lc-6 text-chroma-mhi text-hue-danger hover:bg-lc-2 hover:bg-chroma-mlo hover:bg-hue-danger size-7"
+						className="hue-danger hover:hue-danger text-lc-6 text-chroma-mhi hover:bg-lc-2 hover:bg-chroma-mlo size-7"
 						onClick={() => toast.dismiss(t)}
 						aria-label="Dismiss"
 					>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -6,7 +6,7 @@ const Switch = ({ className, ...props }: SwitchPrimitive.Root.Props) => (
 	<SwitchPrimitive.Root
 		data-slot="switch"
 		className={cn(
-			'peer ring-offset-background focus-visible:ring-ring inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full bg-lc-1 bg-chroma-mlo bg-hue-neutral inset-shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+			'hue-neutral peer ring-offset-background focus-visible:ring-ring inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full bg-lc-1 bg-chroma-mlo inset-shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
 			className
 		)}
 		{...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = ({
 	return (
 		<textarea
 			className={cn(
-				'border-lc-3 border-chroma-mlo border-hue-primary hover:border-primary bg-card/50 ring-offset-background placeholder:text-muted-foreground text-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-2xl border px-3 py-2 text-sm inset-shadow-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+				'border-lc-3 border-chroma-mlo hover:border-primary bg-card/50 ring-offset-background placeholder:text-muted-foreground text-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-2xl border px-3 py-2 text-sm inset-shadow-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
 				className
 			)}
 			data-slot="textarea"

--- a/src/features/chat/components/cart-button.tsx
+++ b/src/features/chat/components/cart-button.tsx
@@ -77,7 +77,7 @@ export function CartButton() {
 									key={phrase.id}
 									data-key={phrase.id}
 									data-testid="chat-cart-item"
-									className="hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary flex flex-row items-start justify-between gap-2 rounded p-2 text-sm"
+									className="hover:bg-lc-1 hover:bg-chroma-mlo flex flex-row items-start justify-between gap-2 rounded p-2 text-sm"
 								>
 									<div className="flex flex-col">
 										<span lang={phrase.lang} className="font-medium">

--- a/src/features/chat/components/chat-message.tsx
+++ b/src/features/chat/components/chat-message.tsx
@@ -18,7 +18,7 @@ export function ChatTurnView({ turn }: Props) {
 			<div className="flex justify-end">
 				<div
 					data-testid="chat-user-message"
-					className="bg-lc-1 bg-chroma-mlo bg-hue-primary text-foreground max-w-[85%] rounded-2xl px-4 py-2 text-sm"
+					className="bg-lc-1 bg-chroma-mlo text-foreground max-w-[85%] rounded-2xl px-4 py-2 text-sm"
 				>
 					{turn.query.kind === 'text' ? (
 						turn.query.text

--- a/src/features/chat/components/phrase-result-card.tsx
+++ b/src/features/chat/components/phrase-result-card.tsx
@@ -22,7 +22,7 @@ export function PhraseResultCard({ phrase }: Props) {
 			data-in-cart={inCart ? '' : undefined}
 			className={cn(
 				'flex flex-row items-start gap-3 rounded border p-3',
-				inCart ? 'bg-lc-1 bg-chroma-mlo bg-hue-primary' : 'bg-card/50'
+				inCart ? 'bg-lc-1 bg-chroma-mlo' : 'bg-card/50'
 			)}
 		>
 			<div className="flex flex-1 flex-col gap-1">

--- a/src/features/chat/components/selection-bar.tsx
+++ b/src/features/chat/components/selection-bar.tsx
@@ -22,7 +22,7 @@ export function SelectionBar() {
 	return (
 		<div
 			data-testid="chat-selection-bar"
-			className="bg-lc-1 bg-chroma-lo bg-hue-primary flex flex-col gap-2 rounded border p-2"
+			className="bg-lc-1 flex flex-col gap-2 rounded border p-2"
 		>
 			<div className="flex flex-row items-center justify-between gap-2">
 				<span className="text-muted-foreground text-xs font-medium">

--- a/src/lib/lang-theme.ts
+++ b/src/lib/lang-theme.ts
@@ -108,12 +108,33 @@ export function useLangPopularityReady(): boolean {
 	)
 }
 
+// The axis hue variables every color utility resolves through. A theme
+// container re-declares them from --hue-primary so its whole subtree inherits
+// the language hue for bg/text/border/gradient with no per-element hue class.
+// (Setting only --hue-* is not enough: the :root axis defaults resolve
+// var(--hue-primary) once, at :root, and inherit that fixed value — so a
+// descendant that overrides --hue-primary is ignored unless the axis var is
+// re-declared here, where the override is in scope.)
+const AXIS_HUE_VARS = [
+	'--bg-h',
+	'--tx-h',
+	'--bd-h',
+	'--bdb-h',
+	'--gf-h',
+	'--gt-h',
+] as const
+
+const AXIS_HUE_CSS = Object.fromEntries(
+	AXIS_HUE_VARS.map((v) => [v, 'var(--hue-primary)'])
+) as CSSProperties
+
 export function getLangThemeCss(lang: string): CSSProperties {
 	const hue = getLangHue(lang)
 	return {
 		'--hue-primary': hue,
 		'--hue-accent': hue,
 		'--hue-neutral': hue,
+		...AXIS_HUE_CSS,
 	} as CSSProperties
 }
 
@@ -132,10 +153,12 @@ export function setLangTheme(element?: HTMLElement, lang?: string): void {
 		el.style.removeProperty('--hue-primary')
 		el.style.removeProperty('--hue-accent')
 		el.style.removeProperty('--hue-neutral')
+		for (const v of AXIS_HUE_VARS) el.style.removeProperty(v)
 		return
 	}
 	const hue = String(getLangHue(lang))
 	el.style.setProperty('--hue-primary', hue)
 	el.style.setProperty('--hue-accent', hue)
 	el.style.setProperty('--hue-neutral', hue)
+	for (const v of AXIS_HUE_VARS) el.style.setProperty(v, 'var(--hue-primary)')
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,7 +7,7 @@ import { useState } from 'react'
 
 /* ── OKLCH single-axis utilities × tailwind-merge ──────────────────────────
    Our color utilities decompose into three same-prefix classes per property
-   (`bg-lc-7 bg-chroma-mhi bg-hue-primary`). Out of the box tailwind-merge
+   (`bg-lc-7 bg-chroma-mhi`). Out of the box tailwind-merge
    treats those as conflicting `bg-*` utilities and keeps only the last one,
    silently dropping two of the three axes. Register each (property × axis) as
    its own conflict group so the axes are independent: two `bg-lc-*` still

--- a/src/routes/_user.tsx
+++ b/src/routes/_user.tsx
@@ -175,7 +175,7 @@ function UserLayout() {
 								fallback={
 									<div
 										aria-hidden
-										className="bg-lc-base bg-chroma-lo bg-hue-neutral mt-1 -mb-[2px] h-12"
+										className="hue-neutral bg-lc-base mt-1 -mb-[2px] h-12"
 									/>
 								}
 							>

--- a/src/routes/_user/-browse-discover.tsx
+++ b/src/routes/_user/-browse-discover.tsx
@@ -95,9 +95,7 @@ function AddedPill({ added }: { added: boolean }) {
 		<span
 			className={cn(
 				'flex items-center gap-1 text-xs font-medium',
-				added
-					? 'text-lc-5 text-chroma-hi text-hue-success'
-					: 'text-primary-foresoft'
+				added ? 'hue-success text-lc-5 text-chroma-hi' : 'text-primary-foresoft'
 			)}
 		>
 			{added ? (

--- a/src/routes/_user/-search-page.tsx
+++ b/src/routes/_user/-search-page.tsx
@@ -405,8 +405,8 @@ export function SearchPage({ rowExtras }: { rowExtras?: RowExtrasRenderer }) {
 function SystemMessage({ children }: { children: ReactNode }) {
 	return (
 		<div className="flex items-start gap-2.5">
-			<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full">
-				<Sparkles className="text-lc-7 text-chroma-hi text-hue-primary size-3.5" />
+			<div className="bg-lc-1 bg-chroma-mlo mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full">
+				<Sparkles className="text-lc-7 text-chroma-hi size-3.5" />
 			</div>
 			<p className="text-muted-foreground pt-1 text-sm">{children}</p>
 		</div>
@@ -430,7 +430,7 @@ function FilterPill({
 				'inline-flex cursor-pointer items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors',
 				active
 					? 'bg-primary-foresoft text-primary-foreground border-transparent'
-					: 'border-border text-muted-foreground hover:border-lc-4 hover:border-chroma-mlo hover:border-hue-primary hover:text-foreground'
+					: 'border-border text-muted-foreground hover:border-lc-4 hover:border-chroma-mlo hover:text-foreground'
 			)}
 		>
 			{children}
@@ -441,8 +441,8 @@ function FilterPill({
 function EmptyResults() {
 	return (
 		<div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
-			<div className="bg-lc-1 bg-chroma-mlo bg-hue-neutral mx-auto flex size-24 items-center justify-center rounded-full">
-				<SearchX className="text-lc-5 text-chroma-mid text-hue-neutral size-12" />
+			<div className="hue-neutral bg-lc-1 bg-chroma-mlo mx-auto flex size-24 items-center justify-center rounded-full">
+				<SearchX className="hue-neutral text-lc-5 text-chroma-mid size-12" />
 			</div>
 			<div className="space-y-1">
 				<p className="text-lg font-semibold">No results found</p>
@@ -618,8 +618,8 @@ function WelcomeState({
 	return (
 		<div className="flex h-full flex-col items-center justify-center space-y-8 p-6">
 			<div className="space-y-3 text-center">
-				<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary mx-auto mb-4 flex size-16 items-center justify-center rounded-full">
-					<MessageCircle className="text-lc-7 text-chroma-hi text-hue-primary size-8" />
+				<div className="bg-lc-1 bg-chroma-mlo mx-auto mb-4 flex size-16 items-center justify-center rounded-full">
+					<MessageCircle className="text-lc-7 text-chroma-hi size-8" />
 				</div>
 				<h2 className="h3">What are you looking for?</h2>
 				<p className="text-muted-foreground mx-auto max-w-sm text-sm">

--- a/src/routes/_user/admin/$lang.requests.$id.lazy.tsx
+++ b/src/routes/_user/admin/$lang.requests.$id.lazy.tsx
@@ -260,7 +260,7 @@ function AddTagPopover({
 						return (
 							<li key={tag.slug}>
 								<label
-									className="hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-neutral flex cursor-pointer items-center gap-2 rounded p-2 text-sm"
+									className="hover:hue-neutral hover:bg-lc-1 flex cursor-pointer items-center gap-2 rounded p-2 text-sm"
 									data-testid="admin-request-tag-option"
 									data-key={tag.slug}
 								>

--- a/src/routes/_user/admin/messages.$id.lazy.tsx
+++ b/src/routes/_user/admin/messages.$id.lazy.tsx
@@ -196,7 +196,7 @@ function AddTagPopover({
 						return (
 							<li key={tag.slug}>
 								<label
-									className="hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-neutral flex cursor-pointer items-center gap-2 rounded p-2 text-sm"
+									className="hover:hue-neutral hover:bg-lc-1 flex cursor-pointer items-center gap-2 rounded p-2 text-sm"
 									data-testid="message-tag-option"
 									data-key={tag.slug}
 								>

--- a/src/routes/_user/admin/messages.index.lazy.tsx
+++ b/src/routes/_user/admin/messages.index.lazy.tsx
@@ -782,8 +782,8 @@ function BulkAddSection({
 								<button
 									type="button"
 									className={cn(
-										'hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-neutral block w-full rounded p-2 text-start text-sm',
-										tagSlug === null && 'bg-lc-1 bg-chroma-mlo bg-hue-primary'
+										'hover:hue-neutral hover:bg-lc-1 block w-full rounded p-2 text-start text-sm',
+										tagSlug === null && 'bg-lc-1 bg-chroma-mlo'
 									)}
 									onClick={() => {
 										setTagSlug(null)
@@ -799,9 +799,8 @@ function BulkAddSection({
 											<button
 												type="button"
 												className={cn(
-													'hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-neutral block w-full rounded p-2 text-start text-sm',
-													tagSlug === tag.slug &&
-														'bg-lc-1 bg-chroma-mlo bg-hue-primary'
+													'hover:hue-neutral hover:bg-lc-1 block w-full rounded p-2 text-start text-sm',
+													tagSlug === tag.slug && 'bg-lc-1 bg-chroma-mlo'
 												)}
 												onClick={() => {
 													setTagSlug(tag.slug)
@@ -917,7 +916,7 @@ function SelectionBar({
 
 	return (
 		<div
-			className="bg-lc-1 bg-chroma-mlo bg-hue-primary flex flex-wrap items-center gap-3 rounded border p-3"
+			className="bg-lc-1 bg-chroma-mlo flex flex-wrap items-center gap-3 rounded border p-3"
 			data-testid="admin-messages-selection-bar"
 		>
 			<span className="text-sm font-semibold">
@@ -1006,7 +1005,7 @@ function MessagesTable({
 			data-name="message-row"
 		>
 			{isAdmin && (
-				<div className="bg-lc-1 bg-chroma-lo bg-hue-neutral flex items-center gap-2 border-b px-3 py-2 text-xs">
+				<div className="hue-neutral bg-lc-1 flex items-center gap-2 border-b px-3 py-2 text-xs">
 					<Checkbox
 						checked={allVisibleSelected}
 						onCheckedChange={toggleVisibleAll}
@@ -1049,7 +1048,7 @@ function MessageRowItem({
 		<li
 			className={cn(
 				'flex items-start gap-3 p-3',
-				isSelected && 'bg-lc-1 bg-chroma-mlo bg-hue-primary'
+				isSelected && 'bg-lc-1 bg-chroma-mlo'
 			)}
 			data-testid="message-row"
 			data-key={row.message_id}

--- a/src/routes/_user/admin/routes.lazy.tsx
+++ b/src/routes/_user/admin/routes.lazy.tsx
@@ -169,8 +169,8 @@ function LoadCell({ isLazy }: { isLazy: boolean }) {
 				className={cn(
 					'inline-block rounded px-1.5 py-0.5 font-mono',
 					isLazy
-						? 'bg-lc-1 bg-chroma-mlo bg-hue-info text-lc-7 text-chroma-hi text-hue-info'
-						: 'bg-lc-1 bg-chroma-mlo bg-hue-neutral text-muted-foreground'
+						? 'hue-info bg-lc-1 bg-chroma-mlo text-lc-7 text-chroma-hi'
+						: 'hue-neutral bg-lc-1 bg-chroma-mlo text-muted-foreground'
 				)}
 			>
 				{isLazy ? 'lazy' : 'eager'}
@@ -184,9 +184,7 @@ function BoolCell({ on }: { on: boolean }) {
 		<td
 			className={cn(
 				'px-2 py-1.5 text-center',
-				on
-					? 'text-lc-7 text-chroma-hi text-hue-success'
-					: 'text-muted-foreground'
+				on ? 'hue-success text-lc-7 text-chroma-hi' : 'text-muted-foreground'
 			)}
 		>
 			{on ? '✓' : '·'}
@@ -198,7 +196,7 @@ function SearchCell({ scope }: { scope: SearchScope | undefined }) {
 	if (scope === undefined)
 		return <td className="text-muted-foreground px-2 py-1.5 text-center">·</td>
 	return (
-		<td className="text-lc-7 text-chroma-hi text-hue-success px-2 py-1.5 text-center font-mono text-xs">
+		<td className="hue-success text-lc-7 text-chroma-hi px-2 py-1.5 text-center font-mono text-xs">
 			{scope}
 		</td>
 	)

--- a/src/routes/_user/browse.$lang.tsx
+++ b/src/routes/_user/browse.$lang.tsx
@@ -287,7 +287,7 @@ function BrowseLanguagePage() {
 												'rounded-full px-4 py-1.5 text-sm transition-colors',
 												active
 													? 'bg-primary text-primary-foreground'
-													: 'bg-lc-1 bg-chroma-lo bg-hue-neutral text-lc-6 text-chroma-mid text-hue-neutral hover:bg-lc-2 hover:bg-chroma-lo hover:bg-hue-neutral'
+													: 'hue-neutral hover:hue-neutral bg-lc-1 text-lc-6 text-chroma-mid hover:bg-lc-2'
 											)}
 										>
 											{tag.name}

--- a/src/routes/_user/browse.index.tsx
+++ b/src/routes/_user/browse.index.tsx
@@ -56,7 +56,7 @@ function BrowsePage() {
 						replace: true,
 					})
 				}
-				className="border-lc-3 border-chroma-mlo border-hue-primary hover:border-primary bg-card/50 flex h-12 w-full items-center gap-3 rounded-2xl border px-4 transition-colors"
+				className="border-lc-3 border-chroma-mlo hover:border-primary bg-card/50 flex h-12 w-full items-center gap-3 rounded-2xl border px-4 transition-colors"
 				data-testid="browse-search-trigger"
 			>
 				<Search className="text-muted-foreground size-5" />
@@ -154,7 +154,7 @@ function StatsSection() {
 			{stats.map((stat) => (
 				<Card key={stat.label} className="bg-card/30">
 					<CardContent className="flex flex-row items-center gap-4 p-6">
-						<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary text-primary rounded-full p-3">
+						<div className="bg-lc-1 bg-chroma-mlo text-primary rounded-full p-3">
 							<stat.icon className="size-6" />
 						</div>
 						<div>
@@ -552,7 +552,7 @@ function PlaylistCard({
 
 function CTASection() {
 	return (
-		<section className="bg-lc-0 bg-chroma-lo bg-hue-primary rounded-lg border p-8 text-center">
+		<section className="bg-lc-0 rounded-lg border p-8 text-center">
 			<h2 className="text-2xl font-bold">Ready to start learning?</h2>
 			<p className="text-muted-foreground mt-2">
 				Join our community of language learners today

--- a/src/routes/_user/friends/-chats-sidebar.tsx
+++ b/src/routes/_user/friends/-chats-sidebar.tsx
@@ -9,7 +9,7 @@ import { avatarUrlify } from '@/lib/hooks'
 import { ago } from '@/lib/dayjs'
 
 const linkActiveProps = {
-	className: 'bg-lc-1 bg-chroma-mlo bg-hue-accent text-accent-foreground',
+	className: 'hue-accent bg-lc-1 bg-chroma-mlo text-accent-foreground',
 }
 
 export function ChatsSidebar() {
@@ -65,7 +65,7 @@ function ChatEntryItem({ entry }: { entry: ChatEntry }) {
 			data-key={uid}
 			to="/friends/chats/$friendUid"
 			params={{ friendUid: uid }}
-			className="hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-accent hover:text-accent-foreground flex items-center gap-3 rounded-2xl px-3 py-2 transition-all"
+			className="hover:hue-accent hover:bg-lc-1 hover:bg-chroma-mlo hover:text-accent-foreground flex items-center gap-3 rounded-2xl px-3 py-2 transition-all"
 			activeProps={linkActiveProps}
 		>
 			<Avatar className="h-8 w-8">

--- a/src/routes/_user/friends/-playlist-preview.tsx
+++ b/src/routes/_user/friends/-playlist-preview.tsx
@@ -28,7 +28,7 @@ export function PlaylistPreview({ id }: { id: uuid }) {
 			params={{ lang: playlist.lang, playlistId: id }}
 		>
 			<div className="bg-card text-card-foreground @container relative z-10 flex flex-col gap-3 rounded-lg border py-0 shadow-sm">
-				<CardHeader className="border-b-lc-3 border-b-chroma-mlo border-b-hue-primary mx-4 mb-0 border-b px-0 py-4">
+				<CardHeader className="border-b-lc-3 border-b-chroma-mlo mx-4 mb-0 border-b px-0 py-4">
 					<CardTitle className="flex flex-row items-center justify-between gap-1 text-lg">
 						<span className="flex items-center gap-1">
 							<ListMusic className="text-muted-foreground" /> Playlist

--- a/src/routes/_user/friends/-request-preview.tsx
+++ b/src/routes/_user/friends/-request-preview.tsx
@@ -28,7 +28,7 @@ export function RequestPreview({ id }: { id: uuid }) {
 			data-key={id}
 		>
 			<CardlikeRequest className="relative z-10">
-				<CardHeader className="border-b-lc-3 border-b-chroma-mlo border-b-hue-primary mx-4 mb-4 border-b px-0 py-4">
+				<CardHeader className="border-b-lc-3 border-b-chroma-mlo mx-4 mb-4 border-b px-0 py-4">
 					<CardTitle className="flex flex-row items-center justify-between gap-1 text-lg">
 						<span className="flex items-center gap-1">
 							<MessageCircleHeart className="text-muted-foreground" /> Phrase

--- a/src/routes/_user/friends/invite.lazy.tsx
+++ b/src/routes/_user/friends/invite.lazy.tsx
@@ -39,7 +39,7 @@ function InviteFriendPage() {
 			data-testid="invite-friend-page"
 		>
 			<div className="text-center">
-				<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary text-primary mb-6 inline-flex items-center space-x-2 rounded-full px-4 py-2 text-sm font-medium">
+				<div className="bg-lc-1 bg-chroma-mlo text-primary mb-6 inline-flex items-center space-x-2 rounded-full px-4 py-2 text-sm font-medium">
 					<Sparkles className="h-4 w-4" />
 					<span>Grow your learning network</span>
 				</div>
@@ -61,7 +61,7 @@ function InviteFriendPage() {
 						<Card className="group border-border/50 transition-all duration-300 hover:shadow-lg">
 							<CardContent className="p-8">
 								<div className="mb-6 flex items-center space-x-3">
-									<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary group-hover:bg-lc-up-1 flex aspect-square h-12 w-12 items-center justify-center rounded-xl transition-colors">
+									<div className="bg-lc-1 bg-chroma-mlo group-hover:bg-lc-up-1 flex aspect-square h-12 w-12 items-center justify-center rounded-xl transition-colors">
 										<Share className="text-primary h-6 w-6" />
 									</div>
 									<div>
@@ -81,7 +81,7 @@ function InviteFriendPage() {
 						<Card className="group border-border/50 transition-all duration-300 hover:shadow-lg">
 							<CardContent className="p-8">
 								<div className="mb-6 flex items-center space-x-3">
-									<div className="bg-lc-1 bg-chroma-mlo bg-hue-accent group-hover:bg-lc-up-1 flex aspect-square h-12 w-12 items-center justify-center rounded-xl transition-colors">
+									<div className="hue-accent bg-lc-1 bg-chroma-mlo group-hover:bg-lc-up-1 flex aspect-square h-12 w-12 items-center justify-center rounded-xl transition-colors">
 										<Copy className="text-accent-foreground h-6 w-6" />
 									</div>
 									<div>
@@ -95,7 +95,7 @@ function InviteFriendPage() {
 								</div>
 								<CopyLinkButton
 									size="lg"
-									className="border-lc-3 border-chroma-mid border-hue-accent bg-lc-1 bg-chroma-mlo bg-hue-accent text-accent-foresoft hover:bg-lc-up-1 w-full"
+									className="hue-accent border-lc-3 border-chroma-mid bg-lc-1 bg-chroma-mlo text-accent-foresoft hover:bg-lc-up-1 w-full"
 									variant="soft"
 									url={share.url}
 								/>
@@ -121,8 +121,8 @@ function InviteFriendPage() {
 							className="group border-border/50 rounded-xl border p-6 text-left shadow transition-all duration-200 hover:shadow-lg"
 						>
 							<div className="flex items-center space-x-4">
-								<div className="bg-lc-1 bg-chroma-mlo bg-hue-info group-hover:bg-lc-up-1 flex h-12 w-12 items-center justify-center rounded-xl transition-colors">
-									<Mail className="text-lc-6 text-chroma-hi text-hue-info h-6 w-6" />
+								<div className="hue-info bg-lc-1 bg-chroma-mlo group-hover:bg-lc-up-1 flex h-12 w-12 items-center justify-center rounded-xl transition-colors">
+									<Mail className="hue-info text-lc-6 text-chroma-hi h-6 w-6" />
 								</div>
 								<div>
 									<h3 className="text-foreground font-semibold">Email</h3>
@@ -140,8 +140,8 @@ function InviteFriendPage() {
 							className="group border-border/50 rounded-xl border p-6 text-left shadow transition-all duration-200 hover:shadow-lg"
 						>
 							<div className="flex items-center space-x-4">
-								<div className="bg-lc-1 bg-chroma-mlo bg-hue-success group-hover:bg-lc-up-1 flex h-12 w-12 items-center justify-center rounded-xl transition-colors">
-									<MessageSquare className="text-lc-6 text-chroma-hi text-hue-success h-6 w-6" />
+								<div className="hue-success bg-lc-1 bg-chroma-mlo group-hover:bg-lc-up-1 flex h-12 w-12 items-center justify-center rounded-xl transition-colors">
+									<MessageSquare className="hue-success text-lc-6 text-chroma-hi h-6 w-6" />
 								</div>
 								<div>
 									<h3 className="text-foreground font-semibold">WhatsApp</h3>
@@ -158,8 +158,8 @@ function InviteFriendPage() {
 								className="group border-border/50 col-span-2 rounded-xl border p-6 text-left shadow transition-all duration-200 hover:shadow-lg"
 							>
 								<div className="flex items-center space-x-3">
-									<div className="bg-lc-1 bg-chroma-mlo bg-hue-warning group-hover:bg-lc-up-1 flex aspect-square h-12 w-12 items-center justify-center rounded-xl transition-colors">
-										<Copy className="text-lc-6 text-chroma-hi text-hue-warning h-6 w-6" />
+									<div className="hue-warning bg-lc-1 bg-chroma-mlo group-hover:bg-lc-up-1 flex aspect-square h-12 w-12 items-center justify-center rounded-xl transition-colors">
+										<Copy className="hue-warning text-lc-6 text-chroma-hi h-6 w-6" />
 									</div>
 									<div>
 										<h3 className="text-foreground text-lg font-semibold">
@@ -192,7 +192,7 @@ function InviteFriendPage() {
 						/>
 					</div>
 					<div className="flex-1 space-y-3 text-center @lg:text-start">
-						<div className="bg-lc-1 bg-chroma-mlo bg-hue-accent text-accent-foresoft inline-flex items-center space-x-2 rounded-full px-3 py-1 text-sm font-medium">
+						<div className="hue-accent bg-lc-1 bg-chroma-mlo text-accent-foresoft inline-flex items-center space-x-2 rounded-full px-3 py-1 text-sm font-medium">
 							<QrCode className="h-4 w-4" />
 							<span>Scan to invite</span>
 						</div>

--- a/src/routes/_user/learn/$lang.deck-settings.tsx
+++ b/src/routes/_user/learn/$lang.deck-settings.tsx
@@ -206,7 +206,7 @@ function DailyGoalSection({
 							learners do well with 10-15 new cards per day.
 						</p>
 						<div className="mx-2 space-y-3">
-							<div className="bg-lc-0 bg-chroma-lo bg-hue-primary flex items-start gap-3 rounded-2xl px-4 py-3">
+							<div className="bg-lc-0 flex items-start gap-3 rounded-2xl px-4 py-3">
 								<Cat className="text-primary mt-0.5 size-7 shrink-0" />
 								<div>
 									<p className="font-semibold">Relaxed — 10 new cards</p>
@@ -215,7 +215,7 @@ function DailyGoalSection({
 									</p>
 								</div>
 							</div>
-							<div className="bg-lc-0 bg-chroma-lo bg-hue-primary flex items-start gap-3 rounded-2xl px-4 py-3">
+							<div className="bg-lc-0 flex items-start gap-3 rounded-2xl px-4 py-3">
 								<IceCreamBowl className="text-primary mt-0.5 size-7 shrink-0" />
 								<div>
 									<p className="font-semibold">Standard — 15 new cards</p>
@@ -224,7 +224,7 @@ function DailyGoalSection({
 									</p>
 								</div>
 							</div>
-							<div className="bg-lc-0 bg-chroma-lo bg-hue-primary flex items-start gap-3 rounded-2xl px-4 py-3">
+							<div className="bg-lc-0 flex items-start gap-3 rounded-2xl px-4 py-3">
 								<Rocket className="text-primary mt-0.5 size-7 shrink-0" />
 								<div>
 									<p className="font-semibold">Serious — 20 new cards</p>

--- a/src/routes/_user/learn/$lang.manage-deck.tsx
+++ b/src/routes/_user/learn/$lang.manage-deck.tsx
@@ -56,15 +56,15 @@ const statusIcon = {
 } as const
 
 const statusColors = {
-	active: 'text-lc-7 text-chroma-hi text-hue-primary',
-	learned: 'text-lc-7 text-chroma-hi text-hue-success',
-	skipped: 'text-lc-5 text-chroma-mid text-hue-neutral',
+	active: 'text-lc-7 text-chroma-hi',
+	learned: 'hue-success text-lc-7 text-chroma-hi',
+	skipped: 'hue-neutral text-lc-5 text-chroma-mid',
 } as const
 
 const statusBgColors = {
-	active: 'bg-lc-1 bg-chroma-lo bg-hue-primary',
-	learned: 'bg-lc-1 bg-chroma-lo bg-hue-success',
-	skipped: 'bg-lc-1 bg-chroma-lo bg-hue-neutral',
+	active: 'bg-lc-1',
+	learned: 'hue-success bg-lc-1',
+	skipped: 'hue-neutral bg-lc-1',
 } as const
 
 const DEFAULT_RETENTION = 0.9
@@ -94,13 +94,13 @@ function getDueInfo(item: DueCheckable): {
 		const overdue = Math.abs(daysUntilDue)
 		return {
 			label: overdue === 1 ? 'Overdue 1d' : `Overdue ${overdue}d`,
-			color: 'text-lc-7 text-chroma-hi text-hue-danger',
+			color: 'hue-danger text-lc-7 text-chroma-hi',
 		}
 	}
 	if (daysUntilDue === 0)
 		return {
 			label: 'Due today',
-			color: 'text-lc-7 text-chroma-hi text-hue-warning',
+			color: 'hue-warning text-lc-7 text-chroma-hi',
 		}
 	return {
 		label: daysUntilDue === 1 ? 'Due in 1d' : `Due in ${daysUntilDue}d`,
@@ -364,7 +364,7 @@ function ManageDeckTable({ lang }: { lang: string }) {
 			<div className="hidden overflow-x-auto rounded-lg border @md:block">
 				<table className="w-full text-sm">
 					<thead>
-						<tr className="bg-lc-1 bg-chroma-lo bg-hue-neutral border-b">
+						<tr className="hue-neutral bg-lc-1 border-b">
 							<SortableHeader
 								label="Phrase"
 								field="phrase"
@@ -428,9 +428,7 @@ function MobileCardRow({ row, lang }: { row: PhraseRow; lang: string }) {
 		<div
 			className={cn(
 				'rounded-lg border transition-colors',
-				open
-					? 'bg-lc-0 bg-chroma-lo bg-hue-neutral'
-					: 'hover:bg-lc-0 hover:bg-chroma-lo hover:bg-hue-neutral',
+				open ? 'hue-neutral bg-lc-0' : 'hover:hue-neutral hover:bg-lc-0',
 				isSkipped && 'opacity-50'
 			)}
 			data-testid="manage-deck-row"
@@ -570,7 +568,7 @@ function DesktopCardRow({ row, lang }: { row: PhraseRow; lang: string }) {
 	return (
 		<tr
 			className={cn(
-				'hover:bg-lc-0 hover:bg-chroma-lo hover:bg-hue-neutral border-b transition-colors last:border-b-0',
+				'hover:hue-neutral hover:bg-lc-0 border-b transition-colors last:border-b-0',
 				isSkipped && 'opacity-50'
 			)}
 			data-testid="manage-deck-row"

--- a/src/routes/_user/learn/-archived-deck-tile.tsx
+++ b/src/routes/_user/learn/-archived-deck-tile.tsx
@@ -97,7 +97,7 @@ export function ArchivedDeckTile({ deck }: { deck: DeckMetaType }) {
 							type="button"
 							onClick={restoreDeck}
 							data-testid="confirm-restore-button"
-							className="hue-primary from-lc-5 from-chroma-mhi to-lc-6 to-chroma-mid text-primary-foreground hover:from-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 text-start shadow transition-transform hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-70"
+							className="from-lc-5 from-chroma-mhi to-lc-6 text-primary-foreground hover:from-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 text-start shadow transition-transform hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-70"
 						>
 							<ArchiveRestore className="size-6" />
 							<div>
@@ -112,7 +112,7 @@ export function ArchivedDeckTile({ deck }: { deck: DeckMetaType }) {
 
 						<DialogClose
 							data-testid="cancel-restore-button"
-							className="hue-neutral border-lc-2 border-chroma-lo bg-lc-1 bg-chroma-mlo text-lc-7 text-chroma-mid hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl border p-4 text-start shadow transition-transform hover:-translate-y-0.5"
+							className="hue-neutral border-lc-2 bg-lc-1 bg-chroma-mlo text-lc-7 text-chroma-mid hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full cursor-pointer flex-col items-start gap-2 rounded-2xl border p-4 text-start shadow transition-transform hover:-translate-y-0.5"
 						>
 							<Archive className="size-6" />
 							<div>

--- a/src/routes/_user/learn/-deck-tile.tsx
+++ b/src/routes/_user/learn/-deck-tile.tsx
@@ -104,7 +104,7 @@ export function DeckTile({ deck }: { deck: DeckMetaType }) {
 								to="/learn/$lang/review"
 								params={{ lang: deck.lang }}
 								data-testid="start-practice-link"
-								className="hue-primary from-lc-5 from-chroma-mhi to-lc-6 to-chroma-mid text-primary-foreground hover:from-lc-up-1 flex h-full flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 shadow transition-transform hover:-translate-y-0.5"
+								className="from-lc-5 from-chroma-mhi to-lc-6 text-primary-foreground hover:from-lc-up-1 flex h-full flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 shadow transition-transform hover:-translate-y-0.5"
 							>
 								{dueToday === 0 ? (
 									<CircleCheck className="size-6" />
@@ -129,7 +129,7 @@ export function DeckTile({ deck }: { deck: DeckMetaType }) {
 								to="/learn/$lang"
 								params={{ lang: deck.lang }}
 								data-testid="deck-link"
-								className="hue-primary border-lc-2 border-chroma-lo bg-lc-1 bg-chroma-mlo text-primary-foresoft hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full flex-col items-start gap-2 rounded-2xl border p-4 shadow transition-transform hover:-translate-y-0.5"
+								className="border-lc-2 bg-lc-1 bg-chroma-mlo text-primary-foresoft hover:bg-lc-down-1 hover:text-lc-up-1 flex h-full flex-col items-start gap-2 rounded-2xl border p-4 shadow transition-transform hover:-translate-y-0.5"
 							>
 								<Logs className="size-6" />
 								<div>
@@ -209,7 +209,7 @@ export function AddDeckTile() {
 			data-testid="add-deck-tile"
 			className="block h-full transition-all duration-200 hover:-translate-y-0.5"
 		>
-			<Card className="border-lc-3 border-chroma-lo border-hue-primary text-muted-foreground hover:text-primary-foresoft hover:border-primary-foresoft flex h-full min-h-[6.5rem] flex-col items-center justify-center gap-1 border-2 border-dashed bg-transparent p-4 shadow-none hover:bg-transparent hover:shadow-none">
+			<Card className="border-lc-3 text-muted-foreground hover:text-primary-foresoft hover:border-primary-foresoft flex h-full min-h-[6.5rem] flex-col items-center justify-center gap-1 border-2 border-dashed bg-transparent p-4 shadow-none hover:bg-transparent hover:shadow-none">
 				<span className="text-2xl leading-none">+</span>
 				<span className="text-xs font-medium">Start a new deck</span>
 			</Card>

--- a/src/routes/_user/learn/-review-banner.tsx
+++ b/src/routes/_user/learn/-review-banner.tsx
@@ -22,7 +22,7 @@ export function ReviewBanner({
 		<div
 			data-testid="review-ready-banner"
 			data-key={focus.lang}
-			className="bg-lc-1 bg-chroma-mlo bg-hue-info border-lc-2 border-chroma-lo border-hue-info border-s-6-mhi-primary @container relative overflow-hidden rounded-lg border border-s-4 p-4 shadow-sm @md:p-5"
+			className="hue-info bg-lc-1 bg-chroma-mlo border-lc-2 border-s-6-mhi-primary @container relative overflow-hidden rounded-lg border border-s-4 p-4 shadow-sm @md:p-5"
 		>
 			<div className="flex flex-col items-start gap-4 @md:flex-row @md:items-center @md:justify-between">
 				<div className="flex items-center gap-4">

--- a/src/routes/_user/profile/-avatar-editor-field.tsx
+++ b/src/routes/_user/profile/-avatar-editor-field.tsx
@@ -30,7 +30,7 @@ export function AvatarEditorField() {
 			<div className="flex flex-col gap-2">
 				<Label
 					htmlFor="avatarUploadInput"
-					className="group border-lc-3 border-chroma-mlo border-hue-primary hover:border-primary hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary relative isolate flex h-40 flex-col items-center rounded-2xl border text-center"
+					className="group border-lc-3 border-chroma-mlo hover:border-primary hover:bg-lc-1 hover:bg-chroma-mlo relative isolate flex h-40 flex-col items-center rounded-2xl border text-center"
 				>
 					{!url ? null : (
 						<div className="z-10 mx-auto my-2 grid aspect-square size-36">

--- a/src/routes/_user/profile/index.tsx
+++ b/src/routes/_user/profile/index.tsx
@@ -111,7 +111,7 @@ function SignOutSection() {
 		<div className="flex justify-end pt-2">
 			<Button
 				variant="ghost"
-				className="text-lc-7 text-chroma-mhi text-hue-danger hover:text-lc-7 hover:text-chroma-hi hover:text-hue-danger"
+				className="hue-danger hover:hue-danger text-lc-7 text-chroma-mhi hover:text-lc-7 hover:text-chroma-hi"
 				onClick={() => signOut.mutate()}
 				data-testid="profile-signout-button"
 				disabled={signOut.isPending}

--- a/src/routes/_user/welcome.tsx
+++ b/src/routes/_user/welcome.tsx
@@ -88,7 +88,7 @@ function WelcomePage() {
 
 			{/* Welcome Header */}
 			<header className="space-y-4 text-center">
-				<div className="from-lc-2 from-chroma-mlo from-hue-primary to-lc-0 to-chroma-lo to-hue-primary mx-auto flex size-20 items-center justify-center rounded-full bg-gradient-to-br">
+				<div className="from-lc-2 from-chroma-mlo to-lc-0 to-chroma-lo mx-auto flex size-20 items-center justify-center rounded-full bg-gradient-to-br">
 					<Sparkles className="text-primary size-10" />
 				</div>
 				<div>
@@ -280,7 +280,7 @@ function FeatureItem({
 }) {
 	return (
 		<div className="flex gap-3">
-			<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary text-primary flex size-10 shrink-0 items-center justify-center rounded-full">
+			<div className="bg-lc-1 bg-chroma-mlo text-primary flex size-10 shrink-0 items-center justify-center rounded-full">
 				<Icon className="size-5" />
 			</div>
 			<div>
@@ -328,8 +328,7 @@ function ActionCard({
 		<Card
 			className={cn(
 				'transition-shadow hover:shadow-md',
-				isPrimary &&
-					'border-lc-4 border-chroma-mlo border-hue-primary bg-lc-0 bg-chroma-lo bg-hue-primary'
+				isPrimary && 'border-lc-4 border-chroma-mlo bg-lc-0'
 			)}
 		>
 			<CardHeader className="pb-2">
@@ -410,9 +409,9 @@ function BrowseRequestsDialog({
 							key={lang.lang}
 							type="button"
 							onClick={() => handleLang(lang.lang)}
-							className="bg-card hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-primary flex flex-col gap-2 rounded-lg border p-4 text-start transition-colors"
+							className="bg-card hover:bg-lc-1 flex flex-col gap-2 rounded-lg border p-4 text-start transition-colors"
 						>
-							<span className="from-lc-5 from-chroma-mhi from-hue-primary to-lc-6 to-chroma-mid to-hue-primary text-primary-foreground inline-flex w-fit items-center justify-center rounded-md bg-gradient-to-br px-2.5 py-1 font-mono text-sm font-semibold tracking-wider uppercase shadow-xs">
+							<span className="from-lc-5 from-chroma-mhi to-lc-6 text-primary-foreground inline-flex w-fit items-center justify-center rounded-md bg-gradient-to-br px-2.5 py-1 font-mono text-sm font-semibold tracking-wider uppercase shadow-xs">
 								{lang.lang.toUpperCase()}
 							</span>
 							<span className="text-sm leading-tight font-semibold">
@@ -429,7 +428,7 @@ function BrowseRequestsDialog({
 						trigger={
 							<button
 								type="button"
-								className="bg-card hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-primary flex flex-col gap-2 rounded-lg border border-dashed p-4 text-start transition-colors"
+								className="bg-card hover:bg-lc-1 flex flex-col gap-2 rounded-lg border border-dashed p-4 text-start transition-colors"
 							>
 								<span className="bg-muted text-muted-foreground inline-flex w-fit items-center justify-center rounded-md px-2.5 py-1">
 									<List className="size-4" />

--- a/src/routes/chats.index.lazy.tsx
+++ b/src/routes/chats.index.lazy.tsx
@@ -59,7 +59,7 @@ function ChatsIndexPage() {
 									params: { lang: language.lang },
 								})
 							}}
-							className="bg-card/50 hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary block w-full rounded border p-3 text-left text-sm"
+							className="bg-card/50 hover:bg-lc-1 hover:bg-chroma-mlo block w-full rounded border p-3 text-left text-sm"
 						>
 							<div className="font-medium">{language.name}</div>
 							<div className="text-muted-foreground font-mono text-xs uppercase">
@@ -75,7 +75,7 @@ function ChatsIndexPage() {
 							type="button"
 							data-testid="chats-search-trigger"
 							onClick={() => setSearchOpen(true)}
-							className="bg-lc-1 bg-chroma-lo bg-hue-primary hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary text-foresoft-primary flex w-full flex-col gap-1 rounded border border-dashed p-3 text-left text-sm"
+							className="bg-lc-1 hover:bg-lc-1 hover:bg-chroma-mlo text-foresoft-primary flex w-full flex-col gap-1 rounded border border-dashed p-3 text-left text-sm"
 						>
 							<div className="flex items-center gap-2 font-medium">
 								<Search className="h-4 w-4" />

--- a/src/routes/fsrs.lazy.tsx
+++ b/src/routes/fsrs.lazy.tsx
@@ -250,7 +250,7 @@ function ForgettingCurveChart({
 						x2={PAD.left + PLOT.w}
 						y1={toY(r)}
 						y2={toY(r)}
-						className="text-lc-2 text-chroma-lo text-hue-neutral"
+						className="hue-neutral text-lc-2"
 						stroke="currentColor"
 						strokeWidth={1}
 					/>
@@ -273,7 +273,7 @@ function ForgettingCurveChart({
 						x2={toX(s.endDay)}
 						y1={PAD.top}
 						y2={PAD.top + PLOT.h}
-						className="text-lc-1 text-chroma-lo text-hue-neutral"
+						className="hue-neutral text-lc-1"
 						stroke="currentColor"
 						strokeWidth={1}
 					/>
@@ -306,7 +306,7 @@ function ForgettingCurveChart({
 						key={`tail-${s.index}`}
 						d={buildPath(pts)}
 						fill="none"
-						className="text-lc-3 text-chroma-mlo text-hue-accent"
+						className="hue-accent text-lc-3 text-chroma-mlo"
 						stroke="currentColor"
 						strokeWidth={1.5}
 					/>
@@ -600,7 +600,7 @@ function FsrsPage() {
 														'flex-1 rounded-2xl border px-1 py-1 text-xs transition-colors',
 														r.score === opt
 															? `${SCORE_META[opt].activeBtn} font-medium`
-															: 'border-border text-muted-foreground hover:bg-lc-1 hover:bg-chroma-lo hover:bg-hue-neutral'
+															: 'hover:hue-neutral border-border text-muted-foreground hover:bg-lc-1'
 													)}
 												>
 													{SCORE_META[opt].label}
@@ -612,7 +612,7 @@ function FsrsPage() {
 											onClick={() => removeReview(r.id)}
 											aria-label={`Remove review ${i}`}
 											disabled={reviews.length <= 1}
-											className="text-muted-foreground hover:text-lc-5 hover:text-chroma-hi hover:text-hue-danger disabled:opacity-40"
+											className="hover:hue-danger text-muted-foreground hover:text-lc-5 hover:text-chroma-hi disabled:opacity-40"
 										>
 											<X className="size-4" />
 										</button>

--- a/src/routes/themes.index.lazy.tsx
+++ b/src/routes/themes.index.lazy.tsx
@@ -280,7 +280,7 @@ function ShowcaseRequestThread() {
 	return (
 		<div className="space-y-4" data-testid="showcase-request">
 			<CardlikeRequest>
-				<CardHeader className="border-lc-2 border-chroma-lo border-hue-primary py-3 @md:py-6">
+				<CardHeader className="border-lc-2 py-3 @md:py-6">
 					<div className="flex flex-row items-center justify-between gap-2">
 						<Byline
 							initials="PL"
@@ -432,7 +432,7 @@ function ShowcaseDeckDialog() {
 			</div>
 
 			<div className="grid grid-cols-1 gap-3 @sm:grid-cols-2">
-				<div className="from-lc-5 from-chroma-mhi from-hue-primary to-lc-6 to-chroma-mid to-hue-primary text-primary-foreground flex h-full flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 shadow">
+				<div className="from-lc-5 from-chroma-mhi to-lc-6 text-primary-foreground flex h-full flex-col items-start gap-2 rounded-2xl bg-gradient-to-br p-4 shadow">
 					<Rocket className="size-6" />
 					<div>
 						<div className="text-base leading-tight font-semibold">
@@ -443,7 +443,7 @@ function ShowcaseDeckDialog() {
 						</div>
 					</div>
 				</div>
-				<div className="border-lc-2 border-chroma-lo border-hue-primary bg-lc-1 bg-chroma-mlo bg-hue-primary text-primary-foresoft flex h-full flex-col items-start gap-2 rounded-2xl border p-4 shadow">
+				<div className="border-lc-2 bg-lc-1 bg-chroma-mlo text-primary-foresoft flex h-full flex-col items-start gap-2 rounded-2xl border p-4 shadow">
 					<Logs className="size-6" />
 					<div>
 						<div className="text-base leading-tight font-semibold">
@@ -645,10 +645,10 @@ const cardStatusShowcaseStates: Array<{
 	soft?: boolean
 }> = [
 	{ choice: 'active', dot: 'bg-primary', soft: true },
-	{ choice: 'learned', dot: 'bg-lc-5 bg-chroma-hi bg-hue-success' },
-	{ choice: 'skipped', dot: 'bg-lc-4 bg-chroma-lo bg-hue-neutral' },
-	{ choice: 'nocard', dot: 'bg-lc-3 bg-chroma-lo bg-hue-neutral' },
-	{ choice: 'nodeck', dot: 'bg-lc-3 bg-chroma-lo bg-hue-neutral' },
+	{ choice: 'learned', dot: 'hue-success bg-lc-5 bg-chroma-hi' },
+	{ choice: 'skipped', dot: 'hue-neutral bg-lc-4' },
+	{ choice: 'nocard', dot: 'hue-neutral bg-lc-3' },
+	{ choice: 'nodeck', dot: 'hue-neutral bg-lc-3' },
 ]
 
 function CardStatusMenuItem({ choice }: { choice: ShowableActions }) {
@@ -1170,7 +1170,7 @@ function ProfilePill({
 }) {
 	return (
 		<div className="flex w-full flex-row items-center gap-4">
-			<div className="hover:bg-lc-1 hover:bg-chroma-mlo hover:bg-hue-primary hover:border-lc-2 hover:border-chroma-mlo hover:border-hue-primary flex grow flex-row items-center justify-start gap-4 rounded-2xl border border-transparent p-2">
+			<div className="hover:bg-lc-1 hover:bg-chroma-mlo hover:border-lc-2 hover:border-chroma-mlo flex grow flex-row items-center justify-start gap-4 rounded-2xl border border-transparent p-2">
 				<Avatar className="size-8">
 					<AvatarFallback seed={seed} className="text-xs font-bold">
 						{username.slice(0, 2).toUpperCase()}
@@ -1234,7 +1234,7 @@ function ShowcaseProfilePills() {
 function ShowcaseIntroCallout() {
 	return (
 		<div className="space-y-2">
-			<div className="border-lc-3 border-chroma-mlo border-hue-primary bg-lc-1 bg-chroma-mlo bg-hue-primary flex items-start gap-2 rounded border px-3 py-2 text-sm">
+			<div className="border-lc-3 border-chroma-mlo bg-lc-1 bg-chroma-mlo flex items-start gap-2 rounded border px-3 py-2 text-sm">
 				<Info className="text-primary mt-0.5 size-4 shrink-0" />
 				<div className="flex-1">
 					<span className="text-foreground/80">
@@ -1246,7 +1246,7 @@ function ShowcaseIntroCallout() {
 					</button>
 				</div>
 			</div>
-			<div className="border-lc-3 border-chroma-mlo border-hue-primary bg-lc-1 bg-chroma-mlo bg-hue-primary flex items-start gap-2 rounded border px-3 py-2 text-sm">
+			<div className="border-lc-3 border-chroma-mlo bg-lc-1 bg-chroma-mlo flex items-start gap-2 rounded border px-3 py-2 text-sm">
 				<Info className="text-primary mt-0.5 size-4 shrink-0" />
 				<div className="flex-1">
 					<span className="text-foreground/80">
@@ -1569,7 +1569,7 @@ function ThemesPage() {
 								)}
 								style={{ '--hue-primary': s.hue } as CSSProperties}
 							>
-								<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary h-10 w-full rounded" />
+								<div className="bg-lc-1 bg-chroma-mlo h-10 w-full rounded" />
 								<span className="flex flex-col items-center text-center leading-tight">
 									<span
 										className={cn(

--- a/src/routes/themes.typography.lazy.tsx
+++ b/src/routes/themes.typography.lazy.tsx
@@ -59,7 +59,7 @@ function SampleBlock({
 
 	return (
 		<Card className="overflow-hidden">
-			<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary border-b px-4 py-2">
+			<div className="bg-lc-1 bg-chroma-mlo border-b px-4 py-2">
 				<div className="flex items-center justify-between">
 					<p className="text-sm font-medium">{label}</p>
 					<p className="text-muted-foreground text-xs">
@@ -69,9 +69,9 @@ function SampleBlock({
 			</div>
 			<CardContent className="space-y-5 p-5" style={baseStyle}>
 				{/* Request-card replica */}
-				<div className="bg-lc-1 bg-chroma-mlo bg-hue-primary rounded-2xl border p-4">
+				<div className="bg-lc-1 bg-chroma-mlo rounded-2xl border p-4">
 					<div className="flex items-start gap-3">
-						<div className="bg-lc-3 bg-chroma-mid bg-hue-primary text-primary-foreground flex size-10 shrink-0 items-center justify-center rounded-full text-sm">
+						<div className="bg-lc-3 bg-chroma-mid text-primary-foreground flex size-10 shrink-0 items-center justify-center rounded-full text-sm">
 							Y
 						</div>
 						<div className="flex-1">
@@ -85,7 +85,7 @@ function SampleBlock({
 					<p className="mt-3">
 						hey, i&apos;m introducing my friend to coworkers, how do i say:
 					</p>
-					<blockquote className="bg-lc-2 bg-chroma-mid bg-hue-primary mt-3 rounded-md border-s-4 px-4 py-3 italic">
+					<blockquote className="bg-lc-2 bg-chroma-mid mt-3 rounded-md border-s-4 px-4 py-3 italic">
 						<span style={boldStyle}>This is maria</span> hello
 					</blockquote>
 					<p className="mt-3">i want to be informal but polite.</p>


### PR DESCRIPTION
An intentionally **aggressive** experiment: how few color classes can the UI run on, and what does it look like when we deliberately simplify the colorspace? Scripted, then compiled + typechecked + built clean. **Draft — expect to pull some of it back.**

## What it does
Removed **294 axis classes (~36%)**, exploiting two facts about the vendored system:
1. `:root` already seeds every axis to `hue-primary` + low chroma, so any `{prop}-hue-primary` / default-chroma class is a pure restatement.
2. All hue resolves through `var(--hue-*)`, so dropping an explicit `hue-primary` is identical even under per-language theming (the inline `--hue-*` override still flows through).

Three rules:
- **Drop default axes**: `{prop}-hue-primary` (all props) and default chroma (`chroma-lo` on bg/text/border/border-b, `chroma-mid` on from/to).
- **Unify hue**: an element using exactly one non-primary hue collapses to a single `hue-<x>` seeder; its per-property hue classes disappear. (2+ distinct non-primary hues → left per-property.)
- **Orphan guard**: a property never loses its last rendering class; luminance is always kept.

Introduced 70 seeders: `hue-neutral` ×31, `hue-success` ×11, `hue-accent` ×10, `hue-info` ×9, `hue-danger` ×5, `hue-warning` ×4.

## Where to look hard (the deliberately bold bits)
- **Hue clobbers**: elements that carried a *minority* accent hue alongside primary now adopt the component's single non-primary hue. If something should've stayed two-toned, that's a pull-back.
- **Ancestor inheritance**: elements that explicitly said `hue-primary` inside a non-primary seeded subtree (e.g. a `hue-danger` callout) now inherit the ancestor's hue.
- **Lang-themed routes**: anything that dropped `hue-primary` now takes the page's language hue — should be a *more* cohesive monochrome, but verify CTAs/badges still read right.
- **Button** `default`/`soft`/`red` kept their explicit seeders on purpose (load-bearing for the shared `solids`/`softs`).

Kept chroma variation per-property (didn't flatten saturation) — that felt like a step too far, but say the word and I'll try it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdrsNCcNMbQC4TbYHaeGsU

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdrsNCcNMbQC4TbYHaeGsU)_