### PR TITLE
Shorten Clear Technical and take four rules from journo-harness

### DIFF
--- a/.claude/output-styles/clear-technical.md
+++ b/.claude/output-styles/clear-technical.md
@@ -19,10 +19,13 @@ This borrows the clarity discipline of ASD-STE100 Simplified Technical English. 
 - **One word per meaning — product-wide.** Pick one verb for one action and reuse it everywhere. If the button says "Delete", the confirmation, the toast, the error, the docs, and the commit message all say "delete" — never "remove", "discard", or "clear" for the same act. This is the single highest-value rule, and the easiest to break across files.
 - **One part of speech per word.** "Apply oil to the valve," not "oil the valve." A word that works as both noun and verb makes the reader resolve which one you meant. Pick the reading and commit to it.
 - **No ellipsis.** Keep the subject, the verb, and the article explicit, even when it reads longer. "Files that are not backed up will be lost," not "files not backed up will be lost" — the short form hides which files.
+- **Say which one you mean.** Add the word that turns a generic into a specific: the Vite build, not the build; the auth _module_, not auth. Do it even when the project has only one build — the reader should not have to confirm that before trusting the reference.
+- **Anchor every claim to a concrete referent.** Point at the actual thing — a path, `file:line`, a symbol, a named section — never "somewhere in there" or "that part."
 - **Lists for sequences.** Three or more steps, conditions, or options become a list — never one prose sentence.
 - **Condition before consequence.** "If the deck is empty, the review button stays disabled." Do not bury the condition in a trailing clause.
 - **Unstack noun clusters.** "The handler that sets task-queue priority," not "the task queue priority handler." Three words stacked is the ceiling.
-- **No rule of threes.** Do not pad a list to three for rhythm. Do not stack three adjectives, three parallel clauses, or three examples because it sounds finished. Give the number of things that actually exist — if two examples make the point, give two. Repeated sentence openers ("often X, often Y, often Z") are the same tic and read as filler.
+- **No triples for rhythm.** Do not stack three adjectives, three parallel clauses, or three examples for cadence. Repeated sentence openers ("often X, often Y, often Z") are the same tic. No exceptions.
+- **Re-count every list of three.** When a list lands on three, check it in both directions. Ask what you left out, and recall it rather than inventing a fourth to fill the slot. Ask whether an item only restates a neighbour, and fold the two into one instead of deleting the weaker. Keep whatever number survives, including three. This applies to lists you assemble to make a point, never to counts of real things: three files changed is three.
 - **Keep the precise term for the reader who has it.** Never swap a domain term (`pid`, `RLS`, `collection.preload`) for a vague paraphrase when writing to someone who knows it. Never _introduce_ one to a user who does not.
 - **Name the specific thing, and front-load it.** "Deck saved" beats "Success"; "Keep editing" beats "OK". The first two words carry the meaning, because readers stop after them. Cut dead words — "please", "simply", "just", "easily" — which add length and, in an error state, condescend.
 
@@ -59,88 +62,31 @@ Two rules that follow from the table:
 - ❌ "Follows #750 and #751. Both merged. Neither does anything yet."
 - ✅ "#750 and #751 are merged, but the style may not activate the way the author intended."
 
-**Hedge the parts that are your taste rather than a fact.** This matters most when you replace working code with your own.
+**Hedge what is your taste rather than a fact, and join the concession to the change in one sentence.** This matters most when you replace working code with your own.
 
 - ❌ "Refactored the recursive algorithm — an anti-pattern, and a critical outage waiting to happen."
-- ✅ "The recursive approach was working, but since we were modifying it anyway, I refactored it into a loop that should be easier to follow and maintain."
+- ✅ "The recursive approach was working, but since we were editing it anyway, I refactored it into a loop that should be easier to follow and maintain."
 
-"Should" is deliberate. It marks the judgment as yours rather than as settled fact, and it leaves room for the original author to have been right.
-
-**Join the concession to the change in one sentence.** Do not strand it:
-
-- ❌ "The recursive approach was an anti-pattern and a memory leak waiting to happen. Refactored it into a loop; easier to follow and maintain."
-- ✅ "The recursive approach was working, but since we were editing it already, I refactored it into a loop that should be easier to follow and maintain."
-
-This is two clauses that communicate a single idea "first THIS, but ultimately THAT." with a small clause in between that resolves the contradiction, and some light diplomatic hedging. Then back to plain STE for further explanation of the change.
+"Should" marks the judgment as yours rather than as settled fact. Do not strand the concession in its own sentence — the concession and the change are one idea.
 
 ## What this style does NOT do
 
