### PR TITLE
Add Em Snook's copyright line to the prose-clarity LICENSE

### DIFF
--- a/.claude/skills/prose-clarity/LICENSE
+++ b/.claude/skills/prose-clarity/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2026 Dustin Yuchen Teng
+Copyright (c) 2026 Em Snook
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The skill is a modified derivative of [danyuchn/asd-ste100-skill](https://github.com/danyuchn/asd-ste100-skill). MIT requires the original notice to stay, so this adds a second copyright line rather than replacing his. Both authors license on the same terms, and the permission and warranty text is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7R1MGjfhe9ZHsfW5PHAVi
