### PR TITLE
Migrate playlist phrase-link + deck-add mutations to collection ops (#625)

### DIFF
--- a/scenetest/TEST_IDS.md
+++ b/scenetest/TEST_IDS.md
@@ -294,6 +294,8 @@ natural wrapper element to label.
 | `remove-phrase-button`       | data-name   | Manage dialog      | Remove phrase button                                                                           |
 | `move-phrase-up-button`      | data-name   | Manage dialog      | Reorder up button                                                                              |
 | `move-phrase-down-button`    | data-name   | Manage dialog      | Reorder down button                                                                            |
+| `link-href-input`            | data-name   | Manage dialog      | Per-phrase timestamp-link input (carries `data-key={link.id}`; saves on blur)                  |
+| `link-href-error`            | data-name   | Manage dialog      | Inline validation error for an invalid timestamp link (`data-key={link.id}`)                   |
 | `bulk-add-playlist-to-deck`  | data-testid | Playlist page      | Add all not-yet-in-deck playlist phrases to the learner's deck                                 |
 
 ## Feed

--- a/scenetest/TEST_IDS.md
+++ b/scenetest/TEST_IDS.md
@@ -276,22 +276,25 @@ natural wrapper element to label.
 
 ## Playlists
 
-| Selector                  | Attribute   | Component/Location | Description                                                                                    |
-| ------------------------- | ----------- | ------------------ | ---------------------------------------------------------------------------------------------- |
-| `playlist-detail-page`    | data-testid | Playlist route     | Playlist detail container                                                                      |
-| `update-playlist-button`  | data-testid | Playlist page      | Edit button (owner only)                                                                       |
-| `edit-playlist-dialog`    | data-testid | Dialog             | Edit playlist dialog (scopes `edit-playlist-form`)                                             |
-| `edit-playlist-form`      | data-testid | Edit dialog        | Form element (scope `title-input`, `description-input`, `href-input`, `submit-button` by this) |
-| `delete-playlist-button`  | data-testid | Playlist page      | Delete button (owner only)                                                                     |
-| `delete-playlist-dialog`  | data-testid | Dialog             | Delete confirmation                                                                            |
-| `manage-phrases-button`   | data-testid | Playlist page      | Manage phrases button (owner only)                                                             |
-| `manage-phrases-dialog`   | data-testid | Dialog             | Manage phrases dialog                                                                          |
-| `add-phrases-button`      | data-testid | Manage dialog      | Button to add phrases                                                                          |
-| `phrase-search-input`     | data-testid | Add phrases        | Search input                                                                                   |
-| `phrase-checkbox`         | data-testid | Add phrases        | Checkbox for phrase selection                                                                  |
-| `add-flashcard-button`    | data-testid | Add phrases        | Confirm add button                                                                             |
-| `remove-phrase-button`    | data-testid | Manage dialog      | Remove phrase button                                                                           |
-| `move-phrase-down-button` | data-testid | Manage dialog      | Reorder down button                                                                            |
+| Selector                     | Attribute   | Component/Location | Description                                                                                    |
+| ---------------------------- | ----------- | ------------------ | ---------------------------------------------------------------------------------------------- |
+| `playlist-detail-page`       | data-testid | Playlist route     | Playlist detail container                                                                      |
+| `update-playlist-button`     | data-testid | Playlist page      | Edit button (owner only)                                                                       |
+| `edit-playlist-dialog`       | data-testid | Dialog             | Edit playlist dialog (scopes `edit-playlist-form`)                                             |
+| `edit-playlist-form`         | data-testid | Edit dialog        | Form element (scope `title-input`, `description-input`, `href-input`, `submit-button` by this) |
+| `delete-playlist-button`     | data-testid | Playlist page      | Delete button (owner only)                                                                     |
+| `delete-playlist-dialog`     | data-testid | Dialog             | Delete confirmation                                                                            |
+| `manage-phrases-button`      | data-testid | Playlist page      | Manage phrases button (owner only)                                                             |
+| `manage-phrases-dialog`      | data-testid | Dialog             | Manage phrases dialog                                                                          |
+| `manage-phrase-card`         | data-testid | Manage dialog      | One phrase row in the manage dialog                                                            |
+| `create-phrase-for-playlist` | data-testid | Manage dialog      | Reveal the inline creator to add a brand-new phrase                                            |
+| `open-phrase-picker`         | data-testid | Manage dialog      | "Add existing phrases" trigger (opens the phrase picker dialog)                                |
+| `phrase-search-input`        | data-testid | Phrase picker      | Search input in the picker dialog                                                              |
+| `phrase-picker-item`         | data-name   | Phrase picker      | A selectable phrase in the picker (carries `data-key={phrase.id}`)                             |
+| `remove-phrase-button`       | data-name   | Manage dialog      | Remove phrase button                                                                           |
+| `move-phrase-up-button`      | data-name   | Manage dialog      | Reorder up button                                                                              |
+| `move-phrase-down-button`    | data-name   | Manage dialog      | Reorder down button                                                                            |
+| `bulk-add-playlist-to-deck`  | data-testid | Playlist page      | Add all not-yet-in-deck playlist phrases to the learner's deck                                 |
 
 ## Feed
 

--- a/scenetest/scenes/playlist-mutations.spec.ts
+++ b/scenetest/scenes/playlist-mutations.spec.ts
@@ -315,8 +315,9 @@ test('learner reorders phrases in their playlist', async ({ actor, team }) => {
 			.click('manage-phrases-button')
 			.up()
 			.see('manage-phrases-dialog')
-			// First card (Alpha, order 1) moves down, swapping orders with Beta.
-			.click('move-phrase-down-button')
+			// Two cards render two down-buttons; #1 is the first card (Alpha,
+			// order 1), which swaps orders with Beta when moved down.
+			.click('move-phrase-down-button #1')
 			.up()
 
 		// Reorder has no success toast, so wait for the swapped orders to persist.

--- a/scenetest/scenes/playlist-mutations.spec.ts
+++ b/scenetest/scenes/playlist-mutations.spec.ts
@@ -424,3 +424,160 @@ test('learner bulk-adds playlist phrases to their deck', async ({
 			await supabase.from('phrase').delete().in('id', phraseIds)
 	}
 })
+
+test('learner sets a timestamp link on a playlist phrase', async ({
+	actor,
+	team,
+}) => {
+	const lang = team.tags!.lang_full
+	const learner = await actor('learner')
+	const nonce = Date.now().toString(36)
+	const title = `Playlist for href ${nonce}`
+	const url = `https://youtu.be/${nonce}?t=42`
+	let playlistId = ''
+	let phraseId = ''
+	let linkId = ''
+
+	try {
+		const { data: playlist } = await supabase
+			.from('phrase_playlist')
+			.insert({ lang, title, uid: learner.key })
+			.select()
+			.single()
+			.throwOnError()
+		playlistId = playlist!.id
+		const { data: phrase } = await supabase
+			.from('phrase')
+			.insert({ lang, text: `Href phrase ${nonce}`, added_by: learner.key })
+			.select()
+			.single()
+			.throwOnError()
+		phraseId = phrase!.id
+		const { data: link } = await supabase
+			.from('playlist_phrase_link')
+			.insert({
+				playlist_id: playlistId,
+				phrase_id: phraseId,
+				uid: learner.key,
+				order: 1,
+			})
+			.select()
+			.single()
+			.throwOnError()
+		linkId = link!.id
+
+		await learner
+			.openTo('/login')
+			.typeInto('email-input', learner.email!)
+			.typeInto('password-input', learner.password!)
+			.click('submit-button')
+			.notSee('login-form')
+			.openTo(`/learn/${lang}/playlists/${playlistId}`)
+			.up()
+			.see('playlist-detail-page')
+			.click('manage-phrases-button')
+			.up()
+			.see('manage-phrases-dialog')
+			.typeInto('link-href-input', url)
+			// The field saves on blur; clicking the dialog body moves focus off it.
+			.click('manage-phrases-dialog')
+			.up()
+
+		const saved = await pollUntil(async () => {
+			const { data } = await supabase
+				.from('playlist_phrase_link')
+				.select('href')
+				.eq('id', linkId)
+				.single()
+			return data?.href === url
+		})
+		assert.ok(saved, 'the timestamp link should persist on the phrase link')
+	} finally {
+		if (playlistId) {
+			await supabase
+				.from('playlist_phrase_link')
+				.delete()
+				.eq('playlist_id', playlistId)
+			await supabase.from('phrase_playlist').delete().eq('id', playlistId)
+		}
+		if (phraseId) await supabase.from('phrase').delete().eq('id', phraseId)
+	}
+})
+
+test('an invalid timestamp link is rejected and not saved', async ({
+	actor,
+	team,
+}) => {
+	const lang = team.tags!.lang_full
+	const learner = await actor('learner')
+	const nonce = Date.now().toString(36)
+	const title = `Playlist for bad href ${nonce}`
+	let playlistId = ''
+	let phraseId = ''
+	let linkId = ''
+
+	try {
+		const { data: playlist } = await supabase
+			.from('phrase_playlist')
+			.insert({ lang, title, uid: learner.key })
+			.select()
+			.single()
+			.throwOnError()
+		playlistId = playlist!.id
+		const { data: phrase } = await supabase
+			.from('phrase')
+			.insert({ lang, text: `Bad href phrase ${nonce}`, added_by: learner.key })
+			.select()
+			.single()
+			.throwOnError()
+		phraseId = phrase!.id
+		const { data: link } = await supabase
+			.from('playlist_phrase_link')
+			.insert({
+				playlist_id: playlistId,
+				phrase_id: phraseId,
+				uid: learner.key,
+				order: 1,
+			})
+			.select()
+			.single()
+			.throwOnError()
+		linkId = link!.id
+
+		await learner
+			.openTo('/login')
+			.typeInto('email-input', learner.email!)
+			.typeInto('password-input', learner.password!)
+			.click('submit-button')
+			.notSee('login-form')
+			.openTo(`/learn/${lang}/playlists/${playlistId}`)
+			.up()
+			.see('playlist-detail-page')
+			.click('manage-phrases-button')
+			.up()
+			.see('manage-phrases-dialog')
+			.typeInto('link-href-input', 'not a url')
+			.click('manage-phrases-dialog')
+			.up()
+			// Validation runs synchronously on blur, before any save — the visible
+			// error proves onSave never fired.
+			.see('link-href-error')
+
+		const { data } = await supabase
+			.from('playlist_phrase_link')
+			.select('href')
+			.eq('id', linkId)
+			.single()
+			.throwOnError()
+		assert.equal(data?.href, null, 'an invalid URL must not be persisted')
+	} finally {
+		if (playlistId) {
+			await supabase
+				.from('playlist_phrase_link')
+				.delete()
+				.eq('playlist_id', playlistId)
+			await supabase.from('phrase_playlist').delete().eq('id', playlistId)
+		}
+		if (phraseId) await supabase.from('phrase').delete().eq('id', phraseId)
+	}
+})

--- a/scenetest/scenes/playlist-mutations.spec.ts
+++ b/scenetest/scenes/playlist-mutations.spec.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert/strict'
 import { test } from '@scenetest/scenes'
 import { createClient } from '@supabase/supabase-js'
 import type { Database } from '../../src/types/supabase'
@@ -6,6 +7,24 @@ const supabase = createClient<Database>(
 	process.env.VITE_SUPABASE_URL ?? 'http://127.0.0.1:54321',
 	process.env.SUPABASE_SERVICE_ROLE_KEY!
 )
+
+// Poll a predicate until it holds. Optimistic mutations without a success toast
+// (reorder, bulk-add-to-deck) have no UI signal for server-write completion, so
+// we wait for the persisted row rather than asserting on a fixed delay.
+async function pollUntil(
+	fn: () => Promise<boolean>,
+	{ timeoutMs = 8000, intervalMs = 150 } = {}
+): Promise<boolean> {
+	const start = Date.now()
+	// Sequential by design — each tick must observe the previous result.
+	/* eslint-disable no-await-in-loop */
+	while (Date.now() - start < timeoutMs) {
+		if (await fn()) return true
+		await new Promise((r) => setTimeout(r, intervalMs))
+	}
+	/* eslint-enable no-await-in-loop */
+	return false
+}
 
 test('learner deletes their playlist', async ({ actor, team }) => {
 	const lang = team.tags!.lang_full
@@ -85,5 +104,323 @@ test('a non-owner sees no owner controls on a playlist', async ({
 	} finally {
 		if (playlistId)
 			await supabase.from('phrase_playlist').delete().eq('id', playlistId)
+	}
+})
+
+test('learner adds an existing phrase to their playlist', async ({
+	actor,
+	team,
+}) => {
+	const lang = team.tags!.lang_full
+	const learner = await actor('learner')
+	const nonce = Date.now().toString(36)
+	const title = `Playlist for add ${nonce}`
+	const phraseText = `Addable phrase ${nonce}`
+	let playlistId = ''
+	let phraseId = ''
+
+	try {
+		const { data: playlist } = await supabase
+			.from('phrase_playlist')
+			.insert({ lang, title, uid: learner.key })
+			.select()
+			.single()
+			.throwOnError()
+		playlistId = playlist!.id
+		const { data: phrase } = await supabase
+			.from('phrase')
+			.insert({ lang, text: phraseText, added_by: learner.key })
+			.select()
+			.single()
+			.throwOnError()
+		phraseId = phrase!.id
+
+		await learner
+			.openTo('/login')
+			.typeInto('email-input', learner.email!)
+			.typeInto('password-input', learner.password!)
+			.click('submit-button')
+			.notSee('login-form')
+			.openTo(`/learn/${lang}/playlists/${playlistId}`)
+			.up()
+			.see('playlist-detail-page')
+			.click('manage-phrases-button')
+			.up()
+			.see('manage-phrases-dialog')
+			.click('open-phrase-picker')
+			.up()
+			.typeInto('phrase-search-input', phraseText)
+			.up()
+			.click('phrase-picker-item')
+			.up()
+			.seeToast('toast-success')
+
+		const { data: links } = await supabase
+			.from('playlist_phrase_link')
+			.select('phrase_id')
+			.eq('playlist_id', playlistId)
+			.throwOnError()
+		assert.equal(links?.length, 1, 'exactly one phrase link should exist')
+		assert.equal(
+			links![0].phrase_id,
+			phraseId,
+			'the link points at the added phrase'
+		)
+	} finally {
+		if (playlistId) {
+			await supabase
+				.from('playlist_phrase_link')
+				.delete()
+				.eq('playlist_id', playlistId)
+			await supabase.from('phrase_playlist').delete().eq('id', playlistId)
+		}
+		if (phraseId) await supabase.from('phrase').delete().eq('id', phraseId)
+	}
+})
+
+test('learner removes a phrase from their playlist', async ({
+	actor,
+	team,
+}) => {
+	const lang = team.tags!.lang_full
+	const learner = await actor('learner')
+	const nonce = Date.now().toString(36)
+	const title = `Playlist for remove ${nonce}`
+	const phraseText = `Removable phrase ${nonce}`
+	let playlistId = ''
+	let phraseId = ''
+
+	try {
+		const { data: playlist } = await supabase
+			.from('phrase_playlist')
+			.insert({ lang, title, uid: learner.key })
+			.select()
+			.single()
+			.throwOnError()
+		playlistId = playlist!.id
+		const { data: phrase } = await supabase
+			.from('phrase')
+			.insert({ lang, text: phraseText, added_by: learner.key })
+			.select()
+			.single()
+			.throwOnError()
+		phraseId = phrase!.id
+		await supabase
+			.from('playlist_phrase_link')
+			.insert({
+				playlist_id: playlistId,
+				phrase_id: phraseId,
+				uid: learner.key,
+				order: 1,
+			})
+			.throwOnError()
+
+		await learner
+			.openTo('/login')
+			.typeInto('email-input', learner.email!)
+			.typeInto('password-input', learner.password!)
+			.click('submit-button')
+			.notSee('login-form')
+			.openTo(`/learn/${lang}/playlists/${playlistId}`)
+			.up()
+			.see('playlist-detail-page')
+			.click('manage-phrases-button')
+			.up()
+			.see('manage-phrases-dialog')
+			.see('manage-phrase-card')
+			.click('remove-phrase-button')
+			.up()
+			.seeToast('toast-success')
+			.notSee('manage-phrase-card')
+
+		const { data: links } = await supabase
+			.from('playlist_phrase_link')
+			.select('id')
+			.eq('playlist_id', playlistId)
+			.throwOnError()
+		assert.equal(links?.length, 0, 'the link should be deleted')
+	} finally {
+		if (playlistId) {
+			await supabase
+				.from('playlist_phrase_link')
+				.delete()
+				.eq('playlist_id', playlistId)
+			await supabase.from('phrase_playlist').delete().eq('id', playlistId)
+		}
+		if (phraseId) await supabase.from('phrase').delete().eq('id', phraseId)
+	}
+})
+
+test('learner reorders phrases in their playlist', async ({ actor, team }) => {
+	const lang = team.tags!.lang_full
+	const learner = await actor('learner')
+	const nonce = Date.now().toString(36)
+	const title = `Playlist for reorder ${nonce}`
+	let playlistId = ''
+	const phraseIds: Array<string> = []
+
+	try {
+		const { data: playlist } = await supabase
+			.from('phrase_playlist')
+			.insert({ lang, title, uid: learner.key })
+			.select()
+			.single()
+			.throwOnError()
+		playlistId = playlist!.id
+
+		// Alpha at order 1, Beta at order 2. Moving Alpha down should swap them.
+		const { data: phrases } = await supabase
+			.from('phrase')
+			.insert([
+				{ lang, text: `Reorder alpha ${nonce}`, added_by: learner.key },
+				{ lang, text: `Reorder beta ${nonce}`, added_by: learner.key },
+			])
+			.select()
+			.throwOnError()
+		const alpha = phrases!.find((p) => p.text.includes('alpha'))!
+		const beta = phrases!.find((p) => p.text.includes('beta'))!
+		phraseIds.push(alpha.id, beta.id)
+		const { data: seededLinks } = await supabase
+			.from('playlist_phrase_link')
+			.insert([
+				{
+					playlist_id: playlistId,
+					phrase_id: alpha.id,
+					uid: learner.key,
+					order: 1,
+				},
+				{
+					playlist_id: playlistId,
+					phrase_id: beta.id,
+					uid: learner.key,
+					order: 2,
+				},
+			])
+			.select()
+			.throwOnError()
+		const linkIds = {
+			alpha: seededLinks!.find((l) => l.phrase_id === alpha.id)!.id,
+			beta: seededLinks!.find((l) => l.phrase_id === beta.id)!.id,
+		}
+
+		await learner
+			.openTo('/login')
+			.typeInto('email-input', learner.email!)
+			.typeInto('password-input', learner.password!)
+			.click('submit-button')
+			.notSee('login-form')
+			.openTo(`/learn/${lang}/playlists/${playlistId}`)
+			.up()
+			.see('playlist-detail-page')
+			.click('manage-phrases-button')
+			.up()
+			.see('manage-phrases-dialog')
+			// First card (Alpha, order 1) moves down, swapping orders with Beta.
+			.click('move-phrase-down-button')
+			.up()
+
+		// Reorder has no success toast, so wait for the swapped orders to persist.
+		const swapped = await pollUntil(async () => {
+			const { data } = await supabase
+				.from('playlist_phrase_link')
+				.select('id, order')
+				.eq('playlist_id', playlistId)
+			const byId = new Map(data?.map((l) => [l.id, l.order]))
+			return byId.get(linkIds.alpha) === 2 && byId.get(linkIds.beta) === 1
+		})
+		assert.ok(swapped, 'Alpha and Beta order values should be swapped')
+	} finally {
+		if (playlistId) {
+			await supabase
+				.from('playlist_phrase_link')
+				.delete()
+				.eq('playlist_id', playlistId)
+			await supabase.from('phrase_playlist').delete().eq('id', playlistId)
+		}
+		if (phraseIds.length)
+			await supabase.from('phrase').delete().in('id', phraseIds)
+	}
+})
+
+test('learner bulk-adds playlist phrases to their deck', async ({
+	actor,
+	team,
+}) => {
+	const lang = team.tags!.lang_full
+	const learner = await actor('learner')
+	const nonce = Date.now().toString(36)
+	const title = `Playlist for deck-add ${nonce}`
+	let playlistId = ''
+	const phraseIds: Array<string> = []
+
+	try {
+		const { data: playlist } = await supabase
+			.from('phrase_playlist')
+			.insert({ lang, title, uid: learner.key })
+			.select()
+			.single()
+			.throwOnError()
+		playlistId = playlist!.id
+
+		const { data: phrases } = await supabase
+			.from('phrase')
+			.insert(
+				[`Deck-add one ${nonce}`, `Deck-add two ${nonce}`].map((text) => ({
+					lang,
+					text,
+					added_by: learner.key,
+				}))
+			)
+			.select()
+			.throwOnError()
+		phraseIds.push(...phrases!.map((p) => p.id))
+		await supabase
+			.from('playlist_phrase_link')
+			.insert(
+				phrases!.map((p, i) => ({
+					playlist_id: playlistId,
+					phrase_id: p.id,
+					uid: learner.key,
+					order: i + 1,
+				}))
+			)
+			.throwOnError()
+
+		// These phrases have no cards yet, so they count as "not in deck" and the
+		// bulk-add button appears (the learner already owns a full-lang deck).
+		await learner
+			.openTo('/login')
+			.typeInto('email-input', learner.email!)
+			.typeInto('password-input', learner.password!)
+			.click('submit-button')
+			.notSee('login-form')
+			.openTo(`/learn/${lang}/playlists/${playlistId}`)
+			.up()
+			.see('playlist-detail-page')
+			.click('bulk-add-playlist-to-deck')
+			.up()
+			.seeToast('toast-success')
+
+		const created = await pollUntil(async () => {
+			const { data } = await supabase
+				.from('user_card')
+				.select('id')
+				.eq('uid', learner.key)
+				.in('phrase_id', phraseIds)
+			return (data?.length ?? 0) >= phraseIds.length
+		})
+		assert.ok(created, 'user_card rows should be created for the added phrases')
+	} finally {
+		if (phraseIds.length) {
+			await supabase.from('user_card').delete().in('phrase_id', phraseIds)
+			await supabase
+				.from('playlist_phrase_link')
+				.delete()
+				.eq('playlist_id', playlistId)
+		}
+		if (playlistId)
+			await supabase.from('phrase_playlist').delete().eq('id', playlistId)
+		if (phraseIds.length)
+			await supabase.from('phrase').delete().in('id', phraseIds)
 	}
 })

--- a/scenetest/scenes/playlist-mutations.spec.ts
+++ b/scenetest/scenes/playlist-mutations.spec.ts
@@ -582,3 +582,194 @@ test('an invalid timestamp link is rejected and not saved', async ({
 		if (phraseId) await supabase.from('phrase').delete().eq('id', phraseId)
 	}
 })
+
+test('bulk-add re-activates a previously-skipped card', async ({
+	actor,
+	team,
+}) => {
+	// Covers addPhrasesToDeck's update branch: a phrase already carrying a
+	// skipped card is flipped back to active rather than inserted.
+	const lang = team.tags!.lang_full
+	const learner = await actor('learner')
+	const nonce = Date.now().toString(36)
+	const title = `Playlist for reactivate ${nonce}`
+	let playlistId = ''
+	let phraseId = ''
+
+	try {
+		const { data: playlist } = await supabase
+			.from('phrase_playlist')
+			.insert({ lang, title, uid: learner.key })
+			.select()
+			.single()
+			.throwOnError()
+		playlistId = playlist!.id
+		const { data: phrase } = await supabase
+			.from('phrase')
+			.insert({
+				lang,
+				text: `Reactivate phrase ${nonce}`,
+				added_by: learner.key,
+			})
+			.select()
+			.single()
+			.throwOnError()
+		phraseId = phrase!.id
+		await supabase
+			.from('playlist_phrase_link')
+			.insert({
+				playlist_id: playlistId,
+				phrase_id: phraseId,
+				uid: learner.key,
+				order: 1,
+			})
+			.throwOnError()
+		// Seed skipped cards for both directions (only_reverse defaults false, so
+		// directionsForPhrase → forward + reverse). Skipped keeps the phrase in
+		// "not in deck" so the bulk-add button appears.
+		await supabase
+			.from('user_card')
+			.insert([
+				{
+					uid: learner.key,
+					phrase_id: phraseId,
+					lang,
+					status: 'skipped',
+					direction: 'forward',
+				},
+				{
+					uid: learner.key,
+					phrase_id: phraseId,
+					lang,
+					status: 'skipped',
+					direction: 'reverse',
+				},
+			])
+			.throwOnError()
+
+		await learner
+			.openTo('/login')
+			.typeInto('email-input', learner.email!)
+			.typeInto('password-input', learner.password!)
+			.click('submit-button')
+			.notSee('login-form')
+			.openTo(`/learn/${lang}/playlists/${playlistId}`)
+			.up()
+			.see('playlist-detail-page')
+			.click('bulk-add-playlist-to-deck')
+			.up()
+
+		const activated = await pollUntil(async () => {
+			const { data } = await supabase
+				.from('user_card')
+				.select('status')
+				.eq('uid', learner.key)
+				.eq('phrase_id', phraseId)
+			return (
+				(data?.length ?? 0) === 2 && data!.every((c) => c.status === 'active')
+			)
+		})
+		assert.ok(activated, 'both skipped cards should flip to active')
+	} finally {
+		if (phraseId)
+			await supabase.from('user_card').delete().eq('phrase_id', phraseId)
+		if (playlistId) {
+			await supabase
+				.from('playlist_phrase_link')
+				.delete()
+				.eq('playlist_id', playlistId)
+			await supabase.from('phrase_playlist').delete().eq('id', playlistId)
+		}
+		if (phraseId) await supabase.from('phrase').delete().eq('id', phraseId)
+	}
+})
+
+test('learner creates and links a new phrase from the playlist page', async ({
+	actor,
+	team,
+}) => {
+	// Covers linkPhrase: the list-item's inline creator makes a phrase and links
+	// it to the playlist in one flow.
+	const lang = team.tags!.lang_full
+	const learner = await actor('learner')
+	const nonce = Date.now().toString(36)
+	const title = `Playlist for create-link ${nonce}`
+	const phraseText = `Created-and-linked ${nonce}`
+	let playlistId = ''
+	let phraseId = ''
+
+	try {
+		const { data: playlist } = await supabase
+			.from('phrase_playlist')
+			.insert({ lang, title, uid: learner.key })
+			.select()
+			.single()
+			.throwOnError()
+		playlistId = playlist!.id
+
+		await learner
+			.openTo('/login')
+			.typeInto('email-input', learner.email!)
+			.typeInto('password-input', learner.password!)
+			.click('submit-button')
+			.notSee('login-form')
+			.openTo(`/learn/${lang}/playlists/${playlistId}`)
+			.up()
+			.see('playlist-detail-page')
+			.click('add-phrase-to-playlist-button')
+			.up()
+			.see('inline-phrase-creator')
+			.typeInto('inline-phrase-creator phrase-text-input', phraseText)
+			.typeInto(
+				'inline-phrase-creator translation-text-input',
+				`translation ${nonce}`
+			)
+			.click('inline-phrase-creator submit-button')
+			.up()
+
+		// linkPhrase persists a playlist_phrase_link pointing at the new phrase.
+		const linked = await pollUntil(async () => {
+			const { data } = await supabase
+				.from('playlist_phrase_link')
+				.select('phrase_id')
+				.eq('playlist_id', playlistId)
+			return (data?.length ?? 0) === 1
+		})
+		assert.ok(linked, 'the created phrase should be linked to the playlist')
+
+		const { data: links } = await supabase
+			.from('playlist_phrase_link')
+			.select('phrase_id')
+			.eq('playlist_id', playlistId)
+			.throwOnError()
+		phraseId = links![0].phrase_id
+		const { data: created } = await supabase
+			.from('phrase')
+			.select('text')
+			.eq('id', phraseId)
+			.single()
+			.throwOnError()
+		assert.equal(
+			created?.text,
+			phraseText,
+			'the linked phrase is the one created'
+		)
+	} finally {
+		// The inline creator also makes a translation and (deck present) cards.
+		if (phraseId) {
+			await supabase.from('user_card').delete().eq('phrase_id', phraseId)
+			await supabase
+				.from('phrase_translation')
+				.delete()
+				.eq('phrase_id', phraseId)
+		}
+		if (playlistId) {
+			await supabase
+				.from('playlist_phrase_link')
+				.delete()
+				.eq('playlist_id', playlistId)
+			await supabase.from('phrase_playlist').delete().eq('id', playlistId)
+		}
+		if (phraseId) await supabase.from('phrase').delete().eq('id', phraseId)
+	}
+})

--- a/src/components/playlists/manage-playlist-phrases-dialog.tsx
+++ b/src/components/playlists/manage-playlist-phrases-dialog.tsx
@@ -1,5 +1,4 @@
 import { useRef, useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
 import {
 	ChevronUp,
@@ -21,9 +20,9 @@ import {
 	type PhrasePlaylistType,
 	validateUrl,
 } from '@/features/playlists/schemas'
-import supabase from '@/lib/supabase-client'
 import { playlistPhraseLinksCollection } from '@/features/playlists/collections'
 import { useOnePlaylistPhrases } from '@/features/playlists/hooks'
+import { useUserId } from '@/lib/use-auth'
 import { SelectPhrasesForComment } from '@/components/comments/select-phrases-for-comment'
 import { InlinePhraseCreator } from '@/components/phrases/inline-phrase-creator'
 import { PhraseSummaryLine } from '../feed/feed-phrase-group-item'
@@ -73,6 +72,27 @@ function HrefInput({
 	)
 }
 
+function removePhrase(linkId: string) {
+	const tx = playlistPhraseLinksCollection.delete(linkId)
+	tx.isPersisted.promise.then(
+		() => toastSuccess('Phrase removed from playlist'),
+		(err: unknown) => {
+			const message = err instanceof Error ? err.message : 'unknown error'
+			toastError(`Failed to remove phrase: ${message}`)
+		}
+	)
+}
+
+function updateHref(linkId: string, href: string) {
+	const tx = playlistPhraseLinksCollection.update(linkId, (d) => {
+		d.href = href || null
+	})
+	tx.isPersisted.promise.catch((err: unknown) => {
+		const message = err instanceof Error ? err.message : 'unknown error'
+		toastError(`Failed to update link: ${message}`)
+	})
+}
+
 export function ManagePlaylistPhrasesDialog({
 	playlist,
 }: {
@@ -81,144 +101,63 @@ export function ManagePlaylistPhrasesDialog({
 	const [open, setOpen] = useState(false)
 	const [showCreateForm, setShowCreateForm] = useState(false)
 	const { data: phrasesData } = useOnePlaylistPhrases(playlist.id)
+	const userId = useUserId()
 
 	// Track which phrase IDs are already in the playlist
 	const currentPhraseIds = phrasesData?.map((p) => p.phrase.id) ?? []
 
-	// Add phrase mutation
-	const addPhraseMutation = useMutation({
-		mutationFn: async (phraseId: string) => {
-			// Check if phrase already exists in playlist
-			if (currentPhraseIds.includes(phraseId)) {
-				throw new Error('Phrase already in playlist')
+	const addPhrase = (phraseId: string) => {
+		if (!userId) return
+		if (currentPhraseIds.includes(phraseId)) {
+			toastError('Phrase is already in this playlist')
+			return
+		}
+		const maxOrder = Math.max(
+			...(phrasesData?.map((p) => p.link.order || 0) ?? [0]),
+			0
+		)
+		const tx = playlistPhraseLinksCollection.insert({
+			id: crypto.randomUUID(),
+			uid: userId,
+			playlist_id: playlist.id,
+			phrase_id: phraseId,
+			order: maxOrder + 1,
+			href: null,
+			created_at: new Date().toISOString(),
+		})
+		tx.isPersisted.promise.then(
+			() => toastSuccess('Phrase added to playlist'),
+			(err: unknown) => {
+				const message = err instanceof Error ? err.message : 'unknown error'
+				toastError(`Failed to add phrase: ${message}`)
 			}
+		)
+	}
 
-			// Calculate next order value
-			const maxOrder = Math.max(
-				...(phrasesData?.map((p) => p.link.order || 0) ?? [0]),
-				0
-			)
+	// Swap order values with the adjacent phrase in the requested direction.
+	const reorder = (currentIndex: number, direction: 'up' | 'down') => {
+		if (!phrasesData) return
+		const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1
+		if (targetIndex < 0 || targetIndex >= phrasesData.length) return
 
-			const { data, error } = await supabase
-				.from('playlist_phrase_link')
-				.insert({
-					playlist_id: playlist.id,
-					phrase_id: phraseId,
-					order: maxOrder + 1,
-					href: null,
-				})
-				.select()
-				.single()
+		const currentLink = phrasesData[currentIndex].link
+		const targetLink = phrasesData[targetIndex].link
+		const currentOrder = currentLink.order ?? currentIndex
+		const targetOrder = targetLink.order ?? targetIndex
 
-			if (error) throw error
-			return data
-		},
-		onSuccess: (data) => {
-			playlistPhraseLinksCollection.utils.writeInsert(data)
-			toastSuccess('Phrase added to playlist')
-		},
-		onError: (error: Error) => {
-			if (error.message === 'Phrase already in playlist') {
-				toastError('Phrase is already in this playlist')
-			} else {
-				toastError(`Failed to add phrase: ${error.message}`)
+		const tx1 = playlistPhraseLinksCollection.update(currentLink.id, (d) => {
+			d.order = targetOrder
+		})
+		const tx2 = playlistPhraseLinksCollection.update(targetLink.id, (d) => {
+			d.order = currentOrder
+		})
+		Promise.all([tx1.isPersisted.promise, tx2.isPersisted.promise]).catch(
+			(err: unknown) => {
+				const message = err instanceof Error ? err.message : 'unknown error'
+				toastError(`Failed to reorder: ${message}`)
 			}
-		},
-	})
-
-	// Remove phrase mutation
-	const removePhraseMutation = useMutation({
-		mutationFn: async (linkId: string) => {
-			const { error } = await supabase
-				.from('playlist_phrase_link')
-				.delete()
-				.eq('id', linkId)
-
-			if (error) throw error
-			return linkId
-		},
-		onSuccess: (linkId) => {
-			playlistPhraseLinksCollection.utils.writeDelete(linkId)
-			toastSuccess('Phrase removed from playlist')
-		},
-		onError: (error: Error) => {
-			toastError(`Failed to remove phrase: ${error.message}`)
-		},
-	})
-
-	// Reorder mutation - swap order values with adjacent phrase
-	const reorderMutation = useMutation({
-		mutationFn: async ({
-			currentIndex,
-			direction,
-		}: {
-			currentIndex: number
-			direction: 'up' | 'down'
-		}) => {
-			if (!phrasesData) return
-
-			const targetIndex =
-				direction === 'up' ? currentIndex - 1 : currentIndex + 1
-			if (targetIndex < 0 || targetIndex >= phrasesData.length) return
-
-			const currentLink = phrasesData[currentIndex].link
-			const targetLink = phrasesData[targetIndex].link
-
-			// Swap order values
-			const currentOrder = currentLink.order || currentIndex
-			const targetOrder = targetLink.order || targetIndex
-
-			// Update both links
-			const { error: error1 } = await supabase
-				.from('playlist_phrase_link')
-				.update({ order: targetOrder })
-				.eq('id', currentLink.id)
-
-			if (error1) throw error1
-
-			const { error: error2 } = await supabase
-				.from('playlist_phrase_link')
-				.update({ order: currentOrder })
-				.eq('id', targetLink.id)
-
-			if (error2) throw error2
-
-			// Return updated data
-			return {
-				current: { ...currentLink, order: targetOrder },
-				target: { ...targetLink, order: currentOrder },
-			}
-		},
-		onSuccess: (data) => {
-			if (!data) return
-			playlistPhraseLinksCollection.utils.writeUpdate(data.current)
-			playlistPhraseLinksCollection.utils.writeUpdate(data.target)
-		},
-		onError: (error: Error) => {
-			toastError(`Failed to reorder: ${error.message}`)
-		},
-	})
-
-	// Update href mutation
-	const updateHrefMutation = useMutation({
-		mutationFn: async ({ linkId, href }: { linkId: string; href: string }) => {
-			const { data, error } = await supabase
-				.from('playlist_phrase_link')
-				.update({ href: href || null })
-				.eq('id', linkId)
-				.select()
-				.single()
-
-			if (error) throw error
-			return data
-		},
-		onSuccess: (data) => {
-			playlistPhraseLinksCollection.utils.writeUpdate(data)
-		},
-		onError: (error: Error) => {
-			toastError(`Failed to update link: ${error.message}`)
-		},
-	})
+		)
+	}
 
 	// Handle phrase selection from SelectPhrasesForComment
 	const handleSelectionChange = (phraseIds: string[]) => {
@@ -227,9 +166,8 @@ export function ManagePlaylistPhrasesDialog({
 			(id) => !currentPhraseIds.includes(id)
 		)
 
-		// Add each new phrase
 		for (const phraseId of newPhraseIds) {
-			addPhraseMutation.mutate(phraseId)
+			addPhrase(phraseId)
 		}
 	}
 
@@ -257,7 +195,7 @@ export function ManagePlaylistPhrasesDialog({
 
 				<div className="min-h-0 flex-1 overflow-y-auto pr-4">
 					<div className="space-y-3">
-						{phrasesData && phrasesData.length > 0 ?
+						{phrasesData && phrasesData.length > 0 ? (
 							phrasesData.map((item, index) => (
 								<div
 									key={item.link.id}
@@ -274,13 +212,8 @@ export function ManagePlaylistPhrasesDialog({
 												className="h-6 w-6"
 												aria-label="Move phrase up"
 												data-name="move-phrase-up-button"
-												disabled={index === 0 || reorderMutation.isPending}
-												onClick={() =>
-													reorderMutation.mutate({
-														currentIndex: index,
-														direction: 'up',
-													})
-												}
+												disabled={index === 0}
+												onClick={() => reorder(index, 'up')}
 											>
 												<ChevronUp className="h-4 w-4" />
 											</Button>
@@ -291,16 +224,8 @@ export function ManagePlaylistPhrasesDialog({
 												className="h-6 w-6"
 												aria-label="Move phrase down"
 												data-name="move-phrase-down-button"
-												disabled={
-													index === phrasesData.length - 1 ||
-													reorderMutation.isPending
-												}
-												onClick={() =>
-													reorderMutation.mutate({
-														currentIndex: index,
-														direction: 'down',
-													})
-												}
+												disabled={index === phrasesData.length - 1}
+												onClick={() => reorder(index, 'down')}
 											>
 												<ChevronDown className="h-4 w-4" />
 											</Button>
@@ -314,12 +239,7 @@ export function ManagePlaylistPhrasesDialog({
 											<div className="mt-2">
 												<HrefInput
 													initialValue={item.link.href}
-													onSave={(href) =>
-														updateHrefMutation.mutate({
-															linkId: item.link.id,
-															href,
-														})
-													}
+													onSave={(href) => updateHref(item.link.id, href)}
 												/>
 											</div>
 										</div>
@@ -327,22 +247,22 @@ export function ManagePlaylistPhrasesDialog({
 										{/* Delete button */}
 										<Button
 											type="button"
-											onClick={() => removePhraseMutation.mutate(item.link.id)}
+											onClick={() => removePhrase(item.link.id)}
 											variant="ghost"
 											size="icon"
 											aria-label="Remove phrase"
 											data-name="remove-phrase-button"
-											disabled={removePhraseMutation.isPending}
 										>
 											<Trash2 className="h-4 w-4" />
 										</Button>
 									</div>
 								</div>
 							))
-						:	<p className="text-muted-foreground py-8 text-center">
+						) : (
+							<p className="text-muted-foreground py-8 text-center">
 								No phrases in this playlist yet. Add some below!
 							</p>
-						}
+						)}
 					</div>
 
 					{/* Inline phrase creator */}
@@ -351,7 +271,7 @@ export function ManagePlaylistPhrasesDialog({
 							<InlinePhraseCreator
 								lang={playlist.lang}
 								onPhraseCreated={(phraseId) => {
-									addPhraseMutation.mutate(phraseId)
+									addPhrase(phraseId)
 								}}
 								onCancel={() => setShowCreateForm(false)}
 								submitLabel="Add phrase to playlist"

--- a/src/components/playlists/manage-playlist-phrases-dialog.tsx
+++ b/src/components/playlists/manage-playlist-phrases-dialog.tsx
@@ -31,9 +31,11 @@ import { buttonVariants } from '../ui/button'
 
 /** Controlled href input that validates on blur and only fires the mutation when valid */
 function HrefInput({
+	linkId,
 	initialValue,
 	onSave,
 }: {
+	linkId: string
 	initialValue: string | null
 	onSave: (href: string) => void
 }) {
@@ -59,6 +61,8 @@ function HrefInput({
 					type="url"
 					placeholder="Timestamp link (optional)"
 					value={value}
+					data-name="link-href-input"
+					data-key={linkId}
 					onChange={(e) => {
 						setValue(e.target.value)
 						if (error) setError(validateUrl(e.target.value))
@@ -67,7 +71,15 @@ function HrefInput({
 					className={`h-8 text-sm ${error ? 'border-red-500' : ''}`}
 				/>
 			</div>
-			{error && <p className="ms-8 mt-1 text-xs text-red-500">{error}</p>}
+			{error && (
+				<p
+					className="ms-8 mt-1 text-xs text-red-500"
+					data-name="link-href-error"
+					data-key={linkId}
+				>
+					{error}
+				</p>
+			)}
 		</div>
 	)
 }
@@ -238,6 +250,7 @@ export function ManagePlaylistPhrasesDialog({
 											{/* Href input for timestamp */}
 											<div className="mt-2">
 												<HrefInput
+													linkId={item.link.id}
 													initialValue={item.link.href}
 													onSave={(href) => updateHref(item.link.id, href)}
 												/>

--- a/src/components/playlists/playlist-list-item.tsx
+++ b/src/components/playlists/playlist-list-item.tsx
@@ -1,6 +1,5 @@
 import { useState, type CSSProperties } from 'react'
 import { ExternalLink, Plus, Send, Bookmark } from 'lucide-react'
-import { useMutation } from '@tanstack/react-query'
 import { PhrasePlaylistType } from '@/features/playlists/schemas'
 import { UidPermalink } from '@/components/card-pieces/user-permalink'
 import { Badge, LangBadge } from '@/components/ui/badge'
@@ -19,11 +18,10 @@ import { Button } from '@/components/ui/button'
 import { InlinePhraseCreator } from '@/components/phrases/inline-phrase-creator'
 import { playlistPhraseLinksCollection } from '@/features/playlists/collections'
 import { cardsCollection } from '@/features/deck/collections'
-import { CardMetaSchema } from '@/features/deck/schemas'
+import { type CardMetaType } from '@/features/deck/schemas'
 import { directionsForPhrase } from '@/features/deck/card-directions'
 import { useDecks, useDeckCards, useMyCard } from '@/features/deck/hooks'
 import { useUserId } from '@/lib/use-auth'
-import supabase from '@/lib/supabase-client'
 import { toastSuccess, toastError } from '@/components/ui/sonner'
 
 export function PlaylistItem({
@@ -50,68 +48,91 @@ export function PlaylistItem({
 	const phrasesNotInDeck =
 		data?.filter((item) => !activeCardPhraseIds.has(item.phrase.id)) ?? []
 
-	const bulkAddMutation = useMutation({
-		mutationFn: async (
-			phrases: Array<{ id: string; only_reverse: boolean | null }>
-		) => {
-			const rows = phrases.flatMap((p) =>
-				directionsForPhrase(p.only_reverse).map((direction) => ({
-					lang: playlist.lang,
-					phrase_id: p.id,
-					status: 'active' as const,
-					direction,
-				}))
-			)
-			const { data: inserted } = await supabase
-				.from('user_card')
-				.upsert(rows, { onConflict: 'uid,phrase_id,direction' })
-				.select()
-				.throwOnError()
-			return inserted
-		},
-		onSuccess: (cards: Array<{ [key: string]: unknown }>) => {
-			for (const card of cards) {
-				cardsCollection.utils.writeInsert(CardMetaSchema.parse(card))
+	// Add every not-yet-in-deck phrase's cards to the deck. Phrases with an
+	// existing (skipped) card get flipped back to active; the rest are inserted.
+	// `phrasesNotInDeck` already excludes active/learned, so we never touch those.
+	const addPhrasesToDeck = (
+		phrases: Array<{ id: string; only_reverse: boolean | null }>
+	) => {
+		if (!userId) return
+		const nowIso = new Date().toISOString()
+		const existingByKey = new Map(
+			(langCards ?? []).map((c) => [`${c.phrase_id}:${c.direction}`, c])
+		)
+		const toInsert: Array<CardMetaType> = []
+		const toActivate: Array<string> = []
+		for (const p of phrases) {
+			for (const direction of directionsForPhrase(p.only_reverse)) {
+				const existing = existingByKey.get(`${p.id}:${direction}`)
+				if (existing) {
+					if (existing.status !== 'active') toActivate.push(existing.id)
+				} else {
+					toInsert.push({
+						id: crypto.randomUUID(),
+						uid: userId,
+						phrase_id: p.id,
+						lang: playlist.lang,
+						status: 'active',
+						direction,
+						created_at: nowIso,
+						updated_at: nowIso,
+						last_reviewed_at: null,
+						difficulty: null,
+						stability: null,
+					})
+				}
 			}
-			toastSuccess(
-				`Added ${cards.length} card${cards.length === 1 ? '' : 's'} to your deck`
-			)
-		},
-		onError: (error: Error) => {
-			toastError('Failed to add cards to deck')
-			console.log('Error', error)
-		},
-	})
+		}
+		const count = toInsert.length + toActivate.length
+		if (count === 0) return
 
-	// Mutation to link a newly created phrase to this playlist
-	const linkPhraseMutation = useMutation({
-		mutationFn: async (phraseId: string) => {
-			const maxOrder = Math.max(
-				...(data?.map((p) => p.link.order || 0) ?? [0]),
-				0
+		const promises: Array<Promise<unknown>> = []
+		if (toInsert.length)
+			promises.push(cardsCollection.insert(toInsert).isPersisted.promise)
+		if (toActivate.length)
+			promises.push(
+				cardsCollection.update(toActivate, (drafts) => {
+					drafts.forEach((d) => {
+						d.status = 'active'
+					})
+				}).isPersisted.promise
 			)
-			const { data: linkData, error } = await supabase
-				.from('playlist_phrase_link')
-				.insert({
-					playlist_id: playlist.id,
-					phrase_id: phraseId,
-					order: maxOrder + 1,
-					href: null,
-				})
-				.select()
-				.single()
-			if (error) throw error
-			return linkData
-		},
-		onSuccess: (linkData) => {
-			playlistPhraseLinksCollection.utils.writeInsert(linkData)
-			toastSuccess('Phrase added to playlist')
-		},
-		onError: (error: Error) => {
-			toastError(`Failed to link phrase: ${error.message}`)
-			console.log('Error', error)
-		},
-	})
+		Promise.all(promises).then(
+			() =>
+				toastSuccess(
+					`Added ${count} card${count === 1 ? '' : 's'} to your deck`
+				),
+			(err: unknown) => {
+				toastError('Failed to add cards to deck')
+				console.log('Error', err)
+			}
+		)
+	}
+
+	// Link a newly created phrase to this playlist.
+	const linkPhrase = (phraseId: string) => {
+		if (!userId) return
+		const maxOrder = Math.max(
+			...(data?.map((p) => p.link.order || 0) ?? [0]),
+			0
+		)
+		const tx = playlistPhraseLinksCollection.insert({
+			id: crypto.randomUUID(),
+			uid: userId,
+			playlist_id: playlist.id,
+			phrase_id: phraseId,
+			order: maxOrder + 1,
+			href: null,
+			created_at: new Date().toISOString(),
+		})
+		tx.isPersisted.promise.then(
+			() => toastSuccess('Phrase added to playlist'),
+			(err: unknown) => {
+				const message = err instanceof Error ? err.message : 'unknown error'
+				toastError(`Failed to link phrase: ${message}`)
+			}
+		)
+	}
 
 	return (
 		<div
@@ -232,7 +253,7 @@ export function PlaylistItem({
 				<InlinePhraseCreator
 					lang={playlist.lang}
 					onPhraseCreated={(phraseId) => {
-						linkPhraseMutation.mutate(phraseId)
+						linkPhrase(phraseId)
 					}}
 					onCancel={() => setShowAddPhrase(false)}
 					submitLabel="Add phrase to playlist"
@@ -245,19 +266,16 @@ export function PlaylistItem({
 				<Button
 					variant="soft"
 					onClick={() =>
-						bulkAddMutation.mutate(
+						addPhrasesToDeck(
 							phrasesNotInDeck.map((item) => ({
 								id: item.phrase.id,
 								only_reverse: item.phrase.only_reverse,
 							}))
 						)
 					}
-					disabled={bulkAddMutation.isPending}
 					data-testid="bulk-add-playlist-to-deck"
 				>
-					{bulkAddMutation.isPending
-						? 'Adding…'
-						: `Add ${phrasesNotInDeck.length} new card${phrasesNotInDeck.length === 1 ? '' : 's'} to deck`}
+					{`Add ${phrasesNotInDeck.length} new card${phrasesNotInDeck.length === 1 ? '' : 's'} to deck`}
 				</Button>
 			)}
 

--- a/src/features/playlists/collections.ts
+++ b/src/features/playlists/collections.ts
@@ -68,6 +68,46 @@ export const playlistPhraseLinksCollection = createCollection(
 		schema: PlaylistPhraseLinkSchema,
 		autoIndex: 'eager',
 		defaultIndexType: BasicIndex,
+		// uid + created_at default server-side (auth.uid() / now()); the optimistic
+		// row already carries client values for them, so { refetch: false }.
+		onInsert: async ({ transaction }) => {
+			await supabase
+				.from('playlist_phrase_link')
+				.insert(
+					transaction.mutations.map((m) => ({
+						id: m.modified.id,
+						playlist_id: m.modified.playlist_id,
+						phrase_id: m.modified.phrase_id,
+						order: m.modified.order,
+						href: m.modified.href,
+					}))
+				)
+				.throwOnError()
+			return { refetch: false }
+		},
+		onUpdate: async ({ transaction }) => {
+			await Promise.all(
+				transaction.mutations.map((m) =>
+					supabase
+						.from('playlist_phrase_link')
+						.update(m.changes as TablesUpdate<'playlist_phrase_link'>)
+						.eq('id', m.original.id)
+						.throwOnError()
+				)
+			)
+			return { refetch: false }
+		},
+		onDelete: async ({ transaction }) => {
+			await supabase
+				.from('playlist_phrase_link')
+				.delete()
+				.in(
+					'id',
+					transaction.mutations.map((m) => m.original.id)
+				)
+				.throwOnError()
+			return { refetch: false }
+		},
 	})
 )
 


### PR DESCRIPTION
Adds onInsert/onUpdate/onDelete to playlistPhraseLinksCollection and ports
the remaining old-pattern playlist call sites off useMutation +
collection.utils.write*:

- manage-playlist-phrases-dialog.tsx: add / remove / reorder / update-href
  all become playlistPhraseLinksCollection.insert/update/delete with the
  toast UX on tx.isPersisted.promise. removePhrase/updateHref are hoisted to
  module scope (they close over nothing). Dropped the isPending disables —
  optimistic updates make them moot.
- playlist-list-item.tsx: linkPhrase → collection.insert; the bulk
  "add cards to deck" upsert becomes an insert/update split over
  cardsCollection (existing skipped cards flip to active, the rest insert),
  reusing langCards to classify — behavior-preserving vs the old
  onConflict upsert.

Optimistic link rows carry client id/uid/created_at to satisfy
PlaylistPhraseLinkSchema; the handlers send only server-authoritative
columns and return { refetch: false }.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XSxVWZQSf19ymNwkXQHr2d