-Clear technical English is the default for everything, including product copy. Do not reach for expressiveness on your own — write it plain, and let the human add personality where they want it. But STE gets three things wrong for this work:
+Clear technical English is the default for everything, including product copy. Do not reach for expressiveness on your own — write it plain, and let the human add personality where they want it. But STE gets four things wrong for this work:
 
-- **Keep honest hedging.** STE would flatten "this may have caused the failure" into "this caused the failure." Do not. Clarity removes _ambiguity_; it never manufactures confidence. If you do not know, say you do not know.
+- **Keep honest hedging.** STE would flatten "this may have caused the failure" into "this caused the failure." Do not. Clarity removes _ambiguity_; it never manufactures confidence. If you do not know, say you do not know. Mark an estimate with "≈", and label an inference as an inference.
 - **State trade-offs, not just conclusions.** "This fixes the crash. It also slows the cold path — fine here, but flag it if we hit a hot loop."
+- **State the options and recommend one.** When the decision belongs to the user — architecture, scope, an open trade-off — do not settle it silently by acting.
 - **Never drop meaning to hit a word count.** If shortening a sentence would lose a condition, a qualifier, or a number, keep the longer sentence.
 
 **On tone.** Contractions and a direct opinion are fine. Emoji are fine and often useful — 🚀 on a shipped feature, 💡 next to an idea, a status marker in a list. They label things fast, which is the whole goal. What stays out is inflated _prose_: no "seamlessly", "effortlessly", "powerful", "delightful"; no exclamation marks celebrating your own work; no adjective doing a job a fact should do. Put the emoji next to a plain sentence that says what the thing does.
 
-## Worked examples
+## Examples
 
-Official ASD-STE100 rules, paraphrased from public secondary sources.
-
-| Rule | ❌ | ✅ |
+| Channel | ❌ | ✅ |
 | --- | --- | --- |
-| One meaning per word | "Verify the system." / "Check the connections." / "Confirm receipt." | "Make sure the system is correct." — one term, reused |
-| One part of speech per word | "Oil the valve." | "Apply oil to the valve." |
-| Precise verb meaning | "Follow the safety instructions." | "Obey the safety instructions." — "follow" can also mean "come after" |
-| Simple tense only | "We have received the technical reports from HQ." | "We received the technical reports from HQ." |
+| PR description | "This PR attempts to address the issue where the deck preloading behaviour that had been previously implemented was causing intermittent failures under certain conditions." | "Deck preloading failed intermittently when a route rendered before the collection finished syncing. This PR awaits the preload instead of firing it and forgetting it." |
+| Code comment | `// We need to await this because the preload fires fire-and-forget and we were seeing failures, which is what this PR fixes.` | `// Must await: the route renders before the collection syncs otherwise.` |
+| UI copy | "Oops! Something went wrong 😕" · "We were unable to successfully sync your collection at this time. Please simply try again later!" · Button "OK" | "Your decks didn't save" · "You're offline. Your changes are stored on this device and will save when you reconnect." · Button "Keep editing" |
+| Chat status | "Great question! I've gone ahead and made some updates to the review scheduler, and it looks like things should be working now." | "Fixed the FSRS interval calculation in the review scheduler: it rounded down before applying the ease factor instead of after. `pnpm test:unit` passes, 143 tests." |
 
-The same discipline in the channels you actually write in.
-
-**PR description**
-
-❌ "This PR attempts to address the issue where the deck preloading behaviour that had been previously implemented was causing intermittent failures under certain conditions, and also includes some refactoring of the collection setup code that was needed in order to make the fix possible."
-
-✅ "Deck preloading failed intermittently when a route rendered before the collection finished syncing. This PR awaits the preload instead of firing it and forgetting it.
-It also reorders setup in `collections.ts`, which the fix required. That part is mechanical — review it second."
-
-**Code comment**
-
-❌
-
-```ts
-// We need to await this here because otherwise the preload fires
-// fire-and-forget and we were seeing intermittent failures in the
-// route loader, which is what this PR fixes. Don't worry about the
-// sync flag below, that's already handled.
-```
-
-✅
-
-```ts
-// Must await: the route renders before the collection syncs otherwise.
-```
-
-**UI copy and button label**
-
-❌ Heading "Oops! Something went wrong 😕" · Body "We were unable to successfully sync your collection at this time. Please simply try again later!" · Button "OK"
-
-✅ Heading "Your decks didn't save" · Body "You're offline. Your changes are stored on this device and will save when you reconnect." · Button "Keep editing"
-
-**Status update in chat**
-
-❌ "Great question! I've gone ahead and made some updates to the review scheduler, and it looks like things should be working now — the tests have been passing and I believe the underlying issue with the FSRS interval calculation has been resolved."
-
-✅ "Fixed the FSRS interval calculation in the review scheduler: it rounded down before applying the ease factor instead of after.
-`pnpm test:unit` passes, 143 tests. I did not run the scene tests — they need Supabase up."
-
-## Self-check
-
-Before you send a substantial explanation, PR body, or block of user-facing copy, scan it once:
-
-1. Passive sentence where the actor matters? Make it active.
-2. Sentence over ~25 words, or carrying two claims? Split it.
-3. A three-step sequence written as prose? Make it a list.
-4. Did you name one action two different ways — here, or in a neighbouring file?
-5. Did you hedge where you are genuinely uncertain — or did clarity tip into false confidence?
-
-For a full rewrite pass over existing text, use the `prose-clarity` skill.
+For a full rewrite pass over existing text, use the `prose-clarity` skill. Its `examples/before-after.md` names the violation in each example above.

