### PR TITLE
Migrate admin mutations to collection ops + optimistic action (#625)

### DIFF
--- a/scenetest/TEST_IDS.md
+++ b/scenetest/TEST_IDS.md
@@ -213,66 +213,71 @@ natural wrapper element to label.
 
 ## Phrase Requests
 
-| Selector                        | Attribute   | Component/Location  | Description                                                                                        |
-| ------------------------------- | ----------- | ------------------- | -------------------------------------------------------------------------------------------------- |
-| `contributions-page`            | data-testid | Contributions route | Contributions page container                                                                       |
-| `contributions-tab--requests`   | data-testid | Contributions page  | Tab for requests                                                                                   |
-| `contributions-tab--phrases`    | data-testid | Contributions page  | Tab for phrases                                                                                    |
-| `contributions-tab--playlists`  | data-testid | Contributions page  | Tab for playlists                                                                                  |
-| `contributions-tab--answers`    | data-testid | Contributions page  | Tab for answers                                                                                    |
-| `contributions-tab--comments`   | data-testid | Contributions page  | Tab for comments                                                                                   |
-| `contributions-comment-item`    | data-testid | Comments tab        | Comment card on the comments tab (use with `data-key={commentId}`)                                 |
-| `new-request-link`              | data-testid | Contributions page  | Link to create new request                                                                         |
-| `new-request-form`              | data-testid | New request page    | Request form container (scope `prompt-input` and `submit-button` by this)                          |
-| `request-detail-page`           | data-testid | Request route       | Request detail container                                                                           |
-| `message-tags-row`              | data-testid | Request detail      | Container for tag chips on a request's message (read-only)                                         |
-| `message-tag-chip`              | data-testid | Request detail      | A single tag chip (list item — has `data-key={slug}`)                                              |
-| `admin-request-gear-link`       | data-testid | Request detail      | Gear icon link to admin page (admin only)                                                          |
-| `admin-messages-page`           | data-testid | /admin/messages     | Page container                                                                                     |
-| `admin-messages-tags-strip`     | data-testid | /admin/messages     | Tag filter strip                                                                                   |
-| `tag-filter-all`                | data-testid | /admin/messages     | "All" pill (clears tag filter)                                                                     |
-| `tag-filter-chip`               | data-testid | /admin/messages     | Individual tag filter chip (has `data-key={slug}`)                                                 |
-| `new-tag-button`                | data-testid | /admin/messages     | Trigger for the "New tag" popover                                                                  |
-| `new-tag-slug`                  | data-testid | New-tag popover     | Slug input                                                                                         |
-| `new-tag-label`                 | data-testid | New-tag popover     | Label input                                                                                        |
-| `new-tag-description`           | data-testid | New-tag popover     | Description textarea                                                                               |
-| `new-tag-submit`                | data-testid | New-tag popover     | Submit button                                                                                      |
-| `edit-tags-button`              | data-testid | /admin/messages     | Trigger for the edit-tags dialog (next to "New tag")                                               |
-| `edit-tags-list`                | data-testid | Edit-tags dialog    | The list of tag rows                                                                               |
-| `edit-tag-row`                  | data-testid | Edit-tags dialog    | A tag row in the list (has `data-key={slug}`)                                                      |
-| `edit-tag-pencil`               | data-testid | Edit-tags dialog    | Pencil button to enter inline edit mode                                                            |
-| `edit-tag-label`                | data-testid | Edit-tags dialog    | Label input (edit mode)                                                                            |
-| `edit-tag-save`                 | data-testid | Edit-tags dialog    | Save button (edit mode)                                                                            |
-| `archive-tag-button`            | data-testid | Edit-tags dialog    | Archive icon opens confirm dialog (active tags)                                                    |
-| `archive-tag-confirm`           | data-testid | Confirm dialog      | Final confirm-archive button                                                                       |
-| `restore-tag-button`            | data-testid | Edit-tags dialog    | Undo icon to restore an archived tag                                                               |
-| `admin-messages-bulk-add`       | data-testid | /admin/messages     | Bulk-add section container                                                                         |
-| `bulk-add-textarea`             | data-testid | Bulk-add            | The textarea for pasted prompts                                                                    |
-| `bulk-add-submit`               | data-testid | Bulk-add            | "Add N messages" button                                                                            |
-| `admin-messages-search`         | data-testid | /admin/messages     | Filter-by-text input                                                                               |
-| `admin-messages-selection-bar`  | data-testid | /admin/messages     | Visible when ≥1 message is selected                                                                |
-| `apply-tag-button`              | data-testid | Selection bar       | Opens apply/remove-tag popover                                                                     |
-| `apply-tag-option`              | data-testid | Apply-tag popover   | Plus button per tag (has `data-key={slug}`)                                                        |
-| `admin-messages-table`          | data-testid | /admin/messages     | Container for the rows (list items have `data-name="message-row"`)                                 |
-| `select-all-visible`            | data-testid | /admin/messages     | Header checkbox                                                                                    |
-| `message-row`                   | data-testid | /admin/messages     | A single message row (has `data-key={message_id}`)                                                 |
-| `message-row-checkbox`          | data-testid | /admin/messages     | Per-row selection checkbox                                                                         |
-| `row-tag-chip`                  | data-testid | /admin/messages     | Tag chip on a row (has `data-key={slug}`, X to detach)                                             |
-| `row-open-request`              | data-testid | /admin/messages     | Link to the admin request detail page                                                              |
-| `admin-request-message-section` | data-testid | Admin request page  | Message section on the admin request detail page                                                   |
-| `request-item`                  | data-testid | Request list        | A request list item (own user)                                                                     |
-| `other-user-request-item`       | data-testid | Request list        | A request by another user                                                                          |
-| `update-request-button`         | data-testid | Request page        | Edit button (owner only)                                                                           |
-| `edit-request-dialog`           | data-testid | Dialog              | Edit request dialog                                                                                |
-| `edit-request-form`             | data-testid | Edit dialog         | Form container inside the edit dialog (scope `prompt-input` and `submit-button` by this)           |
-| `delete-request-button`         | data-testid | Request page        | Delete button (owner only)                                                                         |
-| `delete-request-dialog`         | data-testid | Dialog              | Delete confirmation                                                                                |
-| `confirm-delete-button`         | data-testid | Dialog              | Confirm delete button                                                                              |
-| `comment-item`                  | data-name   | Request page        | Comment container (use with data-key for a specific comment)                                       |
-| `show-replies-button`           | data-name   | Comment item        | Toggle to expand/collapse the reply subthread (select via `comment-item {id} show-replies-button`) |
-| `add-reply-inline`              | data-name   | Comment subthread   | Inline prompt to open the reply dialog (select via `comment-item {id} add-reply-inline`)           |
-| `comment-context-menu-trigger`  | data-testid | Comment             | Context menu button                                                                                |
-| `copy-link-menu-item`           | data-testid | Context menu        | Copy link option                                                                                   |
+| Selector                        | Attribute   | Component/Location   | Description                                                                                        |
+| ------------------------------- | ----------- | -------------------- | -------------------------------------------------------------------------------------------------- |
+| `contributions-page`            | data-testid | Contributions route  | Contributions page container                                                                       |
+| `contributions-tab--requests`   | data-testid | Contributions page   | Tab for requests                                                                                   |
+| `contributions-tab--phrases`    | data-testid | Contributions page   | Tab for phrases                                                                                    |
+| `contributions-tab--playlists`  | data-testid | Contributions page   | Tab for playlists                                                                                  |
+| `contributions-tab--answers`    | data-testid | Contributions page   | Tab for answers                                                                                    |
+| `contributions-tab--comments`   | data-testid | Contributions page   | Tab for comments                                                                                   |
+| `contributions-comment-item`    | data-testid | Comments tab         | Comment card on the comments tab (use with `data-key={commentId}`)                                 |
+| `new-request-link`              | data-testid | Contributions page   | Link to create new request                                                                         |
+| `new-request-form`              | data-testid | New request page     | Request form container (scope `prompt-input` and `submit-button` by this)                          |
+| `request-detail-page`           | data-testid | Request route        | Request detail container                                                                           |
+| `message-tags-row`              | data-testid | Request detail       | Container for tag chips on a request's message (read-only)                                         |
+| `message-tag-chip`              | data-testid | Request detail       | A single tag chip (list item — has `data-key={slug}`)                                              |
+| `admin-request-gear-link`       | data-testid | Request detail       | Gear icon link to admin page (admin only)                                                          |
+| `admin-edit-prompt-button`      | data-testid | Admin request detail | Pencil that reveals the prompt editor (admin only)                                                 |
+| `admin-edit-prompt-textarea`    | data-testid | Admin request detail | Prompt editor textarea                                                                             |
+| `admin-edit-prompt-save`        | data-testid | Admin request detail | Save button for the prompt edit                                                                    |
+| `admin-archive-request-button`  | data-testid | Admin request detail | Archive/restore toggle for the request (admin only)                                                |
+| `admin-messages-page`           | data-testid | /admin/messages      | Page container                                                                                     |
+| `admin-messages-tags-strip`     | data-testid | /admin/messages      | Tag filter strip                                                                                   |
+| `tag-filter-all`                | data-testid | /admin/messages      | "All" pill (clears tag filter)                                                                     |
+| `tag-filter-chip`               | data-testid | /admin/messages      | Individual tag filter chip (has `data-key={slug}`)                                                 |
+| `new-tag-button`                | data-testid | /admin/messages      | Trigger for the "New tag" popover                                                                  |
+| `new-tag-slug`                  | data-testid | New-tag popover      | Slug input                                                                                         |
+| `new-tag-label`                 | data-testid | New-tag popover      | Label input                                                                                        |
+| `new-tag-description`           | data-testid | New-tag popover      | Description textarea                                                                               |
+| `new-tag-submit`                | data-testid | New-tag popover      | Submit button                                                                                      |
+| `edit-tags-button`              | data-testid | /admin/messages      | Trigger for the edit-tags dialog (next to "New tag")                                               |
+| `edit-tags-list`                | data-testid | Edit-tags dialog     | The list of tag rows                                                                               |
+| `edit-tag-row`                  | data-testid | Edit-tags dialog     | A tag row in the list (has `data-key={slug}`)                                                      |
+| `edit-tag-pencil`               | data-testid | Edit-tags dialog     | Pencil button to enter inline edit mode                                                            |
+| `edit-tag-label`                | data-testid | Edit-tags dialog     | Label input (edit mode)                                                                            |
+| `edit-tag-save`                 | data-testid | Edit-tags dialog     | Save button (edit mode)                                                                            |
+| `archive-tag-button`            | data-testid | Edit-tags dialog     | Archive icon opens confirm dialog (active tags)                                                    |
+| `archive-tag-confirm`           | data-testid | Confirm dialog       | Final confirm-archive button                                                                       |
+| `restore-tag-button`            | data-testid | Edit-tags dialog     | Undo icon to restore an archived tag                                                               |
+| `admin-messages-bulk-add`       | data-testid | /admin/messages      | Bulk-add section container                                                                         |
+| `bulk-add-toggle`               | data-testid | Bulk-add             | Expand/collapse the bulk-add section                                                               |
+| `bulk-add-textarea`             | data-testid | Bulk-add             | The textarea for pasted prompts                                                                    |
+| `bulk-add-submit`               | data-testid | Bulk-add             | "Add N messages" button                                                                            |
+| `admin-messages-search`         | data-testid | /admin/messages      | Filter-by-text input                                                                               |
+| `admin-messages-selection-bar`  | data-testid | /admin/messages      | Visible when ≥1 message is selected                                                                |
+| `apply-tag-button`              | data-testid | Selection bar        | Opens apply/remove-tag popover                                                                     |
+| `apply-tag-option`              | data-testid | Apply-tag popover    | Plus button per tag (has `data-key={slug}`)                                                        |
+| `admin-messages-table`          | data-testid | /admin/messages      | Container for the rows (list items have `data-name="message-row"`)                                 |
+| `select-all-visible`            | data-testid | /admin/messages      | Header checkbox                                                                                    |
+| `message-row`                   | data-testid | /admin/messages      | A single message row (has `data-key={message_id}`)                                                 |
+| `message-row-checkbox`          | data-testid | /admin/messages      | Per-row selection checkbox                                                                         |
+| `row-tag-chip`                  | data-testid | /admin/messages      | Tag chip on a row (has `data-key={slug}`, X to detach)                                             |
+| `row-open-request`              | data-testid | /admin/messages      | Link to the admin request detail page                                                              |
+| `admin-request-message-section` | data-testid | Admin request page   | Message section on the admin request detail page                                                   |
+| `request-item`                  | data-testid | Request list         | A request list item (own user)                                                                     |
+| `other-user-request-item`       | data-testid | Request list         | A request by another user                                                                          |
+| `update-request-button`         | data-testid | Request page         | Edit button (owner only)                                                                           |
+| `edit-request-dialog`           | data-testid | Dialog               | Edit request dialog                                                                                |
+| `edit-request-form`             | data-testid | Edit dialog          | Form container inside the edit dialog (scope `prompt-input` and `submit-button` by this)           |
+| `delete-request-button`         | data-testid | Request page         | Delete button (owner only)                                                                         |
+| `delete-request-dialog`         | data-testid | Dialog               | Delete confirmation                                                                                |
+| `confirm-delete-button`         | data-testid | Dialog               | Confirm delete button                                                                              |
+| `comment-item`                  | data-name   | Request page         | Comment container (use with data-key for a specific comment)                                       |
+| `show-replies-button`           | data-name   | Comment item         | Toggle to expand/collapse the reply subthread (select via `comment-item {id} show-replies-button`) |
+| `add-reply-inline`              | data-name   | Comment subthread    | Inline prompt to open the reply dialog (select via `comment-item {id} add-reply-inline`)           |
+| `comment-context-menu-trigger`  | data-testid | Comment              | Context menu button                                                                                |
+| `copy-link-menu-item`           | data-testid | Context menu         | Copy link option                                                                                   |
 
 ## Playlists
 

--- a/scenetest/scenes/admin-mutations.spec.ts
+++ b/scenetest/scenes/admin-mutations.spec.ts
@@ -1,0 +1,195 @@
+import assert from 'node:assert/strict'
+import { test } from '@scenetest/scenes'
+import { createClient } from '@supabase/supabase-js'
+import type { Database } from '../../src/types/supabase'
+
+const supabase = createClient<Database>(
+	process.env.VITE_SUPABASE_URL ?? 'http://127.0.0.1:54321',
+	process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+// Poll a predicate until it holds — used where a mutation has no toast to gate
+// on, or to confirm a server row after an optimistic action.
+async function pollUntil(
+	fn: () => Promise<boolean>,
+	{ timeoutMs = 8000, intervalMs = 150 } = {}
+): Promise<boolean> {
+	const start = Date.now()
+	/* eslint-disable no-await-in-loop */
+	while (Date.now() - start < timeoutMs) {
+		if (await fn()) return true
+		await new Promise((r) => setTimeout(r, intervalMs))
+	}
+	/* eslint-enable no-await-in-loop */
+	return false
+}
+
+// A seeded phrase_request auto-creates a message row via trigger; clean both up.
+async function deleteRequest(requestId: string, messageId: string | null) {
+	if (messageId) {
+		await supabase.from('message_tag_link').delete().eq('message_id', messageId)
+	}
+	await supabase.from('phrase_request').delete().eq('id', requestId)
+	if (messageId) await supabase.from('message').delete().eq('id', messageId)
+}
+
+test('admin edits a request prompt', async ({ actor, team }) => {
+	const lang = team.tags!.lang_full
+	const learner = await actor('learner')
+	const nonce = Date.now().toString(36)
+	const original = `Admin edit target ${nonce}`
+	const updated = `Admin edited prompt ${nonce}`
+	let requestId = ''
+	let messageId: string | null = null
+
+	try {
+		await supabase
+			.from('admin_user')
+			.upsert({ uid: learner.key })
+			.throwOnError()
+		const { data: request } = await supabase
+			.from('phrase_request')
+			.insert({ prompt: original, lang, requester_uid: learner.key })
+			.select()
+			.single()
+			.throwOnError()
+		requestId = request!.id
+		messageId = request!.message_id ?? null
+
+		await learner
+			.openTo('/login')
+			.typeInto('email-input', learner.email!)
+			.typeInto('password-input', learner.password!)
+			.click('submit-button')
+			.notSee('login-form')
+			.openTo(`/admin/${lang}/requests/${requestId}`)
+			.up()
+			.see('admin-request-detail')
+			.click('admin-edit-prompt-button')
+			.up()
+			.typeInto('admin-edit-prompt-textarea', updated)
+			.click('admin-edit-prompt-save')
+			.up()
+			.seeToast('toast-success')
+
+		const saved = await pollUntil(async () => {
+			const { data } = await supabase
+				.from('phrase_request')
+				.select('prompt')
+				.eq('id', requestId)
+				.single()
+			return data?.prompt === updated
+		})
+		assert.ok(saved, 'the edited prompt should persist')
+	} finally {
+		if (requestId) await deleteRequest(requestId, messageId)
+		await supabase.from('admin_user').delete().eq('uid', learner.key)
+	}
+})
+
+test('admin archives a request', async ({ actor, team }) => {
+	const lang = team.tags!.lang_full
+	const learner = await actor('learner')
+	const nonce = Date.now().toString(36)
+	let requestId = ''
+	let messageId: string | null = null
+
+	try {
+		await supabase
+			.from('admin_user')
+			.upsert({ uid: learner.key })
+			.throwOnError()
+		const { data: request } = await supabase
+			.from('phrase_request')
+			.insert({
+				prompt: `Admin archive target ${nonce}`,
+				lang,
+				requester_uid: learner.key,
+			})
+			.select()
+			.single()
+			.throwOnError()
+		requestId = request!.id
+		messageId = request!.message_id ?? null
+
+		await learner
+			.openTo('/login')
+			.typeInto('email-input', learner.email!)
+			.typeInto('password-input', learner.password!)
+			.click('submit-button')
+			.notSee('login-form')
+			.openTo(`/admin/${lang}/requests/${requestId}`)
+			.up()
+			.see('admin-request-detail')
+			.click('admin-archive-request-button')
+			.up()
+			.seeToast('toast-success')
+
+		const archived = await pollUntil(async () => {
+			const { data } = await supabase
+				.from('phrase_request')
+				.select('deleted')
+				.eq('id', requestId)
+				.single()
+			return data?.deleted === true
+		})
+		assert.ok(archived, 'the request should be soft-deleted (deleted: true)')
+	} finally {
+		if (requestId) await deleteRequest(requestId, messageId)
+		await supabase.from('admin_user').delete().eq('uid', learner.key)
+	}
+})
+
+test('admin bulk-adds messages', async ({ actor, team }) => {
+	const lang = team.tags!.lang_full
+	const learner = await actor('learner')
+	const nonce = Date.now().toString(36)
+	const promptA = `Bulk message alpha ${nonce}`
+	const promptB = `Bulk message beta ${nonce}`
+
+	try {
+		await supabase
+			.from('admin_user')
+			.upsert({ uid: learner.key })
+			.throwOnError()
+
+		await learner
+			.openTo('/login')
+			.typeInto('email-input', learner.email!)
+			.typeInto('password-input', learner.password!)
+			.click('submit-button')
+			.notSee('login-form')
+			.openTo('/admin/messages')
+			.up()
+			.see('admin-messages-page')
+			.click('bulk-add-toggle')
+			.up()
+			.click('language-selector-button')
+			.up()
+			.click(`language-options ${lang}`)
+			.up()
+			.typeInto('bulk-add-textarea', `${promptA}\n\n${promptB}`)
+			.click('bulk-add-submit')
+			.up()
+			.seeToast('toast-success')
+
+		const created = await pollUntil(async () => {
+			const { data } = await supabase
+				.from('phrase_request')
+				.select('id')
+				.in('prompt', [promptA, promptB])
+			return (data?.length ?? 0) === 2
+		})
+		assert.ok(created, 'both bulk-added requests should be persisted')
+	} finally {
+		const { data: rows } = await supabase
+			.from('phrase_request')
+			.select('id, message_id')
+			.in('prompt', [promptA, promptB])
+		for (const row of rows ?? []) {
+			// eslint-disable-next-line no-await-in-loop
+			await deleteRequest(row.id, row.message_id ?? null)
+		}
+		await supabase.from('admin_user').delete().eq('uid', learner.key)
+	}
+})

--- a/scenetest/scenes/admin-mutations.spec.ts
+++ b/scenetest/scenes/admin-mutations.spec.ts
@@ -171,8 +171,10 @@ test('admin bulk-adds messages', async ({ actor, team }) => {
 			.typeInto('bulk-add-textarea', `${promptA}\n\n${promptB}`)
 			.click('bulk-add-submit')
 			.up()
-			.seeToast('toast-success')
 
+		// No seeToast here: the success toast can outlive its 5s dismissal window
+		// under CI load, and the DB poll below is the authoritative assertion that
+		// the optimistic action actually persisted both requests.
 		const created = await pollUntil(async () => {
 			const { data } = await supabase
 				.from('phrase_request')

--- a/scenetest/scenes/admin-phrases.spec.md
+++ b/scenetest/scenes/admin-phrases.spec.md
@@ -82,3 +82,22 @@ friend:
 - see admin-phrase-detail
 - see admin-not-authorized-warning
 - notSee admin-archive-button
+
+# admin can restore an archived phrase from the detail page
+
+// The phrase starts archived (via setup); the detail page shows the restore
+// button, and clicking it flips archived back to false.
+
+setup: supabase.from('admin_user').upsert({ uid: '[learner.key]' })
+setup: supabase.from('phrase').update({ archived: true }).eq('id', '[team.partial_nocard_phrase]')
+cleanup: supabase.from('admin_user').delete().eq('uid', '[learner.key]')
+cleanup: supabase.from('phrase').update({ archived: false }).eq('id', '[team.partial_nocard_phrase]')
+
+learner:
+
+- login
+- openTo /admin/[team.lang_partial]/phrases/[team.partial_nocard_phrase]
+- up
+- see admin-phrase-detail
+- click admin-unarchive-button
+- seeToast toast-success

--- a/src/components/cards/admin-archive-phrase.tsx
+++ b/src/components/cards/admin-archive-phrase.tsx
@@ -1,11 +1,24 @@
-import { useMutation } from '@tanstack/react-query'
 import { Archive, ArchiveRestore } from 'lucide-react'
 import { toastSuccess, toastError } from '@/components/ui/sonner'
 
 import type { uuid } from '@/types/main'
-import supabase from '@/lib/supabase-client'
 import { Button } from '@/components/ui/button'
 import { phrasesCollection } from '@/features/phrases/collections'
+
+function setPhraseArchived(phraseId: uuid, archived: boolean) {
+	const tx = phrasesCollection.update(phraseId, (draft) => {
+		draft.archived = archived
+	})
+	tx.isPersisted.promise.then(
+		() => toastSuccess(archived ? 'Phrase archived' : 'Phrase restored'),
+		(err: unknown) => {
+			toastError(
+				archived ? 'Failed to archive phrase' : 'Failed to restore phrase'
+			)
+			console.error(err)
+		}
+	)
+}
 
 export function AdminArchivePhraseButton({
 	phraseId,
@@ -14,32 +27,14 @@ export function AdminArchivePhraseButton({
 	phraseId: uuid
 	disabled?: boolean
 }) {
-	const archiveMutation = useMutation({
-		mutationFn: async () => {
-			await supabase
-				.from('phrase')
-				.update({ archived: true })
-				.eq('id', phraseId)
-				.throwOnError()
-		},
-		onSuccess: () => {
-			phrasesCollection.utils.writeUpdate({ id: phraseId, archived: true })
-			toastSuccess('Phrase archived')
-		},
-		onError: (error) => {
-			toastError('Failed to archive phrase')
-			console.error(error)
-		},
-	})
-
 	return (
 		<Button
 			size="icon"
 			variant="ghost"
 			aria-label="Archive phrase"
 			data-testid="admin-archive-button"
-			onClick={() => archiveMutation.mutate()}
-			disabled={disabled || archiveMutation.isPending}
+			onClick={() => setPhraseArchived(phraseId, true)}
+			disabled={disabled}
 		>
 			<Archive />
 		</Button>
@@ -53,32 +48,14 @@ export function AdminUnarchivePhraseButton({
 	phraseId: uuid
 	disabled?: boolean
 }) {
-	const unarchiveMutation = useMutation({
-		mutationFn: async () => {
-			await supabase
-				.from('phrase')
-				.update({ archived: false })
-				.eq('id', phraseId)
-				.throwOnError()
-		},
-		onSuccess: () => {
-			phrasesCollection.utils.writeUpdate({ id: phraseId, archived: false })
-			toastSuccess('Phrase restored')
-		},
-		onError: (error) => {
-			toastError('Failed to restore phrase')
-			console.error(error)
-		},
-	})
-
 	return (
 		<Button
 			size="icon"
 			variant="ghost"
 			aria-label="Restore phrase"
 			data-testid="admin-unarchive-button"
-			onClick={() => unarchiveMutation.mutate()}
-			disabled={disabled || unarchiveMutation.isPending}
+			onClick={() => setPhraseArchived(phraseId, false)}
+			disabled={disabled}
 		>
 			<ArchiveRestore />
 		</Button>

--- a/src/routes/_user/admin/$lang.requests.$id.lazy.tsx
+++ b/src/routes/_user/admin/$lang.requests.$id.lazy.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import { createLazyFileRoute, Link } from '@tanstack/react-router'
-import { useMutation } from '@tanstack/react-query'
 import { and, eq, not } from '@tanstack/db'
 import { useLiveQuery } from '@tanstack/react-db'
 import {
@@ -34,10 +33,7 @@ import {
 	messageTagLinksCollection,
 	phraseRequestsCollection,
 } from '@/features/requests/collections'
-import {
-	PhraseRequestSchema,
-	type PhraseRequestType,
-} from '@/features/requests/schemas'
+import { type PhraseRequestType } from '@/features/requests/schemas'
 import {
 	useMessageTags,
 	useMessageTagsForMessage,
@@ -45,7 +41,6 @@ import {
 } from '@/features/requests/hooks'
 import type { PhraseFullFilteredType } from '@/features/phrases/schemas'
 import { useAuth } from '@/lib/use-auth'
-import supabase from '@/lib/supabase-client'
 import { ago } from '@/lib/dayjs'
 import type { uuid } from '@/types/main'
 
@@ -425,37 +420,23 @@ function EditableRequestPrompt({
 	const [isEditing, setIsEditing] = useState(false)
 	const [editText, setEditText] = useState(request.prompt)
 
-	const updateRequest = useMutation({
-		mutationFn: async (newPrompt: string) => {
-			const { data } = await supabase
-				.from('phrase_request')
-				.update({ prompt: newPrompt })
-				.eq('id', request.id)
-				.throwOnError()
-				.select()
-			if (!data) throw new Error('Failed to update request')
-			return data[0]
-		},
-		onSuccess: (data) => {
-			phraseRequestsCollection.utils.writeUpdate(
-				PhraseRequestSchema.parse(data)
-			)
-			setIsEditing(false)
-			toastSuccess('Request updated')
-		},
-		onError: (error) => {
-			toastError('Failed to update request')
-			console.error(error)
-		},
-	})
-
 	const handleSave = () => {
 		const trimmed = editText.trim()
-		if (trimmed && trimmed !== request.prompt) {
-			updateRequest.mutate(trimmed)
-		} else {
+		if (!trimmed || trimmed === request.prompt) {
 			setIsEditing(false)
+			return
 		}
+		const tx = phraseRequestsCollection.update(request.id, (draft) => {
+			draft.prompt = trimmed
+		})
+		setIsEditing(false)
+		tx.isPersisted.promise.then(
+			() => toastSuccess('Request updated'),
+			(error: unknown) => {
+				toastError('Failed to update request')
+				console.error(error)
+			}
+		)
 	}
 
 	const handleCancel = () => {
@@ -475,12 +456,7 @@ function EditableRequestPrompt({
 					}}
 				/>
 				<div className="flex gap-2">
-					<Button
-						size="sm"
-						variant="default"
-						onClick={handleSave}
-						disabled={updateRequest.isPending}
-					>
+					<Button size="sm" variant="default" onClick={handleSave}>
 						<Check className="me-1 h-4 w-4" />
 						Save
 					</Button>
@@ -518,36 +494,27 @@ function ArchiveRequestButton({
 	request: PhraseRequestType
 	disabled?: boolean
 }) {
-	const toggleArchive = useMutation({
-		mutationFn: async () => {
-			const { data } = await supabase
-				.from('phrase_request')
-				.update({ deleted: !request.deleted })
-				.eq('id', request.id)
-				.throwOnError()
-				.select()
-			if (!data) throw new Error('Failed to update request')
-			return data[0]
-		},
-		onSuccess: (data) => {
-			phraseRequestsCollection.utils.writeUpdate(
-				PhraseRequestSchema.parse(data)
-			)
-			toastSuccess(request.deleted ? 'Request restored' : 'Request archived')
-		},
-		onError: (error) => {
-			toastError('Failed to update request')
-			console.error(error)
-		},
-	})
+	const toggleArchive = () => {
+		const wasDeleted = request.deleted
+		const tx = phraseRequestsCollection.update(request.id, (draft) => {
+			draft.deleted = !wasDeleted
+		})
+		tx.isPersisted.promise.then(
+			() => toastSuccess(wasDeleted ? 'Request restored' : 'Request archived'),
+			(error: unknown) => {
+				toastError('Failed to update request')
+				console.error(error)
+			}
+		)
+	}
 
 	return (
 		<Button
 			size="icon"
 			variant="ghost"
 			className="shrink-0"
-			onClick={() => toggleArchive.mutate()}
-			disabled={disabled || toggleArchive.isPending}
+			onClick={toggleArchive}
+			disabled={disabled}
 			aria-label={request.deleted ? 'Restore request' : 'Archive request'}
 		>
 			{request.deleted ? (

--- a/src/routes/_user/admin/$lang.requests.$id.lazy.tsx
+++ b/src/routes/_user/admin/$lang.requests.$id.lazy.tsx
@@ -451,12 +451,18 @@ function EditableRequestPrompt({
 					value={editText}
 					onChange={(e) => setEditText(e.target.value)}
 					className="min-h-[100px]"
+					data-testid="admin-edit-prompt-textarea"
 					onKeyDown={(e) => {
 						if (e.key === 'Escape') handleCancel()
 					}}
 				/>
 				<div className="flex gap-2">
-					<Button size="sm" variant="default" onClick={handleSave}>
+					<Button
+						size="sm"
+						variant="default"
+						onClick={handleSave}
+						data-testid="admin-edit-prompt-save"
+					>
 						<Check className="me-1 h-4 w-4" />
 						Save
 					</Button>
@@ -479,6 +485,7 @@ function EditableRequestPrompt({
 					variant="ghost"
 					className="size-7 shrink-0"
 					onClick={() => setIsEditing(true)}
+					data-testid="admin-edit-prompt-button"
 				>
 					<Pencil className="size-3.5" />
 				</Button>
@@ -515,6 +522,7 @@ function ArchiveRequestButton({
 			className="shrink-0"
 			onClick={toggleArchive}
 			disabled={disabled}
+			data-testid="admin-archive-request-button"
 			aria-label={request.deleted ? 'Restore request' : 'Archive request'}
 		>
 			{request.deleted ? (

--- a/src/routes/_user/admin/messages.index.lazy.tsx
+++ b/src/routes/_user/admin/messages.index.lazy.tsx
@@ -1,6 +1,6 @@
 import { useId, useMemo, useState } from 'react'
 import { createLazyFileRoute, Link } from '@tanstack/react-router'
-import { useMutation } from '@tanstack/react-query'
+import { createOptimisticAction } from '@tanstack/db'
 import { eq, useLiveQuery } from '@tanstack/react-db'
 import {
 	Archive,
@@ -74,6 +74,84 @@ type MessageRow = {
 	lang: string
 	request_id: string
 }
+
+// Bulk-insert phrase_request rows (a DB trigger auto-creates one message per
+// request and fills message_id) plus optional tag links. The message_id is
+// server-generated, so the optimistic requests carry client ids only; the
+// confirmed rows (now with message_id) are synced in the mutationFn, along
+// with their message + tag-link rows.
+const bulkAddMessages = createOptimisticAction<{
+	requestIds: Array<string>
+	prompts: Array<string>
+	lang: string
+	userId: string
+	tagSlug: string | null
+}>({
+	onMutate: ({ requestIds, prompts, lang, userId }) => {
+		const now = new Date().toISOString()
+		prompts.forEach((prompt, i) => {
+			phraseRequestsCollection.insert({
+				id: requestIds[i],
+				created_at: now,
+				requester_uid: userId,
+				lang,
+				prompt,
+				upvote_count: 0,
+				deleted: false,
+			})
+		})
+	},
+	mutationFn: async ({ requestIds, prompts, lang, userId, tagSlug }) => {
+		const { data: requests } = await supabase
+			.from('phrase_request')
+			.insert(
+				prompts.map((prompt, i) => ({
+					id: requestIds[i],
+					prompt,
+					lang,
+					requester_uid: userId,
+				}))
+			)
+			.select()
+			.throwOnError()
+		const insertedRequests = requests ?? []
+
+		let insertedLinks: Array<{ message_id: string; tag_slug: string }> = []
+		if (tagSlug && insertedRequests.length > 0) {
+			const { data: links } = await supabase
+				.from('message_tag_link')
+				.insert(
+					insertedRequests
+						.filter((r) => r.message_id)
+						.map((r) => ({
+							message_id: r.message_id as string,
+							tag_slug: tagSlug,
+						}))
+				)
+				.select()
+				.throwOnError()
+			insertedLinks = links ?? []
+		}
+
+		// Sync confirmed rows (server filled message_id) before the optimistic
+		// state drops at the end of mutationFn.
+		for (const row of insertedRequests) {
+			const parsed = PhraseRequestSchema.parse(row)
+			phraseRequestsCollection.utils.writeInsert(parsed)
+			if (parsed.message_id) {
+				messagesCollection.utils.writeInsert({
+					id: parsed.message_id,
+					created_at: parsed.created_at,
+				})
+			}
+		}
+		for (const link of insertedLinks) {
+			messageTagLinksCollection.utils.writeInsert(
+				MessageTagLinkSchema.parse(link)
+			)
+		}
+	},
+})
 
 function AdminMessagesPage() {
 	const { isAdmin, userId } = useAuth()
@@ -675,71 +753,37 @@ function BulkAddSection({
 
 	const selectedTag = allTags.find((t) => t.slug === tagSlug) ?? null
 
-	const bulkAdd = useMutation({
-		mutationFn: async () => {
-			if (!userId) throw new Error('Not authenticated')
-			if (!lang) throw new Error('Pick a language first')
-			if (prompts.length === 0) throw new Error('No prompts to add')
-			const { data: requests } = await supabase
-				.from('phrase_request')
-				.insert(
-					prompts.map((prompt) => ({
-						prompt,
-						lang,
-						requester_uid: userId,
-					}))
+	const runBulkAdd = () => {
+		if (!userId) {
+			toastError('Not authenticated')
+			return
+		}
+		if (!lang) {
+			toastError('Pick a language first')
+			return
+		}
+		if (prompts.length === 0) {
+			toastError('No prompts to add')
+			return
+		}
+		const requestIds = prompts.map(() => crypto.randomUUID())
+		const tx = bulkAddMessages({ requestIds, prompts, lang, userId, tagSlug })
+		tx.isPersisted.promise.then(
+			() => {
+				toastSuccess(
+					`Added ${prompts.length} message${prompts.length === 1 ? '' : 's'}` +
+						(tagSlug ? ` tagged "${tagSlug}"` : '')
 				)
-				.select()
-				.throwOnError()
-			const insertedRequests = requests ?? []
-
-			let insertedLinks: { message_id: string; tag_slug: string }[] = []
-			if (tagSlug && insertedRequests.length > 0) {
-				const { data: links } = await supabase
-					.from('message_tag_link')
-					.insert(
-						insertedRequests
-							.filter((r) => r.message_id)
-							.map((r) => ({
-								message_id: r.message_id as string,
-								tag_slug: tagSlug,
-							}))
-					)
-					.select()
-					.throwOnError()
-				insertedLinks = links ?? []
-			}
-			return { requests: insertedRequests, links: insertedLinks }
-		},
-		onSuccess: ({ requests, links }) => {
-			for (const row of requests) {
-				const parsed = PhraseRequestSchema.parse(row)
-				phraseRequestsCollection.utils.writeInsert(parsed)
-				if (parsed.message_id) {
-					messagesCollection.utils.writeInsert({
-						id: parsed.message_id,
-						created_at: parsed.created_at,
-					})
-				}
-			}
-			for (const link of links) {
-				messageTagLinksCollection.utils.writeInsert(
-					MessageTagLinkSchema.parse(link)
+				setText('')
+			},
+			(err: unknown) => {
+				toastError(
+					err instanceof Error ? err.message : 'Failed to bulk-add messages'
 				)
+				console.error(err)
 			}
-			toastSuccess(
-				`Added ${requests.length} message${requests.length === 1 ? '' : 's'}` +
-					(tagSlug ? ` tagged "${tagSlug}"` : '')
-			)
-			setText('')
-		},
-		onError: (err: unknown) => {
-			toastError(
-				err instanceof Error ? err.message : 'Failed to bulk-add messages'
-			)
-			console.error(err)
-		},
-	})
+		)
+	}
 
 	return (
 		<section
@@ -827,10 +871,8 @@ function BulkAddSection({
 					<div className="flex items-center justify-end gap-2">
 						<Button
 							size="sm"
-							onClick={() => bulkAdd.mutate()}
-							disabled={
-								bulkAdd.isPending || prompts.length === 0 || !lang || !userId
-							}
+							onClick={runBulkAdd}
+							disabled={prompts.length === 0 || !lang || !userId}
 							data-testid="bulk-add-submit"
 						>
 							Add {prompts.length} message{prompts.length === 1 ? '' : 's'}

--- a/src/routes/_user/admin/messages.index.lazy.tsx
+++ b/src/routes/_user/admin/messages.index.lazy.tsx
@@ -794,6 +794,7 @@ function BulkAddSection({
 				type="button"
 				className="flex w-full items-center justify-between"
 				onClick={() => setOpen((v) => !v)}
+				data-testid="bulk-add-toggle"
 			>
 				<span className="inline-flex items-center gap-2 text-sm font-semibold">
 					<Plus className="h-4 w-4" />


### PR DESCRIPTION
Part of the #625 transform: moves the admin batch off `useMutation` + `collection.utils.write*`.

## Changes

- **`admin-archive-phrase.tsx`** — archive/unarchive → `phrasesCollection.update` (the `onUpdate` handler already existed); toasts on `tx.isPersisted.promise`.
- **`admin/$lang.requests.$id`** — request prompt edit and archive/restore toggle → `phraseRequestsCollection.update` (handler existed). The editor now closes optimistically instead of waiting for the server.
- **`admin/messages` bulk-add** → `createOptimisticAction`. `message_id` is generated by a DB trigger, so the optimistic `phrase_request` rows carry client ids only; the confirmed rows (now with `message_id`) plus their message and tag-link rows are synced via `writeInsert` inside the `mutationFn` — no refetch.

Dropped the now-moot `isPending` disables.

### Why `createOptimisticAction` (not a no-op) for bulk-add
A transaction with zero optimistic mutations resolves `isPersisted` **without** calling `mutationFn` (`transactions.js` short-circuits on `mutations.length === 0`), which would silently skip the server insert. Inserting the requests optimistically with client ids makes the transaction non-empty so `mutationFn` runs, and gives the reconciliation a stable key when the trigger-filled rows come back.

## Tests

- **`admin-mutations.spec.ts`** (new, TS — seeds requests + promotes the learner via `admin_user`): edits a prompt, archives a request, bulk-adds two messages, each asserting persisted DB state (toast-less paths use a `pollUntil` check).
- **`admin-phrases.spec.md`** — restore-an-archived-phrase scene (the unarchive half; archive was already covered).
- New testids (`admin-edit-prompt-*`, `admin-archive-request-button`, `bulk-add-toggle`) registered in `TEST_IDS.md`.

`pnpm check` + `oxlint` clean. Scenes were **not** executed here (no Docker/Supabase) — written to the code + testids, to verify in CI. The bulk-add scene's language-picker click and multi-line `typeInto` are the spots to watch on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSxVWZQSf19ymNwkXQHr2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSxVWZQSf19ymNwkXQHr2d)_