### PR TITLE
Add mhsnook marketplace and enable spec-debt & ci-delta plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
 	"outputStyle": "Clear Technical",
+	"extraKnownMarketplaces": {
+		"mhsnook": {
+			"source": {
+				"source": "github",
+				"repo": "mhsnook/skills"
+			}
+		}
+	},
+	"enabledPlugins": {
+		"spec-debt@mhsnook": true,
+		"ci-delta-reports@mhsnook": true
+	},
 	"hooks": {
 		"PreToolUse": [
 			{


### PR DESCRIPTION
Registers the `mhsnook` GitHub marketplace as a known source and enables two plugins from that marketplace for enhanced development tooling.

**Changes:**
- Added `mhsnook` to `extraKnownMarketplaces` pointing to the `mhsnook/skills` GitHub repository
- Enabled `spec-debt@mhsnook` plugin for tracking specification debt
- Enabled `ci-delta-reports@mhsnook` plugin for CI delta reporting

These plugins integrate with Claude Code to provide additional analysis and reporting capabilities during development.

https://claude.ai/code/session_01Pm88v75c9a9aJm712Y7BqQ