### PR TITLE
Validate inline phrase form on mount

### DIFF
--- a/src/components/phrases/inline-phrase-creator.tsx
+++ b/src/components/phrases/inline-phrase-creator.tsx
@@ -168,7 +168,7 @@ function InlinePhraseForm({
 			translation_lang: defaultTranslationLang,
 			only_reverse: false,
 		},
-		validators: { onChange: schema },
+		validators: { onMount: schema, onChange: schema },
 		onSubmit: async ({ value }) => {
 			await submitPhrase(value)
 			onCancel()


### PR DESCRIPTION
## Summary
Add form validation on mount to the inline phrase creator, ensuring validation errors are displayed immediately when the form is rendered.

## Changes
- Added `onMount: schema` to the form validators configuration alongside the existing `onChange: schema` validator
- This ensures the form validates its initial state when mounted, catching any validation issues before user interaction

## Implementation Details
The change leverages TanStack Form's validator lifecycle to run schema validation both on component mount and on field changes. This provides immediate feedback to users about any validation issues with the default form values, improving the user experience when the form is first displayed.

https://claude.ai/code/session_01NJDHQVqzGBxy4Ygu4FGdRT