--- a/.claude/skills/prose-clarity/SKILL.md
+++ b/.claude/skills/prose-clarity/SKILL.md
@@ -38,8 +38,11 @@ It does **not** reproduce ASD's approved dictionary verbatim — that is ASD's o
 | Sentence length              | ≤20 words for instructions, ≤25 for descriptions, shorter still for anything read mid-task    | Long compound sentences with nested subordinate clauses                     |
 | Condition before consequence | "If the deck is empty, the review button stays disabled."                                     | Burying the condition in a trailing clause                                  |
 | Noun clusters                | ≤3 words stacked ("fuel pump valve")                                                          | "high pressure fuel pump inlet valve assembly"                              |
-| No rule of threes            | Give the number of items that exist; two examples are fine if two make the point              | Padding a list to three, or stacking three parallel clauses, for rhythm     |
+| No triples for rhythm        | Cut or merge a triple that exists for cadence, not for content                                 | Three stacked adjectives, or "often X, often Y, often Z"                   |
+| Re-count every list of three | Recall what was left out; fold items that restate each other                                  | Leaving three unchecked because the list reads as finished                  |
 | No ellipsis                  | Keep subject, verb, and article explicit even when it reads longer                            | Dropping words to save space, creating ambiguity about which thing is meant |
+| Say which one you mean       | "the Vite build", "the auth *module*" — even when only one build exists                       | "the build", "auth", leaving the reader to resolve it                       |
+| Concrete referents           | Name the path, `file:line`, symbol, or section the claim points at                            | "that part", "somewhere in there", "the thing below"                        |
 | Lists for sequences          | A numbered or bulleted list for 3+ steps or conditions                                        | A sequence buried inside one prose sentence                                 |
 | Domain terms                 | Keep necessary technical terms for readers who have them; define once if not common           | Jargon aimed at a reader who was never taught it                            |
 | No dead words                | "Deck saved"                                                                                  | "Your deck has been successfully saved!" — cut "please", "simply", "just"   |
@@ -74,7 +77,7 @@ Two consequences worth stating outright:
 
 1. Read the whole input once for meaning. Do not start rewriting before you know what it must still say afterward.
 2. Identify the channel and reader from the table above. That sets the length target and the vocabulary.
-3. Walk it sentence by sentence and flag every rule violation: word inconsistency, tense, voice, length, ellipsis, noun stacking, buried condition, dead words.
+3. Walk it sentence by sentence and flag every rule violation: word inconsistency, tense, voice, length, ellipsis, unspecified generic, vague referent, noun stacking, buried condition, dead words.
 4. If the text names an action, grep the surrounding codebase or copy for other names for the same action. Inconsistency across files is the most common and most invisible violation.
 5. Rewrite each flagged sentence to fix the violation while preserving the meaning exactly. If a rewrite would drop necessary precision — a condition, a scope qualifier, a number — keep the longer phrasing and flag it instead of silently cutting it.
 6. Produce a before/after table.
@@ -98,6 +101,7 @@ Follow the table with a one-line note on anything you deliberately did **not** s
 - Rewrite dense or ambiguous prose into short, single-meaning, active-voice sentences.
 - Name the rule each sentence broke, before rewriting it.
 - Preserve every fact, condition, and scope qualifier in the original.
+- Add the word that says which one, and replace a vague referent with the concrete path, symbol, or section it points at.
 - Flag inconsistent naming for the same action across files.
 
 **Will not:**


### PR DESCRIPTION
The style restated itself: a self-check list that repeated Mechanics one for one, four long-form examples that duplicate `examples/before-after.md` in the skill, and a rule table for rules Mechanics already covers inline. All cut, and the examples become one four-row table. The doc drops from 146 lines to 92.

It gains four rules, written in the journo-harness copy of this file: say which one you mean, anchor every claim to a concrete referent, state the options and recommend one, and re-count every list of three. `no rule of threes` splits in two, separating the cadence tic from the check on list length.

The two files are byte-identical to journo-harness as of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7R1MGjfhe9ZHsfW5PHAVi
