### PR TITLE
Add ASD-STE100 skill for simplified technical English

### DIFF
--- a/.claude/skills/asd-ste100/LICENSE
+++ b/.claude/skills/asd-ste100/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dustin Yuchen Teng
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/asd-ste100/SKILL.md
+++ b/.claude/skills/asd-ste100/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: Simplified Technical English (ASD-STE100)
+description: 'Rewrites ambiguous English into ASD-STE100 style — one meaning per word, active voice, simple tense, short sentences. Use when agent output is hard to parse; triggers: simplify this, STE100 rewrite.'
+version: 0.1.0
+---
+
+# Simplified Technical English (ASD-STE100)
+
+ASD-STE100 is a controlled-language standard built by the aerospace and defense industry (ASD, the AeroSpace and Defense Industries Association of Europe) to stop maintenance technicians from misreading English instructions. The standard removes the two biggest sources of misreading: words with more than one meaning, and sentences with more than one possible structure.
+
+This skill borrows that same discipline for a different reader: an **AI agent or a downstream system** that has to parse an English string — an error message, a tool description, an inter-agent instruction, a status report — without a human in the loop to resolve ambiguity. If a maintenance technician can misread "close the valve" as an adjective ("the valve that is near") instead of a command, so can a language model.
+
+## When to Use This Skill
+
+- An agent's output (explanation, instruction, log message, tool description) reads as dense, jargon-heavy, or ambiguous.
+- Text will be consumed by another agent, a translation pipeline, or a non-native English reader, and misparsing has a real cost.
+- You are writing a prompt, system message, or tool description and want to remove ambiguity before a model ever sees it.
+- You want a **before/after** comparison showing exactly which rule was violated and how the rewrite fixes it.
+
+This skill is not for creative or marketing copy — STE is deliberately flat and literal. Do not apply it to text where voice, nuance, or persuasion is the point.
+
+## Source and Scope
+
+This skill encodes the **rule categories** of ASD-STE100 Issue 9 (Jan 2025): 53 writing rules across 9 sections covering word choice, grammar, sentence structure, and style, backed by a dictionary of ~900 approved words (one meaning, one part of speech each) and ~1,200 words to avoid with suggested replacements. See `references/writing-rules.md` for the full rule summary and citations.
+
+It does **not** reproduce ASD's ~900-word approved dictionary verbatim — that document is ASD's own free-to-download standard, not something to copy wholesale. Instead, this skill applies the _underlying principle_ (pick the plainest, most common word available and use it the same way every time) rather than checking against a fixed word list. When exact ASD-approved wording matters (e.g. actual aircraft maintenance documentation), download the official standard at https://www.asd-ste100.org/ and check word-by-word against the real dictionary.
+
+## Core Rewrite Rules
+
+| Rule                         | Do                                                                                                                                                   | Don't                                                                                       |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| One word, one meaning        | Pick one verb for one action and reuse it every time (e.g. always "check", never mix "check"/"verify"/"confirm" for the same action)                 | Rotate synonyms for the same idea across a document                                         |
+| One part of speech per word  | "Apply oil to the valve" (oil = noun)                                                                                                                | "Oil the valve" (oil = verb) — if "oil" is only approved as a noun                          |
+| Active voice                 | "The agent deletes the file."                                                                                                                        | "The file is deleted (by the agent)." — unless the actor is genuinely unknown or irrelevant |
+| Simple tenses only           | "We received the report." (simple past)                                                                                                              | "We have received the report." (present perfect)                                            |
+| One instruction per sentence | "Open the file. Read line 3."                                                                                                                        | "Open the file and read line 3, then check if it matches."                                  |
+| Sentence length              | ≤20 words for instructions/procedures, ≤25 words for descriptions                                                                                    | Long compound/subordinate-clause sentences                                                  |
+| Noun clusters                | ≤3 words stacked as a noun phrase ("fuel pump valve")                                                                                                | 4+ word noun stacks ("high pressure fuel pump inlet valve assembly")                        |
+| No ellipsis                  | Keep the subject, verb, and article explicit even if it reads longer                                                                                 | Drop words to save space ("Files not backed up will be lost" → ambiguous which files)       |
+| Paragraph limits             | One topic per paragraph, ≤6 sentences                                                                                                                | Multi-topic paragraphs                                                                      |
+| Lists for sequences          | Use a numbered or bulleted list for 3+ steps or conditions                                                                                           | Bury a sequence inside one prose sentence                                                   |
+| Domain terms                 | Keep necessary technical nouns/verbs, but define them once if not common English (STE allows a project-specific glossary beyond its base dictionary) | Use jargon without ever defining it                                                         |
+
+## Process
+
+1. Read the input text once for meaning — do not start rewriting before you understand what it must still say afterward.
+2. Walk it sentence by sentence and flag every rule violation (word ambiguity, tense, voice, length, ellipsis, noun stacking).
+3. Rewrite each flagged sentence to fix the violation while preserving the original meaning exactly. If a rewrite would drop necessary precision (a safety condition, a scope qualifier, a number), keep the longer phrasing and flag it instead of silently simplifying.
+4. Produce a before/after table (see Output Format).
+5. If the input already complies, say so — do not force changes onto compliant text.
+
+## Output Format
+
+```markdown
+| Rule violated           | Original                                | Simplified                                  |
+| ----------------------- | --------------------------------------- | ------------------------------------------- |
+| Present perfect tense   | "We have received your request."        | "We received your request."                 |
+| Noun cluster (4+ words) | "the agent task queue priority handler" | "the handler that sets task-queue priority" |
+```
+
+Follow the table with a one-line note on anything you deliberately did **not** simplify, and why (usually: simplifying would lose required precision).
+
+## Boundaries
+
+**Will:**
+
+- Rewrite ambiguous or dense English into short, single-meaning, active-voice sentences.
+- Flag exactly which rule a sentence violates before rewriting it.
+- Preserve every fact, condition, and scope qualifier in the original.
+- Suggest a one-line glossary entry for domain terms that must stay.
+
+**Will not:**
+
+- Reproduce ASD's official ~900-word dictionary as if it were memorized verbatim — always treat the official download as the source of truth for exact approved wording.
+- Simplify creative, marketing, or persuasive copy where voice and nuance are the point.
+- Silently drop a safety condition, exception, or scope qualifier to shorten a sentence — it will flag the trade-off instead.
+- Guarantee an aerospace/defense-grade STE-compliant document; this is a general-purpose clarity tool inspired by STE, not a certified STE authoring tool.
+
+## Additional Resources
+
+- **`references/writing-rules.md`** — fuller summary of the 9 rule sections and dictionary structure, with citations to the official standard and secondary sources.
+- **`examples/before-after.md`** — worked examples, including official STE examples and agent-output examples built for this skill.
+
+## Credit
+
+Vendored from [danyuchn/asd-ste100-skill](https://github.com/danyuchn/asd-ste100-skill) (MIT, © 2026 Dustin Yuchen Teng). See `LICENSE`.

--- a/.claude/skills/asd-ste100/examples/before-after.md
+++ b/.claude/skills/asd-ste100/examples/before-after.md
@@ -1,0 +1,59 @@
+# Before / After Examples
+
+## Part 1 — Official STE Examples
+
+These illustrate real ASD-STE100 rules, drawn from public secondary sources (see `references/writing-rules.md`). They are paraphrased illustrations of the rule, not quotes from the standard itself.
+
+| Rule | Before | After | Why |
+|---|---|---|---|
+| One meaning per word | "Verify the system." / "Check the connections." / "Confirm receipt." | "Make sure the system is correct." (one approved term used consistently) | Three near-synonyms force the reader to guess whether they mean the same action. |
+| One part of speech per word | "Oil the valve." | "Apply oil to the valve." | If "oil" is approved only as a noun, using it as a verb breaks the one-word-one-role guarantee. |
+| Precise verb meaning | "Follow the safety instructions." | "Obey the safety instructions." | "Follow" can mean "come after" or "obey" — STE picks the unambiguous one. |
+| Simple tense only | "We have received the technical reports from HQ." | "We received the technical reports from HQ." | Present perfect adds a second parse ("received, and still relevant now?") that simple past avoids. |
+
+## Part 2 — Applied to Agent Output
+
+These are original examples built for this skill's actual use case: rewriting AI agent output so another agent, a translation layer, or a non-native reader can parse it without ambiguity. They are illustrations, not quotes from any real system.
+
+### Example A — Tool description
+
+**Before:**
+> This tool will attempt to synchronize state across the various backends that have been configured, and if a conflict is detected it may resolve it automatically depending on the strategy that has been set, or otherwise it will surface the conflict for manual review.
+
+**Violations flagged:**
+- Two instructions in one sentence (sync + resolve/surface).
+- Present-perfect and modal stacking ("have been configured", "may resolve", "has been set") — multiple hedges compound ambiguity.
+- 55 words, far over the 25-word descriptive cap.
+
+**After:**
+> The tool synchronizes state across the configured backends. If it finds a conflict, it checks the current strategy. If the strategy allows automatic resolution, the tool resolves the conflict. If not, the tool reports the conflict for manual review.
+
+### Example B — Error message
+
+**Before:**
+> An error may have occurred while processing your request due to a possible mismatch in the expected data format, which could be caused by an outdated client version.
+
+**Violations flagged:**
+- Passive voice with unclear actor ("an error may have occurred").
+- Present perfect + double hedge ("may have occurred", "could be caused").
+- One sentence carrying two separate claims (error occurred; possible cause).
+
+**After:**
+> The request failed. The data format did not match what the server expected. Check your client version — an outdated client is the most common cause.
+
+### Example C — Inter-agent instruction
+
+**Before:**
+> Once the upstream job has completed and assuming no errors were raised, the downstream agent should proceed to consume the output artifact, though it is worth noting that partial artifacts are sometimes produced under timeout conditions.
+
+**Violations flagged:**
+- Present perfect ("has completed") and subordinate-clause stacking ("assuming...", "though it is worth noting...").
+- One sentence, three separate facts (completion condition, next action, edge-case warning).
+- 42 words, over the 20-word instruction cap.
+
+**After:**
+> Wait for the upstream job to finish with no errors. Then read the output artifact. Warning: a timeout can produce a partial artifact. Check the artifact is complete before you use it.
+
+## How to Read These Examples
+
+Part 1 shows the actual rules this skill is built on. Part 2 shows the transfer: the same discipline — one meaning per word, active voice, simple tense, one instruction per sentence, explicit conditions instead of buried subordinate clauses — makes machine-to-machine and cross-language text safer to parse, not just aircraft manuals.

--- a/.claude/skills/asd-ste100/references/writing-rules.md
+++ b/.claude/skills/asd-ste100/references/writing-rules.md
@@ -1,0 +1,56 @@
+# ASD-STE100 Writing Rules — Summary and Sources
+
+This file summarizes the public, official description of ASD-STE100 (Simplified Technical English). It paraphrases rule *categories*; it does not reproduce the standard's text or its ~900-word dictionary verbatim. For the authoritative document, request the free download at the official site.
+
+## What ASD-STE100 Is
+
+ASD-STE100 is a controlled natural language, first released in 1986 (as AECMA Document PSC-85-16598) by what is now ASD (the AeroSpace and Defense Industries Association of Europe). It was built at the request of European airlines — most staffed by non-native English speakers — who needed maintenance documentation that could not be misread, because a misread instruction on an aircraft can kill people. The standard is maintained by the Simplified Technical English Maintenance Group (STEMG) and has been free to download since Issue 6 (2013). The current edition is Issue 9 (January 2025).
+
+## Structure
+
+- **53 writing rules across 9 sections** covering word choice, grammar, sentence structure, and style.
+- **A dictionary** of roughly 900 approved words, each restricted to one meaning and one part of speech, plus roughly 1,200 words to avoid with suggested replacements.
+- **A terminology allowance**: organizations may define their own dictionary of approved technical nouns and verbs beyond the base ~900 words, for domain-specific vocabulary the base dictionary can't cover.
+
+## Rule Categories (Paraphrased)
+
+**Word choice**
+- Use approved words only in their approved meaning and part of speech.
+- Each word maps to exactly one meaning — don't rely on context to disambiguate a word that has several dictionary senses.
+- Prefer the plainer, shorter, more common word over a formal or rare synonym.
+
+**Verb forms**
+- Permitted forms: infinitive, imperative, simple present, simple past, simple future, and past participle used only as an adjective.
+- No present perfect, past perfect, or other compound/auxiliary constructions ("we have received" is not allowed; "we received" is).
+- "-ing" forms are permitted only as a technical noun or as part of a technical noun, not as a verb form.
+
+**Voice**
+- Active voice is required for procedures and instructions.
+- Passive voice is allowed only in descriptive text, and only when the actor performing the action is genuinely unknown or irrelevant to the reader.
+
+**Sentence structure**
+- One instruction per sentence.
+- Maximum ~20 words per sentence for procedures/instructions; maximum ~25 words for descriptive text.
+- Do not omit sentence parts (verb, subject, article) just to shorten the sentence — the standard explicitly warns that this creates ambiguity rather than clarity.
+- Noun clusters (strings of nouns stacked as a modifier) are capped at 3 words.
+
+**Paragraph and document structure**
+- One topic per paragraph.
+- Maximum ~6 sentences per paragraph.
+- Use vertical (numbered or bulleted) lists for sequences, conditions, or complex enumerations instead of burying them in prose.
+
+**Safety instructions**
+- Safety-critical instructions must open with a clear command or condition, not be buried mid-sentence.
+
+## Why This Skill Repurposes STE for Agent Output
+
+STE was designed to eliminate ambiguity for a reader who cannot ask a follow-up question — a technician on a tarmac, working from a manual, with no author to call. An AI agent parsing another agent's output, a tool description, or a system message is in the same position: no back-channel to resolve "does this passive-voice sentence mean the caller does X, or the callee does X?" The same rule set that protects an airline mechanic from a misread torque spec protects a downstream agent from a misread instruction.
+
+## Sources
+
+- [ASD-STE100 official site](https://www.asd-ste100.org/)
+- [ASD-STE100 — About STE](https://www.asd-ste100.org/about_STE.html)
+- [ASD Europe — Simplified Technical English](https://www.asd-europe.org/standards-specifications/simplified-technical-english/)
+- [Simplified Technical English — Wikipedia](https://en.wikipedia.org/wiki/Simplified_Technical_English)
+- [TechScribe — ASD-STE100 Simplified Technical English](https://www.techscribe.co.uk/techw/asd-simplified-technical-english.htm)
+- [SKYbrary — Simplified Technical English (STE)](https://skybrary.aero/articles/simplified-technical-english-ste)


### PR DESCRIPTION
## Summary

Adds a new Claude skill for rewriting ambiguous or dense English into ASD-STE100 (Simplified Technical English) style. This skill is designed to clarify AI agent output, tool descriptions, inter-agent instructions, and other machine-to-machine text that must be parsed without human disambiguation.

## Changes

- **`SKILL.md`** — Core skill definition with:
  - Overview of ASD-STE100 and its application to agent output
  - When to use the skill (dense/ambiguous agent output, downstream parsing, prompt clarity)
  - 11 core rewrite rules (one word per meaning, active voice, simple tense, sentence length, noun clusters, etc.)
  - Step-by-step process for identifying and fixing violations
  - Output format (before/after table with rule citations)
  - Clear boundaries on what the skill will and will not do

- **`examples/before-after.md`** — Worked examples showing:
  - Official STE rule illustrations (word ambiguity, part of speech, verb precision, tense)
  - Applied examples for agent output (tool descriptions, error messages, inter-agent instructions)
  - Explanation of how the same discipline that protects aircraft maintenance also protects machine-to-machine parsing

- **`references/writing-rules.md`** — Reference documentation:
  - Summary of ASD-STE100 structure (53 rules across 9 sections, ~900-word dictionary)
  - Paraphrased rule categories (word choice, verb forms, voice, sentence structure, paragraph structure, safety)
  - Rationale for repurposing STE for agent output
  - Links to official sources and secondary references

- **`LICENSE`** — MIT license (vendored from danyuchn/asd-ste100-skill)

## Implementation Notes

- The skill does **not** reproduce ASD's official ~900-word dictionary verbatim; instead it applies the underlying principle (plainest, most common word, used consistently) and directs users to the official standard for exact approved wording.
- The skill is scoped to clarity and precision, not creative or marketing copy.
- Output format is a before/after table with rule violations flagged, followed by notes on any deliberate non-simplifications (to preserve safety conditions or required precision).

https://claude.ai/code/session_01HUbeF2w7n2vzXzGeePgeH1