### PR TITLE
Stop the copy-link scene waiting for its toast to disappear

### DIFF
--- a/scenetest/scenes/requests.spec.md
+++ b/scenetest/scenes/requests.spec.md
@@ -77,6 +77,12 @@ learner:
 // The permalink points back at the request with the comment id in `focus`, so
 // the link opens the thread scrolled to that comment. Writing to the clipboard
 // needs a browser permission, granted for every actor in scenetest/config.ts.
+//
+// @@TODO `see` rather than `seeToast`, which waits for the toast to disappear.
+// The context menu is right-aligned, so if the mouse is left nearby, sonner
+// reads it as a hover, pauses the dismiss timer, and the toast never goes away.
+// The preceding `openTo` clears any earlier toast, and an error toast fails the
+// scene through errorSelectors.
 
 learner:
 
@@ -88,4 +94,4 @@ learner:
 - up
 - click copy-link-menu-item
 - up
-- seeToast toast-success
+- see toast-success


### PR DESCRIPTION
Fixes the one scene failing on `main` after #774. `seeToast` waits for the toast to appear **and then to disappear**, and the disappearance was timing out because the virtual mouse was virtual hovering over the toast, so they weren't going away.

## The fix

`see toast-success` instead of `seeToast toast-success`. The scene cares that copying produced a success toast, not that the toast auto-dismissed on schedule — that's a UI implementation detail, and tying the assertion to it makes the scene depend on where the mouse happens to be left.

Nothing is lost by dropping the disappearance check here: the preceding `openTo` cleared any earlier toast, so the toast seen is necessarily this action's, and an error toast still fails the scene through `errorSelectors`.

`pnpm scene scenetest/scenes/requests.spec.md` — 5/5 scenes, 38/38 assertions.

## Follow-ups, not in this PR

- **Upstream:** filed scenetest/scenetest-js#246 proposing `seeToast` assert it got a *new* toast rather than waiting for the old one to vanish. That fixes this class of flake generally, and closes a silent false-positive in the current implementation.

https://claude.ai/code/session_01Y95qMgrdnTw3PiUC5ujrem