### PR TITLE
Fold friend summaries from the action log, retiring the last refetch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,19 +101,19 @@ Sunlo is a language-learning app: FSRS spaced-repetition flashcards, social feat
 
 Deep-module architecture: each domain owns `schemas.ts`, `collections.ts`, `hooks.ts`, and a barrel `index.ts` (some add `live.ts`, `mutations.ts`, `store.ts`, `fsrs.ts`). Modules are deliberately wide where concepts are inseparable — `requests/` holds requests + comments + comment→phrase links + upvotes because a comment without a request is meaningless; don't split a wide module to satisfy a lint rule.
 
-| Domain          | Schemas                                                   | Collections                                                   | Key Hooks                                                          |
-| --------------- | --------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------ |
-| `profile`       | PublicProfile, MyProfile, LanguageKnown                   | publicProfiles, myProfile                                     | useAuth, useProfile                                                |
-| `languages`     | Language, LangTag, LangSchema                             | languages, langTags                                           | useLanguageMeta, useLanguageTags                                   |
-| `phrases`       | PhraseFull, Translation, PhraseSearch                     | phrases, phrasesFull (live)                                   | useLanguagePhrases, usePhrase                                      |
-| `deck`          | Deck, Card                                                | decks, cards, cardsWithReviews (live)                         | useDeck, useDeckCards, useDeckPids, useCardScheduling              |
-| `review`        | CardReview, DailyReviewState                              | cardReviews, reviewDays                                       | useReviewsToday, useReviewMutation                                 |
-| `requests`      | PhraseRequest, RequestComment, CommentPhraseLink, upvotes | phraseRequests, comments, commentPhraseLinks, upvotes         | useRequest, useRequestCounts, useOneComment, useCommentPhraseLinks |
-| `social`        | FriendRequestAction, FriendSummary, ChatMessage           | friendRequestActions, chatMessages, relationsFullQuery (live) | useRelationFriends, useAllChats, useSocialRealtime                 |
-| `chat`          | ChatQuery, ChatTurn, ChatResultPhrase                     | (zustand store, no collection — prototype phrasebook search)  | useChatStore, useChatTurns, useChatSearch                          |
-| `notifications` | Notification                                              | notifications                                                 | useNotifications, useUnreadCount, useMarkAsRead                    |
-| `playlists`     | PhrasePlaylist, PlaylistPhraseLink                        | phrasePlaylists, playlistPhraseLinks                          | useOnePlaylist, useLangPlaylists                                   |
-| `feed`          | FeedActivity                                              | (uses React Query — the one `useInfiniteQuery` feature)       | useFeedLang                                                        |
+| Domain          | Schemas                                                   | Collections                                                                | Key Hooks                                                          |
+| --------------- | --------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `profile`       | PublicProfile, MyProfile, LanguageKnown                   | publicProfiles, myProfile                                                  | useAuth, useProfile                                                |
+| `languages`     | Language, LangTag, LangSchema                             | languages, langTags                                                        | useLanguageMeta, useLanguageTags                                   |
+| `phrases`       | PhraseFull, Translation, PhraseSearch                     | phrases, phrasesFull (live)                                                | useLanguagePhrases, usePhrase                                      |
+| `deck`          | Deck, Card                                                | decks, cards, cardsWithReviews (live)                                      | useDeck, useDeckCards, useDeckPids, useCardScheduling              |
+| `review`        | CardReview, DailyReviewState                              | cardReviews, reviewDays                                                    | useReviewsToday, useReviewMutation                                 |
+| `requests`      | PhraseRequest, RequestComment, CommentPhraseLink, upvotes | phraseRequests, comments, commentPhraseLinks, upvotes                      | useRequest, useRequestCounts, useOneComment, useCommentPhraseLinks |
+| `social`        | FriendRequestAction, FriendSummary, ChatMessage           | friendRequestActions, chatMessages, friendSummaries + relationsFull (live) | useRelationFriends, useAllChats, useSocialRealtime                 |
+| `chat`          | ChatQuery, ChatTurn, ChatResultPhrase                     | (zustand store, no collection — prototype phrasebook search)               | useChatStore, useChatTurns, useChatSearch                          |
+| `notifications` | Notification                                              | notifications                                                              | useNotifications, useUnreadCount, useMarkAsRead                    |
+| `playlists`     | PhrasePlaylist, PlaylistPhraseLink                        | phrasePlaylists, playlistPhraseLinks                                       | useOnePlaylist, useLangPlaylists                                   |
+| `feed`          | FeedActivity                                              | (uses React Query — the one `useInfiniteQuery` feature)                    | useFeedLang                                                        |
 
 **Imports**: consumer code (routes, components) imports from the barrel (`@/features/deck`); cross-domain wiring imports specific files (`@/features/deck/collections`); intra-feature imports are relative (`./schemas`). Always use the `@/` alias otherwise.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,19 +101,19 @@ Sunlo is a language-learning app: FSRS spaced-repetition flashcards, social feat
 
 Deep-module architecture: each domain owns `schemas.ts`, `collections.ts`, `hooks.ts`, and a barrel `index.ts` (some add `live.ts`, `mutations.ts`, `store.ts`, `fsrs.ts`). Modules are deliberately wide where concepts are inseparable — `requests/` holds requests + comments + comment→phrase links + upvotes because a comment without a request is meaningless; don't split a wide module to satisfy a lint rule.
 
-| Domain          | Schemas                                                   | Collections                                                  | Key Hooks                                                          |
-| --------------- | --------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------ |
-| `profile`       | PublicProfile, MyProfile, LanguageKnown                   | publicProfiles, myProfile                                    | useAuth, useProfile                                                |
-| `languages`     | Language, LangTag, LangSchema                             | languages, langTags                                          | useLanguageMeta, useLanguageTags                                   |
-| `phrases`       | PhraseFull, Translation, PhraseSearch                     | phrases, phrasesFull (live)                                  | useLanguagePhrases, usePhrase                                      |
-| `deck`          | Deck, Card                                                | decks, cards, cardsWithReviews (live)                        | useDeck, useDeckCards, useDeckPids, useCardScheduling              |
-| `review`        | CardReview, DailyReviewState                              | cardReviews, reviewDays                                      | useReviewsToday, useReviewMutation                                 |
-| `requests`      | PhraseRequest, RequestComment, CommentPhraseLink, upvotes | phraseRequests, comments, commentPhraseLinks, upvotes        | useRequest, useRequestCounts, useOneComment, useCommentPhraseLinks |
-| `social`        | FriendSummary, ChatMessage                                | friendSummaries, chatMessages, relationsFull (live)          | useRelationFriends, useAllChats, useSocialRealtime                 |
-| `chat`          | ChatQuery, ChatTurn, ChatResultPhrase                     | (zustand store, no collection — prototype phrasebook search) | useChatStore, useChatTurns, useChatSearch                          |
-| `notifications` | Notification                                              | notifications                                                | useNotifications, useUnreadCount, useMarkAsRead                    |
-| `playlists`     | PhrasePlaylist, PlaylistPhraseLink                        | phrasePlaylists, playlistPhraseLinks                         | useOnePlaylist, useLangPlaylists                                   |
-| `feed`          | FeedActivity                                              | (uses React Query — the one `useInfiniteQuery` feature)      | useFeedLang                                                        |
+| Domain          | Schemas                                                   | Collections                                                   | Key Hooks                                                          |
+| --------------- | --------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `profile`       | PublicProfile, MyProfile, LanguageKnown                   | publicProfiles, myProfile                                     | useAuth, useProfile                                                |
+| `languages`     | Language, LangTag, LangSchema                             | languages, langTags                                           | useLanguageMeta, useLanguageTags                                   |
+| `phrases`       | PhraseFull, Translation, PhraseSearch                     | phrases, phrasesFull (live)                                   | useLanguagePhrases, usePhrase                                      |
+| `deck`          | Deck, Card                                                | decks, cards, cardsWithReviews (live)                         | useDeck, useDeckCards, useDeckPids, useCardScheduling              |
+| `review`        | CardReview, DailyReviewState                              | cardReviews, reviewDays                                       | useReviewsToday, useReviewMutation                                 |
+| `requests`      | PhraseRequest, RequestComment, CommentPhraseLink, upvotes | phraseRequests, comments, commentPhraseLinks, upvotes         | useRequest, useRequestCounts, useOneComment, useCommentPhraseLinks |
+| `social`        | FriendRequestAction, FriendSummary, ChatMessage           | friendRequestActions, chatMessages, relationsFullQuery (live) | useRelationFriends, useAllChats, useSocialRealtime                 |
+| `chat`          | ChatQuery, ChatTurn, ChatResultPhrase                     | (zustand store, no collection — prototype phrasebook search)  | useChatStore, useChatTurns, useChatSearch                          |
+| `notifications` | Notification                                              | notifications                                                 | useNotifications, useUnreadCount, useMarkAsRead                    |
+| `playlists`     | PhrasePlaylist, PlaylistPhraseLink                        | phrasePlaylists, playlistPhraseLinks                          | useOnePlaylist, useLangPlaylists                                   |
+| `feed`          | FeedActivity                                              | (uses React Query — the one `useInfiniteQuery` feature)       | useFeedLang                                                        |
 
 **Imports**: consumer code (routes, components) imports from the barrel (`@/features/deck`); cross-domain wiring imports specific files (`@/features/deck/collections`); intra-feature imports are relative (`./schemas`). Always use the `@/` alias otherwise.
 

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -58,7 +58,7 @@ This is the exception, not the default. Most writes are safe to show immediately
 
 **Reasonable exceptions:**
 
-- **Realtime sync handlers** writing supabase channel events into a collection (`writeRealtimeRow(chatMessagesCollection, ...)` inside a `postgres_changes` callback) — that's sync, not a mutation.
+- **Realtime sync handlers** writing supabase channel events into a collection (`writeSyncedRow(chatMessagesCollection, ...)` inside a `postgres_changes` callback) — that's sync, not a mutation.
 - **Mutations whose server-side transformation can't be predicted client-side** (e.g. FSRS scheduling on review submission) — evaluate case-by-case; may need `createOptimisticAction` with a best-guess optimistic update, or may legitimately keep the React Query pattern.
 
 ## The `{ refetch: false }` contract
@@ -136,7 +136,7 @@ if (row) cardsCollection.utils.writeUpdate(row)
 
 A realtime frame arrives after the database commits, so it carries the truth and is safe to write into the synced layer. But a collection that is only correct once the frame lands is wrong until then, and stays wrong whenever the socket is down. Make the handler correct on its own; let realtime cover the writes made by other clients and other devices.
 
-Use `writeRealtimeRow(collection, key, row)` and `deleteSyncedRow(collection, key)` (`src/lib/collections/realtime-row.ts`) for INSERT and UPDATE frames. It upserts, because a frame can arrive for a row this client never fetched and `writeUpdate` throws on a key it cannot find. It also skips the write when every field already matches, which is this client's own mutation echoing back — writing it would re-run every live query for nothing.
+Use `writeSyncedRow(collection, key, row)` and `deleteSyncedRow(collection, key)` (`src/lib/collections/realtime-row.ts`) for INSERT and UPDATE frames. It upserts, because a frame can arrive for a row this client never fetched and `writeUpdate` throws on a key it cannot find. It also skips the write when every field already matches, which is this client's own mutation echoing back — writing it would re-run every live query for nothing.
 
 **INSERT and UPDATE frames are RLS-scoped; DELETE frames are not.** Supabase tests each subscriber's policies against the new row, so an insert or update reaches you only if you could have fetched that row yourself. It cannot do the same for a delete, because the row is already gone by then. So every delete on a published table reaches every subscriber of that table, whoever owned the row.
 
@@ -225,7 +225,7 @@ useEffect(() => {
 			},
 			(payload) => {
 				const row = ChatMessageSchema.parse(payload.new)
-				writeRealtimeRow(chatMessagesCollection, row.id, row)
+				writeSyncedRow(chatMessagesCollection, row.id, row)
 			}
 		)
 		.subscribe()

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -48,6 +48,14 @@ The component subscribes to the collection via `useLiveQuery` (here through `use
 
 See PR #623 (`cardsCollection.onUpdate` + review context-menu) for a worked example. See also the [TanStack DB optimistic-mutations skill](../node_modules/@tanstack/db/skills/db-core/mutations-optimistic/SKILL.md) for `createOptimisticAction` (multi-collection atomic mutations) and `createPacedMutations` (auto-save / debounce / throttle).
 
+### When the optimistic state is worse than waiting
+
+`collection.insert / update / delete` take `{ optimistic: false }`. The handler still runs and the transaction still resolves through `isPersisted.promise`; the row just never enters the optimistic layer, so it appears when the handler writes the server's row back.
+
+Reach for it when a rollback would be more confusing than a wait. Friend requests are the case in the app today: `validate_friend_request_action` rejects several transitions, and a relationship that reads "friends" for a moment and then reads "unconnected" again is a worse thing to show than a button that waits and then reports the error. `useFriendRequestAction` writes non-optimistically and holds its own `pendingAction` for the spinner.
+
+This is the exception, not the default. Most writes are safe to show immediately: the server accepts them, and the optimistic value is what the user came to see.
+
 **Reasonable exceptions:**
 
 - **Realtime sync handlers** writing supabase channel events into a collection (`writeRealtimeRow(chatMessagesCollection, ...)` inside a `postgres_changes` callback) — that's sync, not a mutation.

--- a/scenetest/TEST_IDS.md
+++ b/scenetest/TEST_IDS.md
@@ -338,6 +338,25 @@ natural wrapper element to label.
 | `invite-qr-card`     | data-testid | Invite page        | Card wrapping the QR code section            |
 | `invite-qr-code`     | data-testid | Invite page        | QR code element encoding the signup referral |
 
+## Relationship actions
+
+One button per relationship status, on the friend profile page
+(`routes/_user/friends/$uid.tsx` → `-relationship-actions.tsx`). The confirm
+buttons live inside a `ConfirmDestructiveActionDialog`, so click the status
+button first to open it.
+
+| Selector                                | Attribute   | Component/Location  | Description               |
+| --------------------------------------- | ----------- | ------------------- | ------------------------- |
+| `friend-profile-page`                   | data-testid | Friend profile      | Profile page container    |
+| `add-friend-button`                     | data-testid | Unconnected         | Sends the invite          |
+| `requested-status-button`               | data-testid | Pending, sent by me | Opens the cancel dialog   |
+| `cancel-friend-request-button`          | data-testid | Cancel dialog       | Cancels the invite I sent |
+| `accept-friend-request-button`          | data-testid | Pending, sent to me | Accepts the invite        |
+| `decline-friend-request-button`         | data-testid | Pending, sent to me | Opens the decline dialog  |
+| `confirm-decline-friend-request-button` | data-testid | Decline dialog      | Declines the invite       |
+| `friends-status-button`                 | data-testid | Friends             | Opens the unfriend dialog |
+| `unfriend-button`                       | data-testid | Unfriend dialog     | Ends the friendship       |
+
 ## Share-with-friends picker
 
 Used by the "Send in chat" / share actions for phrases, playlists, and requests

--- a/scenetest/scenes/social.spec.md
+++ b/scenetest/scenes/social.spec.md
@@ -11,17 +11,28 @@ learner:
   // DB-state agreement belongs in inline serverChecks on the social
   // collections, not in this scene.
 
-# friend accepts a friend request and removes a friend
+# learner3 accepts a friend request and then unfriends
 
-friend:
+The seed leaves learner's invite to learner3 pending. Accepting it, and then
+undoing it, walks the pair through all three statuses. Each button state is
+folded from the action log on the client — no `friend_summary` fetch — so this
+scene is what proves the fold and the write-back agree with the server.
+
+cleanup: supabase.from('friend_request_action').delete().eq('uid_by', '[learner3.key]').eq('uid_for', '[learner.key]')
+
+learner3:
 
 - login
-  // STUB — never implemented; carried over from a skipped legacy spec. To implement:
-  // - sidebar shows a pending friend request (seed data)
-  // - open friend requests and accept the request
-  // - verify the new friend appears on /friends
-  // - open the friend's profile and unfriend them
-  // - verify they are no longer connected
+- openTo /friends/[learner.key]
+- see friend-profile-page
+- see accept-friend-request-button
+- click accept-friend-request-button
+- seeToast toast-success
+- see friends-status-button
+- click friends-status-button
+- click unfriend-button
+- seeToast toast-neutral
+- see add-friend-button
 
 # learner declines or removes a friend
 

--- a/src/components/profile-with-relationship.tsx
+++ b/src/components/profile-with-relationship.tsx
@@ -59,13 +59,7 @@ export function ProfileWithRelationship({ uid }: { uid: uuid }) {
 								aria-label="Confirm: Decline friend request"
 								onClick={() => friendRequest.act('decline')}
 							>
-								{friendRequest.isPending ? (
-									<IconSizedLoader />
-								) : friendRequest.lastAction ? (
-									<Check className="size-6 text-white" />
-								) : (
-									<>Confirm</>
-								)}
+								Confirm
 							</Button>
 						</ConfirmDestructiveActionDialog>
 					</>
@@ -87,13 +81,7 @@ export function ProfileWithRelationship({ uid }: { uid: uuid }) {
 							aria-label="Confirm: Cancel friend request"
 							onClick={() => friendRequest.act('cancel')}
 						>
-							{friendRequest.isPending ? (
-								<IconSizedLoader />
-							) : friendRequest.lastAction ? (
-								<Check className="size-6 text-white" />
-							) : (
-								<>Confirm</>
-							)}
+							Confirm
 						</Button>
 					</ConfirmDestructiveActionDialog>
 				) : profile.relation.status === 'friends' ? (

--- a/src/components/profile-with-relationship.tsx
+++ b/src/components/profile-with-relationship.tsx
@@ -9,93 +9,99 @@ import { useOnePublicProfile } from '@/features/social/public-profile'
 
 export function ProfileWithRelationship({ uid }: { uid: uuid }) {
 	const { data: profile } = useOnePublicProfile(uid)
-	const inviteResponseMutation = useFriendRequestAction(uid)
+	const friendRequest = useFriendRequestAction(uid)
 	const isMostRecentByThem = profile?.relation?.most_recent_uid_by === uid
 
 	return !profile ? null : (
-			<AvatarIconRow {...profile}>
-				<div className="flex flex-row gap-2">
-					{inviteResponseMutation.isPending ?
-						<IconSizedLoader />
-					: inviteResponseMutation.isSuccess ?
-						<span className="rounded-squircle size-8 rounded-full bg-green-600 p-1">
-							<Check className="size-6 text-white" />
-						</span>
-					: !profile.relation || profile.relation.status === 'unconnected' ?
+		<AvatarIconRow {...profile}>
+			<div className="flex flex-row gap-2">
+				{friendRequest.isPending ? (
+					<IconSizedLoader />
+				) : friendRequest.lastAction ? (
+					<span className="rounded-squircle size-8 rounded-full bg-green-600 p-1">
+						<Check className="size-6 text-white" />
+					</span>
+				) : !profile.relation || profile.relation.status === 'unconnected' ? (
+					<Button
+						variant="default"
+						className="size-8"
+						size="icon"
+						aria-label="Send friend request"
+						onClick={() => friendRequest.act('invite')}
+					>
+						<Send className="mt-[0.1rem] mr-[0.1rem] size-6" />
+					</Button>
+				) : profile.relation.status === 'pending' && isMostRecentByThem ? (
+					<>
 						<Button
 							variant="default"
 							className="size-8"
 							size="icon"
-							aria-label="Send friend request"
-							onClick={() => inviteResponseMutation.mutate('invite')}
+							aria-label="Accept pending invitation"
+							onClick={() => friendRequest.act('accept')}
 						>
-							<Send className="mt-[0.1rem] mr-[0.1rem] size-6" />
+							<ThumbsUp />
 						</Button>
-					: profile.relation.status === 'pending' && isMostRecentByThem ?
-						<>
-							<Button
-								variant="default"
-								className="size-8"
-								size="icon"
-								aria-label="Accept pending invitation"
-								onClick={() => inviteResponseMutation.mutate('accept')}
-							>
-								<ThumbsUp />
-							</Button>
-							<ConfirmDestructiveActionDialog
-								title="Decline this invitation"
-								description="Please confirm whether you'd like to decline this invitation"
-							>
-								<Button
-									variant="neutral"
-									className="size-8"
-									size="icon"
-									aria-label="Decline pending invitation"
-								>
-									<X className="size-6 p-0" />
-								</Button>
-								<Button
-									variant="red"
-									aria-label="Confirm: Decline friend request"
-									onClick={() => inviteResponseMutation.mutate('decline')}
-								>
-									{inviteResponseMutation.isPending ?
-										<IconSizedLoader />
-									: inviteResponseMutation.isSuccess ?
-										<Check className="size-6 text-white" />
-									:	<>Confirm</>}
-								</Button>
-							</ConfirmDestructiveActionDialog>
-						</>
-					: profile.relation?.status === 'pending' && !isMostRecentByThem ?
 						<ConfirmDestructiveActionDialog
-							title={`Cancel this request`}
-							description={`Please confirm whether you'd like to cancel this friend request`}
+							title="Decline this invitation"
+							description="Please confirm whether you'd like to decline this invitation"
 						>
 							<Button
 								variant="neutral"
 								className="size-8"
 								size="icon"
-								aria-label="Cancel friend request"
+								aria-label="Decline pending invitation"
 							>
 								<X className="size-6 p-0" />
 							</Button>
 							<Button
 								variant="red"
-								aria-label="Confirm: Cancel friend request"
-								onClick={() => inviteResponseMutation.mutate('cancel')}
+								aria-label="Confirm: Decline friend request"
+								onClick={() => friendRequest.act('decline')}
 							>
-								{inviteResponseMutation.isPending ?
+								{friendRequest.isPending ? (
 									<IconSizedLoader />
-								: inviteResponseMutation.isSuccess ?
+								) : friendRequest.lastAction ? (
 									<Check className="size-6 text-white" />
-								:	<>Confirm</>}
+								) : (
+									<>Confirm</>
+								)}
 							</Button>
 						</ConfirmDestructiveActionDialog>
-					: profile.relation.status === 'friends' ?
-						<UserCheck className="size-6 p-0" />
-					:	<> status is "{profile.relation.status}" for some reason</>}
-				</div>
-			</AvatarIconRow>
-		)
+					</>
+				) : profile.relation?.status === 'pending' && !isMostRecentByThem ? (
+					<ConfirmDestructiveActionDialog
+						title={`Cancel this request`}
+						description={`Please confirm whether you'd like to cancel this friend request`}
+					>
+						<Button
+							variant="neutral"
+							className="size-8"
+							size="icon"
+							aria-label="Cancel friend request"
+						>
+							<X className="size-6 p-0" />
+						</Button>
+						<Button
+							variant="red"
+							aria-label="Confirm: Cancel friend request"
+							onClick={() => friendRequest.act('cancel')}
+						>
+							{friendRequest.isPending ? (
+								<IconSizedLoader />
+							) : friendRequest.lastAction ? (
+								<Check className="size-6 text-white" />
+							) : (
+								<>Confirm</>
+							)}
+						</Button>
+					</ConfirmDestructiveActionDialog>
+				) : profile.relation.status === 'friends' ? (
+					<UserCheck className="size-6 p-0" />
+				) : (
+					<> status is "{profile.relation.status}" for some reason</>
+				)}
+			</div>
+		</AvatarIconRow>
+	)
 }

--- a/src/components/profile-with-relationship.tsx
+++ b/src/components/profile-with-relationship.tsx
@@ -14,13 +14,9 @@ export function ProfileWithRelationship({ uid }: { uid: uuid }) {
 
 	return !profile ? null : (
 		<AvatarIconRow {...profile}>
-			<div className="flex flex-row gap-2">
+			<div className="relative flex flex-row gap-2">
 				{friendRequest.isPending ? (
 					<IconSizedLoader />
-				) : friendRequest.lastAction ? (
-					<span className="rounded-squircle size-8 rounded-full bg-green-600 p-1">
-						<Check className="size-6 text-white" />
-					</span>
 				) : !profile.relation || profile.relation.status === 'unconnected' ? (
 					<Button
 						variant="default"
@@ -89,6 +85,20 @@ export function ProfileWithRelationship({ uid }: { uid: uuid }) {
 				) : (
 					<> status is "{profile.relation.status}" for some reason</>
 				)}
+				{/* The row underneath has already settled into the new status. This
+				    marks the moment it changed, then gets out of the way. Keyed by
+				    the action so a second one replays it. */}
+				{friendRequest.lastAction ? (
+					<span
+						key={friendRequest.lastAction}
+						aria-hidden
+						className="animate-out fade-out zoom-out-75 fill-mode-forwards pointer-events-none absolute inset-0 flex items-center delay-700 duration-500"
+					>
+						<span className="rounded-squircle size-8 rounded-full bg-green-600 p-1">
+							<Check className="size-6 text-white" />
+						</span>
+					</span>
+				) : null}
 			</div>
 		</AvatarIconRow>
 	)

--- a/src/components/share/friend-picker.tsx
+++ b/src/components/share/friend-picker.tsx
@@ -24,7 +24,7 @@ import type { uuid } from '@/types/main'
 import { UserAvatar } from '@/components/ui/user-avatar'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { LoginSignupButtons } from '@/components/ui/authenticated-dialog'
-import { IconSizedLoader, Loader } from '@/components/ui/loader'
+import { Loader } from '@/components/ui/loader'
 
 const EMPTY_UIDS: uuid[] = []
 
@@ -170,7 +170,6 @@ function PickerBody({
 	setSearch,
 	searchRef,
 	onSend,
-	isPending = false,
 }: {
 	friendsOverride?: RelationsFullType[]
 	preview?: ReactNode
@@ -180,7 +179,6 @@ function PickerBody({
 	setSearch: Dispatch<SetStateAction<string>>
 	searchRef: RefObject<HTMLInputElement | null>
 	onSend: (uids: uuid[]) => void
-	isPending?: boolean
 }) {
 	// These live queries run only while the picker is open (PickerBody is
 	// portal-mounted by the dialog), so closed pickers on list items cost
@@ -319,11 +317,11 @@ function PickerBody({
 				</span>
 				<Button
 					className="ms-auto gap-2"
-					disabled={count === 0 || !isReady || isPending}
+					disabled={count === 0 || !isReady}
 					onClick={() => onSend(uids)}
 					data-testid="send-to-friends-button"
 				>
-					{isPending ? <IconSizedLoader /> : <Send className="size-4" />}
+					<Send className="size-4" />
 					<span className="whitespace-nowrap">
 						{count > 0 ? `Send to ${count}` : 'Send'}
 					</span>
@@ -362,7 +360,6 @@ export function FriendPickerDialog({
 	description,
 	preview,
 	onSend,
-	isPending = false,
 	authTitle = 'Login to Send',
 	authMessage = 'You need to be logged in to send things to friends.',
 	trigger,
@@ -374,7 +371,6 @@ export function FriendPickerDialog({
 	description?: string
 	preview?: ReactNode
 	onSend: (uids: uuid[]) => void
-	isPending?: boolean
 	authTitle?: string
 	authMessage?: string
 	trigger?: ReactNode
@@ -454,7 +450,6 @@ export function FriendPickerDialog({
 								setSearch={setSearch}
 								searchRef={searchRef}
 								onSend={onSend}
-								isPending={isPending}
 							/>
 						</>
 					) : (

--- a/src/components/share/friend-picker.tsx
+++ b/src/components/share/friend-picker.tsx
@@ -170,7 +170,7 @@ function PickerBody({
 	setSearch,
 	searchRef,
 	onSend,
-	isPending,
+	isPending = false,
 }: {
 	friendsOverride?: RelationsFullType[]
 	preview?: ReactNode
@@ -180,7 +180,7 @@ function PickerBody({
 	setSearch: Dispatch<SetStateAction<string>>
 	searchRef: RefObject<HTMLInputElement | null>
 	onSend: (uids: uuid[]) => void
-	isPending: boolean
+	isPending?: boolean
 }) {
 	// These live queries run only while the picker is open (PickerBody is
 	// portal-mounted by the dialog), so closed pickers on list items cost

--- a/src/components/share/send-phrase.tsx
+++ b/src/components/share/send-phrase.tsx
@@ -20,7 +20,7 @@ function SendPhraseDialog({
 	onOpenChange: (open: boolean) => void
 	trigger?: ReactNode
 }) {
-	const mutation = useSendToFriends(
+	const { send } = useSendToFriends(
 		phrase.lang,
 		{ message_type: 'recommendation', phrase_id: phrase.id },
 		{ onSuccess: () => onOpenChange(false) }
@@ -35,8 +35,7 @@ function SendPhraseDialog({
 			authTitle="Login to Send"
 			authMessage="You need to be logged in to send phrases to friends."
 			preview={<PhrasePreviewChip phrase={phrase} />}
-			onSend={(uids) => mutation.mutate(uids)}
-			isPending={mutation.isPending}
+			onSend={send}
 		/>
 	)
 }

--- a/src/components/share/send-phrase.tsx
+++ b/src/components/share/send-phrase.tsx
@@ -20,11 +20,7 @@ function SendPhraseDialog({
 	onOpenChange: (open: boolean) => void
 	trigger?: ReactNode
 }) {
-	const { send } = useSendToFriends(
-		phrase.lang,
-		{ message_type: 'recommendation', phrase_id: phrase.id },
-		{ onSuccess: () => onOpenChange(false) }
-	)
+	const send = useSendToFriends()
 	return (
 		<FriendPickerDialog
 			open={open}
@@ -35,7 +31,14 @@ function SendPhraseDialog({
 			authTitle="Login to Send"
 			authMessage="You need to be logged in to send phrases to friends."
 			preview={<PhrasePreviewChip phrase={phrase} />}
-			onSend={send}
+			onSend={(recipientUids) => {
+				send({
+					recipientUids,
+					lang: phrase.lang,
+					content: { message_type: 'recommendation', phrase_id: phrase.id },
+				})
+				onOpenChange(false)
+			}}
 		/>
 	)
 }

--- a/src/components/share/send-playlist.tsx
+++ b/src/components/share/send-playlist.tsx
@@ -19,11 +19,7 @@ export function SendPlaylistToFriendDialog({
 	children: ReactNode
 }) {
 	const [open, setOpen] = useState(false)
-	const { send } = useSendToFriends(
-		lang,
-		{ message_type: 'playlist', playlist_id: id },
-		{ onSuccess: () => setOpen(false) }
-	)
+	const send = useSendToFriends()
 
 	if (!lang || !id) return null
 
@@ -43,7 +39,14 @@ export function SendPlaylistToFriendDialog({
 					subtitle="Send this playlist to a friend"
 				/>
 			}
-			onSend={send}
+			onSend={(recipientUids) => {
+				send({
+					recipientUids,
+					lang,
+					content: { message_type: 'playlist', playlist_id: id },
+				})
+				setOpen(false)
+			}}
 		/>
 	)
 }

--- a/src/components/share/send-playlist.tsx
+++ b/src/components/share/send-playlist.tsx
@@ -19,7 +19,7 @@ export function SendPlaylistToFriendDialog({
 	children: ReactNode
 }) {
 	const [open, setOpen] = useState(false)
-	const mutation = useSendToFriends(
+	const { send } = useSendToFriends(
 		lang,
 		{ message_type: 'playlist', playlist_id: id },
 		{ onSuccess: () => setOpen(false) }
@@ -43,8 +43,7 @@ export function SendPlaylistToFriendDialog({
 					subtitle="Send this playlist to a friend"
 				/>
 			}
-			onSend={(uids) => mutation.mutate(uids)}
-			isPending={mutation.isPending}
+			onSend={send}
 		/>
 	)
 }

--- a/src/components/share/send-request.tsx
+++ b/src/components/share/send-request.tsx
@@ -19,7 +19,7 @@ export function SendRequestToFriendDialog({
 	children: ReactNode
 }) {
 	const [open, setOpen] = useState(false)
-	const mutation = useSendToFriends(
+	const { send } = useSendToFriends(
 		lang,
 		{ message_type: 'request', request_id: id },
 		{ onSuccess: () => setOpen(false) }
@@ -43,8 +43,7 @@ export function SendRequestToFriendDialog({
 					subtitle="Send this request to a friend"
 				/>
 			}
-			onSend={(uids) => mutation.mutate(uids)}
-			isPending={mutation.isPending}
+			onSend={send}
 		/>
 	)
 }

--- a/src/components/share/send-request.tsx
+++ b/src/components/share/send-request.tsx
@@ -19,11 +19,7 @@ export function SendRequestToFriendDialog({
 	children: ReactNode
 }) {
 	const [open, setOpen] = useState(false)
-	const { send } = useSendToFriends(
-		lang,
-		{ message_type: 'request', request_id: id },
-		{ onSuccess: () => setOpen(false) }
-	)
+	const send = useSendToFriends()
 
 	if (!lang || !id) return null
 
@@ -43,7 +39,14 @@ export function SendRequestToFriendDialog({
 					subtitle="Send this request to a friend"
 				/>
 			}
-			onSend={send}
+			onSend={(recipientUids) => {
+				send({
+					recipientUids,
+					lang,
+					content: { message_type: 'request', request_id: id },
+				})
+				setOpen(false)
+			}}
 		/>
 	)
 }

--- a/src/features/feed/hooks.ts
+++ b/src/features/feed/hooks.ts
@@ -7,7 +7,7 @@ import { useLiveQuery, eq } from '@tanstack/react-db'
 import supabase from '@/lib/supabase-client'
 import { FeedActivitySchema, type FeedActivityType } from './schemas'
 import type { LangType } from '@/features/languages/schemas'
-import { friendSummariesCollection } from '@/features/social/collections'
+import { friendSummaries } from '@/features/social/live'
 
 export type FeedFilterType = 'request' | 'playlist' | 'phrase'
 
@@ -81,7 +81,7 @@ export function useFriendUids() {
 	return useLiveQuery(
 		(q) =>
 			q
-				.from({ friend: friendSummariesCollection })
+				.from({ friend: friendSummaries })
 				.where(({ friend }) => eq(friend.status, 'friends'))
 				.select(({ friend }) => ({ uid: friend.uid })),
 		[]

--- a/src/features/notifications/hooks.ts
+++ b/src/features/notifications/hooks.ts
@@ -3,7 +3,7 @@ import { isNull, useLiveQuery } from '@tanstack/react-db'
 import type { UseLiveQueryResult, uuid } from '@/types/main'
 import { NotificationSchema, type NotificationType } from './schemas'
 import { notificationsCollection } from './collections'
-import { writeRealtimeRow } from '@/lib/collections/realtime-row'
+import { writeSyncedRow } from '@/lib/collections/realtime-row'
 import supabase from '@/lib/supabase-client'
 import { useUserId } from '@/lib/use-auth'
 import type { Tables } from '@/types/supabase'
@@ -75,7 +75,7 @@ export const useNotificationsRealtime = () => {
 					const row = NotificationSchema.parse(
 						payload.new as Tables<'notification'>
 					)
-					writeRealtimeRow(notificationsCollection, row.id, row)
+					writeSyncedRow(notificationsCollection, row.id, row)
 				}
 			)
 			.on(
@@ -90,7 +90,7 @@ export const useNotificationsRealtime = () => {
 					const row = NotificationSchema.parse(
 						payload.new as Tables<'notification'>
 					)
-					writeRealtimeRow(notificationsCollection, row.id, row)
+					writeSyncedRow(notificationsCollection, row.id, row)
 				}
 			)
 			.subscribe()

--- a/src/features/social/collections.ts
+++ b/src/features/social/collections.ts
@@ -90,7 +90,7 @@ export const chatMessagesCollection = createCollection(
 		queryClient,
 		startSync: false,
 		schema: ChatMessageSchema,
-		// Every chat message the app writes lands here — see `sendToFriends`.
+		// Every chat message the app writes lands here — see `useSendToFriends`.
 		onInsert: async ({ transaction }) => {
 			const submitted = transaction.mutations.map(
 				(m) => m.modified as ChatMessageType
@@ -112,8 +112,13 @@ export const chatMessagesCollection = createCollection(
 			)
 			// The write-back is what `refetch: false` promises. Upsert, because
 			// this row's own realtime frame can land before the insert resolves.
-			for (const row of rows)
-				writeSyncedRow(chatMessagesCollection, row.id, row)
+			// Batched: each write is otherwise its own commit, and a commit
+			// copies the whole collection into the query cache and re-runs every
+			// live query over it — eight recipients would pay that eight times.
+			chatMessagesCollection.utils.writeBatch(() => {
+				for (const row of rows)
+					writeSyncedRow(chatMessagesCollection, row.id, row)
+			})
 			return { refetch: false }
 		},
 		// Read receipts stamp one `read_at` across every unread message from a

--- a/src/features/social/collections.ts
+++ b/src/features/social/collections.ts
@@ -90,6 +90,32 @@ export const chatMessagesCollection = createCollection(
 		queryClient,
 		startSync: false,
 		schema: ChatMessageSchema,
+		// Every chat message the app writes lands here — see `sendToFriends`.
+		onInsert: async ({ transaction }) => {
+			const submitted = transaction.mutations.map(
+				(m) => m.modified as ChatMessageType
+			)
+			const { data } = await supabase
+				.from('chat_message')
+				// The server stamps `created_at`. The optimistic row carries a
+				// local guess only so the thread orders correctly before the
+				// write-back lands.
+				.insert(submitted.map(({ created_at: _created_at, ...row }) => row))
+				.select()
+				.throwOnError()
+			const rows = data?.map((row) => ChatMessageSchema.parse(row)) ?? []
+			should(
+				'chat_message insert returned one row per message sent',
+				rows.length === submitted.length &&
+					submitted.every((sent) => rows.some((row) => row.id === sent.id)),
+				{ submitted, returned: rows }
+			)
+			// The write-back is what `refetch: false` promises. Upsert, because
+			// this row's own realtime frame can land before the insert resolves.
+			for (const row of rows)
+				writeSyncedRow(chatMessagesCollection, row.id, row)
+			return { refetch: false }
+		},
 		// Read receipts stamp one `read_at` across every unread message from a
 		// friend, so grouping collapses the batch to a single request. The
 		// reader doesn't wait on it, so the error toast belongs here.

--- a/src/features/social/collections.ts
+++ b/src/features/social/collections.ts
@@ -1,36 +1,78 @@
 import { createCollection, BTreeIndex } from '@tanstack/react-db'
 import { queryCollectionOptions } from '@tanstack/query-db-collection'
 import {
-	FriendSummarySchema,
-	type FriendSummaryType,
+	FriendRequestActionSchema,
+	type FriendRequestActionType,
 	ChatMessageSchema,
 	type ChatMessageType,
 } from './schemas'
+import { should } from '@scenetest/checks/react'
 import { toastError } from '@/components/ui/sonner'
 import { groupUpdatesByChanges } from '@/lib/collections/group-updates'
 import { queryClient } from '@/lib/query-client'
 import supabase from '@/lib/supabase-client'
 import type { TablesUpdate } from '@/types/supabase'
 
-export const friendSummariesCollection = createCollection(
+export const friendRequestActionsCollection = createCollection(
 	queryCollectionOptions({
-		id: 'friends',
-		queryKey: ['user', 'friend_summary'],
+		id: 'friend_request_actions',
+		queryKey: ['user', 'friend_request_action'],
 		queryFn: async () => {
 			if (!(await supabase.auth.getSession()).data?.session) return []
-			console.log(`Loading friendSummariesCollection`)
+			console.log(`Loading friendRequestActionsCollection`)
 			const { data } = await supabase
-				.from('friend_summary')
+				.from('friend_request_action')
 				.select()
 				.throwOnError()
-			return data?.map((item) => FriendSummarySchema.parse(item)) ?? []
+			return data?.map((item) => FriendRequestActionSchema.parse(item)) ?? []
 		},
-		getKey: (item: FriendSummaryType) => `${item.uid_less}--${item.uid_more}`,
+		getKey: (item: FriendRequestActionType) => item.id,
 		queryClient,
 		startSync: false,
-		schema: FriendSummarySchema,
+		schema: FriendRequestActionSchema,
 		autoIndex: 'eager',
 		defaultIndexType: BTreeIndex,
+		// Append-only: an action is a fact about a moment, so nothing updates or
+		// deletes one. The relationship's current state is the fold in `live.ts`.
+		onInsert: async ({ transaction }) => {
+			const submitted = transaction.mutations.map(
+				(m) => m.modified as FriendRequestActionType
+			)
+			const { data } = await supabase
+				.from('friend_request_action')
+				// `created_at` is the server's to stamp — it orders the log, and a
+				// skewed client clock would reorder someone's friendships.
+				.insert(submitted.map(({ created_at: _created_at, ...row }) => row))
+				.select()
+				.throwOnError()
+			const rows =
+				data?.map((row) => FriendRequestActionSchema.parse(row)) ?? []
+			// `validate_friend_request_action` rewrites one action before storing
+			// it: an invite to someone who already invited you is mutual consent,
+			// so it lands as an accept. Every other action is stored as sent, and
+			// an invalid one raises instead, which throws out of this handler.
+			should(
+				'friend_request_action insert returned each row as sent, or an invite the server accepted',
+				rows.length === submitted.length &&
+					submitted.every((sent) => {
+						const row = rows.find((r) => r.id === sent.id)
+						return (
+							!!row &&
+							(row.action_type === sent.action_type ||
+								(sent.action_type === 'invite' && row.action_type === 'accept'))
+						)
+					}),
+				{ submitted, returned: rows }
+			)
+			// The write-back is what `refetch: false` promises — and here it is
+			// also the only thing that puts the row in the collection, because
+			// `useFriendRequestAction` writes with `{ optimistic: false }`.
+			// Upsert, not insert: this row's own realtime frame can land before
+			// the insert resolves, in which case the key is already here.
+			for (const row of rows)
+				friendRequestActionsCollection.utils.writeUpsert(row)
+			return { refetch: false }
+		},
 	})
 )
 

--- a/src/features/social/collections.ts
+++ b/src/features/social/collections.ts
@@ -7,6 +7,7 @@ import {
 	type ChatMessageType,
 } from './schemas'
 import { should } from '@scenetest/checks/react'
+import { writeSyncedRow } from '@/lib/collections/realtime-row'
 import { toastError } from '@/components/ui/sonner'
 import { groupUpdatesByChanges } from '@/lib/collections/group-updates'
 import { queryClient } from '@/lib/query-client'
@@ -62,10 +63,11 @@ export const friendRequestActionsCollection = createCollection(
 			// The write-back is what `refetch: false` promises — and here it is
 			// also the only thing that puts the row in the collection, because
 			// `useFriendRequestAction` writes with `{ optimistic: false }`.
-			// Upsert, not insert: this row's own realtime frame can land before
-			// the insert resolves, in which case the key is already here.
+			// `writeSyncedRow` rather than a bare writeInsert: this row's own
+			// realtime frame can land first, in which case the key is already
+			// here and `writeInsert` would throw.
 			for (const row of rows)
-				friendRequestActionsCollection.utils.writeUpsert(row)
+				writeSyncedRow(friendRequestActionsCollection, row.id, row)
 			return { refetch: false }
 		},
 	})

--- a/src/features/social/collections.ts
+++ b/src/features/social/collections.ts
@@ -47,21 +47,16 @@ export const friendRequestActionsCollection = createCollection(
 				.throwOnError()
 			const rows =
 				data?.map((row) => FriendRequestActionSchema.parse(row)) ?? []
+			// The handler needs every submitted row back, so `writeUpsert` puts a
+			// row under each key. It deliberately does not assert the action type:
 			// `validate_friend_request_action` rewrites one action before storing
-			// it: an invite to someone who already invited you is mutual consent,
-			// so it lands as an accept. Every other action is stored as sent, and
-			// an invalid one raises instead, which throws out of this handler.
+			// it — an invite to someone who already invited you is mutual consent,
+			// so it lands as an accept — which is why the caller reads the stored
+			// type back rather than trusting what it sent. An invalid action
+			// raises instead, and that throws out of this handler.
 			should(
-				'friend_request_action insert returned each row as sent, or an invite the server accepted',
-				rows.length === submitted.length &&
-					submitted.every((sent) => {
-						const row = rows.find((r) => r.id === sent.id)
-						return (
-							!!row &&
-							(row.action_type === sent.action_type ||
-								(sent.action_type === 'invite' && row.action_type === 'accept'))
-						)
-					}),
+				'friend_request_action insert returned every submitted row',
+				rows.length === submitted.length,
 				{ submitted, returned: rows }
 			)
 			// The write-back is what `refetch: false` promises — and here it is

--- a/src/features/social/friend-summary-fold.test.ts
+++ b/src/features/social/friend-summary-fold.test.ts
@@ -133,32 +133,6 @@ describe('the friend summary fold', () => {
 		expect(summaries.toArray).toHaveLength(2)
 	})
 
-	it('ranks an optimistic `Z` stamp against the server`s `+00:00` form', () => {
-		// A client-stamped `new Date().toISOString()` and PostgREST's offset form
-		// are compared as strings by the sort key, so the two spellings have to
-		// order by the instant they name.
-		pushAction(
-			action({
-				id: 'b3',
-				created_at: '2026-01-05T00:00:00.000Z',
-				uid_by: ME,
-				uid_for: BEN,
-				action_type: 'remove',
-			})
-		)
-		expect(byFriend(BEN)?.status).toBe('unconnected')
-		pushAction(
-			action({
-				id: 'b4',
-				created_at: '2026-01-06T00:00:00+00:00',
-				uid_by: BEN,
-				uid_for: ME,
-				action_type: 'invite',
-			})
-		)
-		expect(byFriend(BEN)?.status).toBe('pending')
-	})
-
 	it('picks one winner when two actions on a pair share a timestamp', () => {
 		const at = '2026-01-07T00:00:00+00:00'
 		pushAction(

--- a/src/features/social/friend-summary-fold.test.ts
+++ b/src/features/social/friend-summary-fold.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { createCollection } from '@tanstack/db'
+import { createFriendSummaries } from './friend-summary-fold'
+import type { FriendRequestActionType } from './schemas'
+import type { friendRequestActionsCollection } from './collections'
+import type { myProfileCollection } from '@/features/profile/collections'
+
+const ME = '11111111-1111-4111-8111-111111111111'
+const ANA = '22222222-2222-4222-8222-222222222222'
+const BEN = '33333333-3333-4333-8333-333333333333'
+
+const action = (
+	overrides: Partial<FriendRequestActionType> & {
+		id: string
+		created_at: string
+		action_type: FriendRequestActionType['action_type']
+	}
+): FriendRequestActionType => {
+	const uid_by = overrides.uid_by ?? ME
+	const uid_for = overrides.uid_for ?? ANA
+	const [uid_less, uid_more] = [uid_by, uid_for].toSorted()
+	return { uid_by, uid_for, uid_less, uid_more, ...overrides }
+}
+
+const LOG: Array<FriendRequestActionType> = [
+	// Ana and I are friends: I invited her, she accepted.
+	action({
+		id: 'a1',
+		created_at: '2026-01-01T00:00:00+00:00',
+		action_type: 'invite',
+	}),
+	action({
+		id: 'a2',
+		created_at: '2026-01-02T00:00:00+00:00',
+		uid_by: ANA,
+		uid_for: ME,
+		action_type: 'accept',
+	}),
+	// Ben invited me and is still waiting. His invite is newer than both of
+	// Ana's actions, so a fold that ignored the pair would pick it for her too.
+	action({
+		id: 'b1',
+		created_at: '2026-01-03T00:00:00+00:00',
+		uid_by: BEN,
+		uid_for: ME,
+		action_type: 'invite',
+	}),
+]
+
+/** Push a row into a collection's synced layer after the initial load. */
+let pushAction: (row: FriendRequestActionType) => void
+let loadProfile: () => void
+
+const actions = createCollection<FriendRequestActionType>({
+	id: 'test_friend_request_actions',
+	getKey: (row) => row.id,
+	sync: {
+		sync: ({ begin, write, commit, markReady }) => {
+			begin()
+			for (const row of LOG) write({ type: 'insert', value: row })
+			commit()
+			markReady()
+			pushAction = (row) => {
+				begin()
+				write({ type: 'insert', value: row })
+				commit()
+			}
+		},
+	},
+}) as unknown as typeof friendRequestActionsCollection
+
+// The fold reads only `uid` off the profile row, so the rest is not modelled.
+// It starts empty, to exercise the "no profile yet" case first.
+const me = createCollection<{ uid: string }>({
+	id: 'test_my_profile',
+	getKey: (row) => row.uid,
+	sync: {
+		sync: ({ begin, write, commit, markReady }) => {
+			markReady()
+			loadProfile = () => {
+				begin()
+				write({ type: 'insert', value: { uid: ME } })
+				commit()
+			}
+		},
+	},
+}) as unknown as typeof myProfileCollection
+
+const summaries = createFriendSummaries(actions, me)
+const byFriend = (uid: string) => summaries.toArray.find((s) => s.uid === uid)
+
+describe('the friend summary fold', () => {
+	beforeAll(async () => {
+		await summaries.preload()
+	})
+
+	it('folds to nothing until the profile says who the reader is', () => {
+		expect(summaries.toArray).toHaveLength(0)
+	})
+
+	it('fills in on its own once the profile arrives', () => {
+		loadProfile()
+		expect(summaries.toArray).toHaveLength(2)
+	})
+
+	it('folds one summary per pair, not one per action', () => {
+		expect(summaries.toArray).toHaveLength(2)
+	})
+
+	it('reads each pair state off that pair`s own newest action', () => {
+		expect(byFriend(ANA)?.status).toBe('friends')
+		expect(byFriend(BEN)?.status).toBe('pending')
+	})
+
+	it('names the other party as `uid`, whichever side of the pair they sit on', () => {
+		expect(byFriend(ANA)?.uid_less).toBe(ME)
+		expect(byFriend(BEN)?.uid_less).toBe(ME)
+		expect(byFriend(ANA)?.most_recent_uid_by).toBe(ANA)
+		expect(byFriend(BEN)?.most_recent_uid_by).toBe(BEN)
+	})
+
+	it('follows a new action live', () => {
+		pushAction(
+			action({
+				id: 'b2',
+				created_at: '2026-01-04T00:00:00+00:00',
+				uid_by: ME,
+				uid_for: BEN,
+				action_type: 'accept',
+			})
+		)
+		expect(byFriend(BEN)?.status).toBe('friends')
+		expect(summaries.toArray).toHaveLength(2)
+	})
+
+	it('ranks an optimistic `Z` stamp against the server`s `+00:00` form', () => {
+		// A client-stamped `new Date().toISOString()` and PostgREST's offset form
+		// are compared as strings by the sort key, so the two spellings have to
+		// order by the instant they name.
+		pushAction(
+			action({
+				id: 'b3',
+				created_at: '2026-01-05T00:00:00.000Z',
+				uid_by: ME,
+				uid_for: BEN,
+				action_type: 'remove',
+			})
+		)
+		expect(byFriend(BEN)?.status).toBe('unconnected')
+		pushAction(
+			action({
+				id: 'b4',
+				created_at: '2026-01-06T00:00:00+00:00',
+				uid_by: BEN,
+				uid_for: ME,
+				action_type: 'invite',
+			})
+		)
+		expect(byFriend(BEN)?.status).toBe('pending')
+	})
+
+	it('picks one winner when two actions on a pair share a timestamp', () => {
+		const at = '2026-01-07T00:00:00+00:00'
+		pushAction(
+			action({
+				id: 'b5',
+				created_at: at,
+				uid_by: ME,
+				uid_for: BEN,
+				action_type: 'accept',
+			})
+		)
+		pushAction(
+			action({
+				id: 'b6',
+				created_at: at,
+				uid_by: ME,
+				uid_for: BEN,
+				action_type: 'remove',
+			})
+		)
+		expect(summaries.toArray).toHaveLength(2)
+		expect(byFriend(BEN)?.most_recent_action_type).toBe('remove')
+	})
+})

--- a/src/features/social/friend-summary-fold.ts
+++ b/src/features/social/friend-summary-fold.ts
@@ -1,0 +1,108 @@
+import { concat, createLiveQueryCollection, eq, max } from '@tanstack/db'
+import { STATUS_AFTER_ACTION, type FriendSummaryType } from './schemas'
+import type { friendRequestActionsCollection } from './collections'
+import type { myProfileCollection } from '@/features/profile/collections'
+
+/** The key both `friend_summary` and its client-side fold use for a pair. */
+export const friendPairKey = (pair: {
+	uid_less: string
+	uid_more: string
+}): string => `${pair.uid_less}--${pair.uid_more}`
+
+// A column reference as the query builder hands it over, not its value.
+type ColumnRef = Parameters<typeof concat>[0]
+
+/**
+ * A sortable key for one action, so `max()` can pick the newest of a pair.
+ *
+ * `created_at` is fixed-width ISO from PostgREST, so it sorts lexically the way
+ * it sorts chronologically. `id` breaks a tie between two actions stamped in
+ * the same microsecond, which keeps the pick single-valued — two winners would
+ * be two rows under one key. The pair columns lead so the key can be compared
+ * against a group's `max()` directly; they are constant within a group, so
+ * they do not affect which action wins.
+ */
+const actionSortKey = (action: {
+	uid_less: ColumnRef
+	uid_more: ColumnRef
+	created_at: ColumnRef
+	id: ColumnRef
+}) =>
+	concat(
+		action.uid_less,
+		'|',
+		action.uid_more,
+		'|',
+		action.created_at,
+		'|',
+		action.id
+	)
+
+/**
+ * Fold the friend-request action log into one summary row per pair — the same
+ * shape the `friend_summary` view returns, computed locally.
+ *
+ * Two steps, because the query compiler aggregates values rather than picking a
+ * row: group the log by pair to find each pair's winning sort key, then join
+ * that key back to the action carrying it.
+ *
+ * `uid` is the other party, relative to the reader, which the view computes
+ * from `auth.uid()`. Here the reader's own uid comes from a join to their
+ * profile row — the one row `myProfileCollection` holds. A pair whose profile
+ * row has not loaded yet folds to nothing rather than to a guess, and fills in
+ * on its own when the profile arrives.
+ *
+ * Takes its sources as arguments so the fold can be exercised over plain local
+ * collections — see ./friend-summary-fold.test.ts.
+ */
+export const createFriendSummaries = (
+	actions: typeof friendRequestActionsCollection,
+	me: typeof myProfileCollection
+) => {
+	const latestPerPair = createLiveQueryCollection({
+		id: 'friend_pairs',
+		query: (q) =>
+			q
+				.from({ action: actions })
+				.groupBy(({ action }) => [action.uid_less, action.uid_more])
+				.select(({ action }) => ({
+					uid_less: action.uid_less,
+					uid_more: action.uid_more,
+					newest_action_key: max(actionSortKey(action)),
+				})),
+		getKey: friendPairKey,
+	})
+
+	return createLiveQueryCollection({
+		id: 'friend_summaries',
+		query: (q) =>
+			q
+				.from({ latest: latestPerPair })
+				.join(
+					{ action: actions },
+					({ latest, action }) =>
+						eq(actionSortKey(action), latest.newest_action_key),
+					'inner'
+				)
+				.join({ meLess: me }, ({ latest, meLess }) =>
+					eq(latest.uid_less, meLess.uid)
+				)
+				.join({ meMore: me }, ({ latest, meMore }) =>
+					eq(latest.uid_more, meMore.uid)
+				)
+				.fn.where(({ meLess, meMore }) => !!meLess || !!meMore)
+				.fn.select(
+					({ action, meLess }): FriendSummaryType => ({
+						uid_less: action.uid_less,
+						uid_more: action.uid_more,
+						uid: meLess ? action.uid_more : action.uid_less,
+						status: STATUS_AFTER_ACTION[action.action_type],
+						most_recent_created_at: action.created_at,
+						most_recent_uid_by: action.uid_by,
+						most_recent_uid_for: action.uid_for,
+						most_recent_action_type: action.action_type,
+					})
+				),
+		getKey: friendPairKey,
+	})
+}

--- a/src/features/social/friend-summary-fold.ts
+++ b/src/features/social/friend-summary-fold.ts
@@ -3,40 +3,25 @@ import { STATUS_AFTER_ACTION, type FriendSummaryType } from './schemas'
 import type { friendRequestActionsCollection } from './collections'
 import type { myProfileCollection } from '@/features/profile/collections'
 
-/** The key both `friend_summary` and its client-side fold use for a pair. */
-export const friendPairKey = (pair: {
-	uid_less: string
-	uid_more: string
-}): string => `${pair.uid_less}--${pair.uid_more}`
+/** The key a pair is stored under, matching the old `friend_summary` fetch. */
+const friendPairKey = (pair: { uid_less: string; uid_more: string }): string =>
+	`${pair.uid_less}--${pair.uid_more}`
 
 // A column reference as the query builder hands it over, not its value.
 type ColumnRef = Parameters<typeof concat>[0]
 
 /**
- * A sortable key for one action, so `max()` can pick the newest of a pair.
+ * A sortable key for one action, so `max()` can pick the newest of a pair, and
+ * the join below can find the action that key came from.
  *
  * `created_at` is fixed-width ISO from PostgREST, so it sorts lexically the way
  * it sorts chronologically. `id` breaks a tie between two actions stamped in
  * the same microsecond, which keeps the pick single-valued — two winners would
- * be two rows under one key. The pair columns lead so the key can be compared
- * against a group's `max()` directly; they are constant within a group, so
- * they do not affect which action wins.
+ * be two rows under one key — and makes the key unique, so the join matches
+ * exactly one action.
  */
-const actionSortKey = (action: {
-	uid_less: ColumnRef
-	uid_more: ColumnRef
-	created_at: ColumnRef
-	id: ColumnRef
-}) =>
-	concat(
-		action.uid_less,
-		'|',
-		action.uid_more,
-		'|',
-		action.created_at,
-		'|',
-		action.id
-	)
+const actionSortKey = (action: { created_at: ColumnRef; id: ColumnRef }) =>
+	concat(action.created_at, '|', action.id)
 
 /**
  * Fold the friend-request action log into one summary row per pair — the same
@@ -61,6 +46,7 @@ export const createFriendSummaries = (
 ) => {
 	const latestPerPair = createLiveQueryCollection({
 		id: 'friend_pairs',
+		gcTime: 20 * 60 * 1000,
 		query: (q) =>
 			q
 				.from({ action: actions })
@@ -104,5 +90,9 @@ export const createFriendSummaries = (
 					})
 				),
 		getKey: friendPairKey,
+		// These are module-scope singletons, so they should outlive a navigation
+		// that unmounts every subscriber. The 5s default would tear down all
+		// three pipelines and re-fold the whole log on the way back.
+		gcTime: 20 * 60 * 1000,
 	})
 }

--- a/src/features/social/hooks.ts
+++ b/src/features/social/hooks.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
 import { toastError, toastNeutral, toastSuccess } from '@/components/ui/sonner'
 
 import type { Tables } from '@/types/supabase'
@@ -384,16 +383,59 @@ export type ShareableContent =
 	| { message_type: 'request'; request_id: uuid }
 	| { message_type: 'playlist'; playlist_id: uuid }
 
-const SHARE_SUCCESS_TOAST: Record<ShareableContent['message_type'], string> = {
+export const SHARE_SUCCESS_TOAST: Record<
+	ShareableContent['message_type'],
+	string
+> = {
 	recommendation: 'Phrase sent to friend',
 	request: 'Request sent to friend',
 	playlist: 'Playlist sent to friend',
 }
 
 /**
- * Send a phrase / request / playlist to one or more friends as a chat message.
- * Shared by the three "send in chat" surfaces — they differ only in the
- * `message_type` + foreign key carried in `content`.
+ * Send one piece of shared content to one or more friends.
+ *
+ * Every chat message the app writes goes through here, so the row shape and
+ * its null foreign keys are stated once. The write is optimistic: the message
+ * is in the thread before the server answers, and a rejected one rolls back
+ * with the error toast its caller attaches to the returned transaction.
+ */
+export const sendToFriends = ({
+	senderUid,
+	recipientUids,
+	lang,
+	content,
+}: {
+	senderUid: uuid
+	recipientUids: Array<uuid>
+	lang: string
+	content: ShareableContent
+}) =>
+	chatMessagesCollection.insert(
+		recipientUids.map((recipient_uid) =>
+			ChatMessageSchema.parse({
+				// Client-generated so the server's row replaces this one rather
+				// than joining it. `created_at` is a local guess the write-back
+				// overwrites with the server's stamp.
+				id: crypto.randomUUID(),
+				created_at: new Date().toISOString(),
+				sender_uid: senderUid,
+				recipient_uid,
+				lang,
+				phrase_id: null,
+				request_id: null,
+				playlist_id: null,
+				related_message_id: null,
+				read_at: null,
+				...content,
+			})
+		)
+	)
+
+/**
+ * Send a phrase / request / playlist to friends from one of the three share
+ * dialogs. They differ only in the `content` they carry, and each closes
+ * itself through `onSuccess` as soon as the messages are in the thread.
  */
 export const useSendToFriends = (
 	lang: string,
@@ -401,28 +443,24 @@ export const useSendToFriends = (
 	{ onSuccess }: { onSuccess?: () => void } = {}
 ) => {
 	const userId = useUserId()
-	return useMutation({
-		mutationKey: ['send-to-friend', lang, content],
-		mutationFn: async (friendUids: uuid[]) => {
-			if (!userId) throw new Error('User not logged in')
-			const inserts = friendUids.map((recipient_uid) => ({
-				sender_uid: userId,
-				recipient_uid,
-				lang,
-				...content,
-			}))
-			const { data } = await supabase
-				.from('chat_message')
-				.insert(inserts)
-				.throwOnError()
-			return data
-		},
-		onSuccess: () => {
-			onSuccess?.()
-			toastSuccess(SHARE_SUCCESS_TOAST[content.message_type])
-		},
-		onError: () => toastError('Something went wrong'),
-	})
+	const send = (recipientUids: Array<uuid>) => {
+		if (!userId) return
+		const tx = sendToFriends({
+			senderUid: userId,
+			recipientUids,
+			lang,
+			content,
+		})
+		onSuccess?.()
+		tx.isPersisted.promise.then(
+			() => toastSuccess(SHARE_SUCCESS_TOAST[content.message_type]),
+			(error: unknown) => {
+				console.log(`Failed to send to friends:`, error, content)
+				toastError('Something went wrong')
+			}
+		)
+	}
+	return { send }
 }
 
 /** Subscribe to realtime friend-request and chat-message events. */

--- a/src/features/social/hooks.ts
+++ b/src/features/social/hooks.ts
@@ -1,13 +1,16 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { toastError, toastNeutral, toastSuccess } from '@/components/ui/sonner'
 
-import type { Tables, TablesInsert } from '@/types/supabase'
+import type { Tables } from '@/types/supabase'
 import type { UseLiveQueryResult, uuid } from '@/types/main'
 import {
 	ChatMessageSchema,
+	FriendRequestActionSchema,
+	FRIEND_ACTION_TOAST,
 	type ChatMessageRelType,
 	type ChatMessageType,
+	type FriendRequestResponseType,
 } from './schemas'
 import { writeRealtimeRow } from '@/lib/collections/realtime-row'
 import supabase from '@/lib/supabase-client'
@@ -15,7 +18,7 @@ import { useUserId } from '@/lib/use-auth'
 import { and, eq, isNull, useLiveQuery } from '@tanstack/react-db'
 import {
 	chatMessagesCollection,
-	friendSummariesCollection,
+	friendRequestActionsCollection,
 } from './collections'
 import { mapArrays } from '@/lib/utils'
 import { relationsFull, type RelationsFullType } from './live'
@@ -57,41 +60,88 @@ export const useOneRelation = (
 		[uid]
 	)
 
-export const useFriendRequestAction = (uid_for: uuid) => {
+/** What `useFriendRequestAction` hands back to a button. */
+export type FriendRequestAction = {
+	act: (action_type: FriendRequestResponseType) => void
+	/** The action currently in flight, or null. */
+	pendingAction: FriendRequestResponseType | null
+	isPending: boolean
+	/** The last action the server stored, for a call site showing an outcome. */
+	lastAction: FriendRequestResponseType | null
+	error: Error | null
+}
+
+/**
+ * Record one friend request action, and wait for the server to store it.
+ *
+ * The write is deliberately not optimistic. `validate_friend_request_action`
+ * rejects several transitions, and a relationship that reads "friends" for a
+ * moment and then reads "unconnected" again is a worse thing to show than a
+ * button that waits and then reports the error. `onInsert` writes the stored
+ * row into the synced layer, so the relationship changes once, when it is real.
+ */
+export const useFriendRequestAction = (uid_for: uuid): FriendRequestAction => {
 	const uid_by = useUserId()
 	const [uid_less, uid_more] = [uid_by, uid_for].toSorted()
+	const [pendingAction, setPendingAction] =
+		useState<FriendRequestResponseType | null>(null)
+	const [lastAction, setLastAction] =
+		useState<FriendRequestResponseType | null>(null)
+	const [error, setError] = useState<Error | null>(null)
 
-	return useMutation({
-		mutationKey: ['user', uid_by, 'friend_request_action', uid_for],
-		mutationFn: async (action_type: string) => {
-			await supabase
-				.from('friend_request_action')
-				.insert({
-					uid_less,
-					uid_more,
-					uid_by,
-					uid_for,
-					action_type,
-				} as TablesInsert<'friend_request_action'>)
-				.throwOnError()
-		},
-		onSuccess: (_, variable) => {
-			if (variable === 'invite') toastSuccess('Friend request sent 👍')
-			if (variable === 'accept')
-				toastSuccess('Accepted invitation. You are now connected 👍')
-			if (variable === 'decline') toastNeutral('Declined this invitation')
-			if (variable === 'cancel') toastNeutral('Cancelled this invitation')
-			if (variable === 'remove') toastNeutral('You are no longer friends')
-		},
-		onError: (error, variables) => {
-			console.log(
-				`Something went wrong trying to modify your relationship:`,
-				error,
-				variables
-			)
-			toastError(`Something went wrong with this interaction`)
-		},
-	})
+	const act = (action_type: FriendRequestResponseType) => {
+		if (!uid_by || pendingAction !== null) return
+		const id = crypto.randomUUID()
+		setPendingAction(action_type)
+		setError(null)
+		const tx = friendRequestActionsCollection.insert(
+			FriendRequestActionSchema.parse({
+				id,
+				// The schema needs a timestamp and the handler drops it: the server
+				// stamps `created_at`, and nothing renders this row before then.
+				created_at: new Date().toISOString(),
+				uid_less,
+				uid_more,
+				uid_by,
+				uid_for,
+				action_type,
+			}),
+			{ optimistic: false }
+		)
+		tx.isPersisted.promise.then(
+			() => {
+				// Read the toast off the stored row, not off what we sent: an invite
+				// to someone who already invited you is stored as an accept.
+				const stored =
+					friendRequestActionsCollection.get(id)?.action_type ?? action_type
+				setPendingAction(null)
+				setLastAction(stored)
+				const toast = FRIEND_ACTION_TOAST[stored]
+				if (toast.tone === 'success') toastSuccess(toast.text)
+				else toastNeutral(toast.text)
+			},
+			(caught: unknown) => {
+				const failure =
+					caught instanceof Error ? caught : new Error(String(caught))
+				console.log(
+					`Something went wrong trying to modify your relationship:`,
+					failure,
+					action_type
+				)
+				setPendingAction(null)
+				setError(failure)
+				toastError(`Something went wrong with this interaction`)
+			}
+		)
+	}
+
+	return {
+		act,
+		pendingAction,
+		isPending: pendingAction !== null,
+		lastAction,
+		error,
+	}
 }
 
 type ChatsMap = {
@@ -360,19 +410,12 @@ export const useSocialRealtime = () => {
 					table: 'friend_request_action',
 				},
 				(payload) => {
-					const newAction = payload.new as Tables<'friend_request_action'>
-					if (
-						newAction.action_type === 'accept' &&
-						newAction.uid_for === userId
-					)
+					const row = FriendRequestActionSchema.parse(payload.new)
+					if (row.action_type === 'accept' && row.uid_for === userId)
 						toastSuccess('Friend request accepted')
-					if (newAction.action_type === 'accept' && newAction.uid_by === userId)
+					if (row.action_type === 'accept' && row.uid_by === userId)
 						toastSuccess('You are now connected')
-					// We break the mutations.md convention here because friend
-					// summaries are a view, so we do a full refetch when friend
-					// requests come in. This will change when the friendSummaries
-					// fold/view moves into the client.
-					void friendSummariesCollection.utils.refetch()
+					writeRealtimeRow(friendRequestActionsCollection, row.id, row)
 				}
 			)
 			.subscribe()

--- a/src/features/social/hooks.ts
+++ b/src/features/social/hooks.ts
@@ -12,7 +12,7 @@ import {
 	type FriendRequestActionType,
 	type FriendRequestResponseType,
 } from './schemas'
-import { writeRealtimeRow } from '@/lib/collections/realtime-row'
+import { writeSyncedRow } from '@/lib/collections/realtime-row'
 import supabase from '@/lib/supabase-client'
 import { useUserId } from '@/lib/use-auth'
 import { and, eq, isNull, useLiveQuery } from '@tanstack/react-db'
@@ -447,7 +447,7 @@ export const useSocialRealtime = () => {
 						toastSuccess('Friend request accepted')
 					if (row.action_type === 'accept' && row.uid_by === userId)
 						toastSuccess('You are now connected')
-					writeRealtimeRow(friendRequestActionsCollection, row.id, row)
+					writeSyncedRow(friendRequestActionsCollection, row.id, row)
 				}
 			)
 			.subscribe()
@@ -468,7 +468,7 @@ export const useSocialRealtime = () => {
 					const row = ChatMessageSchema.parse(
 						payload.new as Tables<'chat_message'>
 					)
-					writeRealtimeRow(chatMessagesCollection, row.id, row)
+					writeSyncedRow(chatMessagesCollection, row.id, row)
 				}
 			)
 			.on(
@@ -482,7 +482,7 @@ export const useSocialRealtime = () => {
 					const row = ChatMessageSchema.parse(
 						payload.new as Tables<'chat_message'>
 					)
-					writeRealtimeRow(chatMessagesCollection, row.id, row)
+					writeSyncedRow(chatMessagesCollection, row.id, row)
 				}
 			)
 			.subscribe()

--- a/src/features/social/hooks.ts
+++ b/src/features/social/hooks.ts
@@ -7,9 +7,9 @@ import type { UseLiveQueryResult, uuid } from '@/types/main'
 import {
 	ChatMessageSchema,
 	FriendRequestActionSchema,
-	FRIEND_ACTION_TOAST,
 	type ChatMessageRelType,
 	type ChatMessageType,
+	type FriendRequestActionType,
 	type FriendRequestResponseType,
 } from './schemas'
 import { writeRealtimeRow } from '@/lib/collections/realtime-row'
@@ -60,16 +60,38 @@ export const useOneRelation = (
 		[uid]
 	)
 
+/** What each action tells the person who took it, once the server stores it. */
+export const FRIEND_ACTION_TOAST: Record<
+	FriendRequestResponseType,
+	{ text: string; tone: 'success' | 'neutral' }
+> = {
+	invite: { text: 'Friend request sent 👍', tone: 'success' },
+	accept: {
+		text: 'Accepted invitation. You are now connected 👍',
+		tone: 'success',
+	},
+	decline: { text: 'Declined this invitation', tone: 'neutral' },
+	cancel: { text: 'Cancelled this invitation', tone: 'neutral' },
+	remove: { text: 'You are no longer friends', tone: 'neutral' },
+}
+
 /** What `useFriendRequestAction` hands back to a button. */
 export type FriendRequestAction = {
 	act: (action_type: FriendRequestResponseType) => void
-	/** The action currently in flight, or null. */
-	pendingAction: FriendRequestResponseType | null
 	isPending: boolean
 	/** The last action the server stored, for a call site showing an outcome. */
 	lastAction: FriendRequestResponseType | null
 	error: Error | null
 }
+
+type ActionState = Omit<FriendRequestAction, 'act'> & { uid_for: uuid }
+
+/** Nothing has been tried yet for this person. */
+const NO_ACTION_YET = {
+	isPending: false,
+	lastAction: null,
+	error: null,
+} satisfies Omit<ActionState, 'uid_for'>
 
 /**
  * Record one friend request action, and wait for the server to store it.
@@ -82,41 +104,48 @@ export type FriendRequestAction = {
  */
 export const useFriendRequestAction = (uid_for: uuid): FriendRequestAction => {
 	const uid_by = useUserId()
-	const [uid_less, uid_more] = [uid_by, uid_for].toSorted()
-	const [pendingAction, setPendingAction] =
-		useState<FriendRequestResponseType | null>(null)
-	const [lastAction, setLastAction] =
-		useState<FriendRequestResponseType | null>(null)
-	const [error, setError] = useState<Error | null>(null)
+	// Scoped to `uid_for` so navigating from one profile to another does not
+	// show the previous person's outcome — this component stays mounted.
+	const [state, setState] = useState<ActionState>({
+		uid_for,
+		...NO_ACTION_YET,
+	})
+	const current: ActionState =
+		state.uid_for === uid_for ? state : { uid_for, ...NO_ACTION_YET }
 
 	const act = (action_type: FriendRequestResponseType) => {
-		if (!uid_by || pendingAction !== null) return
+		if (!uid_by || current.isPending) return
+		const [uid_less, uid_more] = [uid_by, uid_for].toSorted()
 		const id = crypto.randomUUID()
-		setPendingAction(action_type)
-		setError(null)
+		setState({ uid_for, isPending: true, lastAction: null, error: null })
+		// `collection.insert` validates against the collection's schema, so the
+		// object only needs to satisfy the type here. `created_at` is required by
+		// that schema and dropped by the handler — the server stamps it.
 		const tx = friendRequestActionsCollection.insert(
-			FriendRequestActionSchema.parse({
+			{
 				id,
-				// The schema needs a timestamp and the handler drops it: the server
-				// stamps `created_at`, and nothing renders this row before then.
 				created_at: new Date().toISOString(),
 				uid_less,
 				uid_more,
 				uid_by,
 				uid_for,
 				action_type,
-			}),
+			} satisfies FriendRequestActionType,
 			{ optimistic: false }
 		)
 		tx.isPersisted.promise.then(
 			() => {
-				// Read the toast off the stored row, not off what we sent: an invite
-				// to someone who already invited you is stored as an accept.
-				const stored =
+				// Report what the server settled on, not what we asked for: an
+				// invite to someone who already invited you is stored as an accept.
+				const settled =
 					friendRequestActionsCollection.get(id)?.action_type ?? action_type
-				setPendingAction(null)
-				setLastAction(stored)
-				const toast = FRIEND_ACTION_TOAST[stored]
+				setState({
+					uid_for,
+					isPending: false,
+					lastAction: settled,
+					error: null,
+				})
+				const toast = FRIEND_ACTION_TOAST[settled]
 				if (toast.tone === 'success') toastSuccess(toast.text)
 				else toastNeutral(toast.text)
 			},
@@ -128,8 +157,12 @@ export const useFriendRequestAction = (uid_for: uuid): FriendRequestAction => {
 					failure,
 					action_type
 				)
-				setPendingAction(null)
-				setError(failure)
+				setState({
+					uid_for,
+					isPending: false,
+					lastAction: null,
+					error: failure,
+				})
 				toastError(`Something went wrong with this interaction`)
 			}
 		)
@@ -137,10 +170,9 @@ export const useFriendRequestAction = (uid_for: uuid): FriendRequestAction => {
 
 	return {
 		act,
-		pendingAction,
-		isPending: pendingAction !== null,
-		lastAction,
-		error,
+		isPending: current.isPending,
+		lastAction: current.lastAction,
+		error: current.error,
 	}
 }
 

--- a/src/features/social/hooks.ts
+++ b/src/features/social/hooks.ts
@@ -383,24 +383,22 @@ export type ShareableContent =
 	| { message_type: 'request'; request_id: uuid }
 	| { message_type: 'playlist'; playlist_id: uuid }
 
-export const SHARE_SUCCESS_TOAST: Record<
-	ShareableContent['message_type'],
-	string
-> = {
+const SHARE_SUCCESS_TOAST: Record<ShareableContent['message_type'], string> = {
 	recommendation: 'Phrase sent to friend',
 	request: 'Request sent to friend',
 	playlist: 'Playlist sent to friend',
 }
 
 /**
- * Send one piece of shared content to one or more friends.
+ * Build one chat message per recipient and hand them to the collection.
  *
  * Every chat message the app writes goes through here, so the row shape and
- * its null foreign keys are stated once. The write is optimistic: the message
- * is in the thread before the server answers, and a rejected one rolls back
- * with the error toast its caller attaches to the returned transaction.
+ * its null foreign keys are stated once. The write is optimistic: unlike a
+ * friend request, nothing server-side rejects or rewrites a message, so a
+ * failure is a real failure and rolling it back out of the thread is the
+ * right thing to show.
  */
-export const sendToFriends = ({
+const sendChatMessages = ({
 	senderUid,
 	recipientUids,
 	lang,
@@ -410,48 +408,55 @@ export const sendToFriends = ({
 	recipientUids: Array<uuid>
 	lang: string
 	content: ShareableContent
-}) =>
-	chatMessagesCollection.insert(
-		recipientUids.map((recipient_uid) =>
-			ChatMessageSchema.parse({
-				// Client-generated so the server's row replaces this one rather
-				// than joining it. `created_at` is a local guess the write-back
-				// overwrites with the server's stamp.
-				id: crypto.randomUUID(),
-				created_at: new Date().toISOString(),
-				sender_uid: senderUid,
-				recipient_uid,
-				lang,
-				phrase_id: null,
-				request_id: null,
-				playlist_id: null,
-				related_message_id: null,
-				read_at: null,
-				...content,
-			})
-		)
+}) => {
+	// One stamp for the whole share, so a message sent to eight friends sorts
+	// identically in all eight threads. The server's stamp replaces it.
+	const created_at = new Date().toISOString()
+	return chatMessagesCollection.insert(
+		recipientUids.map((recipient_uid) => ({
+			// Client-generated so the server's row replaces this one rather than
+			// joining it. The collection validates against `ChatMessageSchema`.
+			id: crypto.randomUUID(),
+			created_at,
+			sender_uid: senderUid,
+			recipient_uid,
+			lang,
+			phrase_id: null,
+			request_id: null,
+			playlist_id: null,
+			related_message_id: null,
+			read_at: null,
+			...content,
+		}))
 	)
+}
 
 /**
- * Send a phrase / request / playlist to friends from one of the three share
- * dialogs. They differ only in the `content` they carry, and each closes
- * itself through `onSuccess` as soon as the messages are in the thread.
+ * Send a phrase / request / playlist to friends.
+ *
+ * The hook supplies the sender and owns the toasts; everything that varies
+ * per click is an argument. That way one hook serves both the share dialogs,
+ * which carry fixed content to many friends, and the chat recommend dialog,
+ * which sends to one friend content it picks at click time.
  */
-export const useSendToFriends = (
-	lang: string,
-	content: ShareableContent,
-	{ onSuccess }: { onSuccess?: () => void } = {}
-) => {
+export const useSendToFriends = () => {
 	const userId = useUserId()
-	const send = (recipientUids: Array<uuid>) => {
+	return ({
+		recipientUids,
+		lang,
+		content,
+	}: {
+		recipientUids: Array<uuid>
+		lang: string
+		content: ShareableContent
+	}) => {
 		if (!userId) return
-		const tx = sendToFriends({
+		const tx = sendChatMessages({
 			senderUid: userId,
 			recipientUids,
 			lang,
 			content,
 		})
-		onSuccess?.()
 		tx.isPersisted.promise.then(
 			() => toastSuccess(SHARE_SUCCESS_TOAST[content.message_type]),
 			(error: unknown) => {
@@ -460,7 +465,6 @@ export const useSendToFriends = (
 			}
 		)
 	}
-	return { send }
 }
 
 /** Subscribe to realtime friend-request and chat-message events. */

--- a/src/features/social/hooks.ts
+++ b/src/features/social/hooks.ts
@@ -443,10 +443,12 @@ export const useSocialRealtime = () => {
 				},
 				(payload) => {
 					const row = FriendRequestActionSchema.parse(payload.new)
+					// Only the other party's actions are news. Your own frame
+					// echoes back here too, and `useFriendRequestAction` has
+					// already toasted it — telling you twice is what the
+					// `learner3 accepts a friend request` scene caught.
 					if (row.action_type === 'accept' && row.uid_for === userId)
 						toastSuccess('Friend request accepted')
-					if (row.action_type === 'accept' && row.uid_by === userId)
-						toastSuccess('You are now connected')
 					writeSyncedRow(friendRequestActionsCollection, row.id, row)
 				}
 			)

--- a/src/features/social/index.ts
+++ b/src/features/social/index.ts
@@ -8,7 +8,6 @@ export {
 	FriendRequestActionSchema,
 	type FriendRequestActionType,
 	type FriendRequestResponseType,
-	STATUS_AFTER_ACTION,
 	ChatMessageSchema,
 	type ChatMessageType,
 	type ChatMessageRelType,

--- a/src/features/social/index.ts
+++ b/src/features/social/index.ts
@@ -40,8 +40,6 @@ export {
 	type ChatEntry,
 	markChatRead,
 	useSendToFriends,
-	sendToFriends,
-	SHARE_SUCCESS_TOAST,
 	type ShareableContent,
 	useSocialRealtime,
 } from './hooks'

--- a/src/features/social/index.ts
+++ b/src/features/social/index.ts
@@ -5,6 +5,10 @@
 export {
 	FriendSummarySchema,
 	type FriendSummaryType,
+	FriendRequestActionSchema,
+	type FriendRequestActionType,
+	type FriendRequestResponseType,
+	STATUS_AFTER_ACTION,
 	ChatMessageSchema,
 	type ChatMessageType,
 	type ChatMessageRelType,
@@ -15,12 +19,12 @@ export {
 
 // Collections
 export {
-	friendSummariesCollection,
+	friendRequestActionsCollection,
 	chatMessagesCollection,
 } from './collections'
 
-// Live collections
-export { relationsFull, type RelationsFullType } from './live'
+// Live collections — the friend-summary fold over the action log
+export { friendSummaries, relationsFull, type RelationsFullType } from './live'
 
 // Hooks
 export {
@@ -28,6 +32,7 @@ export {
 	useIncomingFriendRequests,
 	useOneRelation,
 	useFriendRequestAction,
+	type FriendRequestAction,
 	useAllChats,
 	useOneFriendChat,
 	useUnreadMessages,

--- a/src/features/social/index.ts
+++ b/src/features/social/index.ts
@@ -40,6 +40,8 @@ export {
 	type ChatEntry,
 	markChatRead,
 	useSendToFriends,
+	sendToFriends,
+	SHARE_SUCCESS_TOAST,
 	type ShareableContent,
 	useSocialRealtime,
 } from './hooks'

--- a/src/features/social/live.ts
+++ b/src/features/social/live.ts
@@ -1,8 +1,18 @@
 import { createLiveQueryCollection, eq } from '@tanstack/db'
-import { friendSummariesCollection } from './collections'
-import { publicProfilesCollection } from '@/features/profile/collections'
+import { createFriendSummaries } from './friend-summary-fold'
+import { friendRequestActionsCollection } from './collections'
+import {
+	myProfileCollection,
+	publicProfilesCollection,
+} from '@/features/profile/collections'
 import type { FriendSummaryType } from './schemas'
 import type { PublicProfileType } from '@/features/profile/schemas'
+
+/** Every pair the signed-in user belongs to, with its current status. */
+export const friendSummaries = createFriendSummaries(
+	friendRequestActionsCollection,
+	myProfileCollection
+)
 
 export type RelationsFullType = FriendSummaryType & {
 	isMostRecentByMe: boolean
@@ -12,7 +22,7 @@ export type RelationsFullType = FriendSummaryType & {
 export const relationsFull = createLiveQueryCollection({
 	query: (q) =>
 		q
-			.from({ relation: friendSummariesCollection })
+			.from({ relation: friendSummaries })
 			.join(
 				{ profile: publicProfilesCollection },
 				({ relation, profile }) => eq(relation.uid, profile.uid),

--- a/src/features/social/live.ts
+++ b/src/features/social/live.ts
@@ -1,4 +1,4 @@
-import { createLiveQueryCollection, eq } from '@tanstack/db'
+import { BTreeIndex, createLiveQueryCollection, eq } from '@tanstack/db'
 import { createFriendSummaries } from './friend-summary-fold'
 import { friendRequestActionsCollection } from './collections'
 import {
@@ -13,6 +13,12 @@ export const friendSummaries = createFriendSummaries(
 	friendRequestActionsCollection,
 	myProfileCollection
 )
+
+// A live query collection cannot take `autoIndex`, so the two fields consumers
+// look rows up by are indexed here — `uid` for the join in `useOnePublicProfile`
+// and `status` for the friends filters.
+friendSummaries.createIndex((row) => row.uid, { indexType: BTreeIndex })
+friendSummaries.createIndex((row) => row.status, { indexType: BTreeIndex })
 
 export type RelationsFullType = FriendSummaryType & {
 	isMostRecentByMe: boolean

--- a/src/features/social/public-profile.ts
+++ b/src/features/social/public-profile.ts
@@ -1,5 +1,5 @@
 import { publicProfilesCollection } from '@/features/profile/collections'
-import { friendSummariesCollection } from './collections'
+import { friendSummaries } from './live'
 import type { FriendSummaryType } from './schemas'
 import type { PublicProfileType } from '@/features/profile/schemas'
 import type { UseLiveQueryResult, uuid } from '@/types/main'
@@ -11,11 +11,11 @@ export const useSearchProfilesByUsername = (
 ): UseLiveQueryResult<PublicProfileType[]> => {
 	return useLiveQuery(
 		(q) =>
-			!query.trim() ?
-				undefined
-			:	q
-					.from({ profile: publicProfilesCollection })
-					.where(({ profile }) => ilike(profile.username, `%${query}%`)),
+			!query.trim()
+				? undefined
+				: q
+						.from({ profile: publicProfilesCollection })
+						.where(({ profile }) => ilike(profile.username, `%${query}%`)),
 		[query]
 	)
 }
@@ -31,19 +31,17 @@ export const useOnePublicProfile = (
 				.from({ profile: publicProfilesCollection })
 				.where(({ profile }) => eq(profile.uid, uid))
 				.findOne()
-				.join(
-					{ relation: friendSummariesCollection },
-					({ profile, relation }) => eq(relation.uid, profile.uid)
+				.join({ relation: friendSummaries }, ({ profile, relation }) =>
+					eq(relation.uid, profile.uid)
 				)
 				.fn.select(({ profile, relation }) => ({
 					...profile,
-					relation:
-						!relation ? null : (
-							{
+					relation: !relation
+						? null
+						: {
 								...relation,
 								isMostRecentByMe: relation.most_recent_uid_for === relation.uid,
-							}
-						),
+							},
 				})),
 		[uid]
 	)

--- a/src/features/social/schemas.ts
+++ b/src/features/social/schemas.ts
@@ -9,6 +9,10 @@ export const FriendRequestResponseEnumSchema = z.enum([
 	'invite',
 ])
 
+export type FriendRequestResponseType = z.infer<
+	typeof FriendRequestResponseEnumSchema
+>
+
 export const FriendStatusEnumSchema = z.enum([
 	'friends',
 	'pending',
@@ -22,6 +26,60 @@ export const MessageTypeEnumSchema = z.enum([
 	'playlist',
 ])
 
+/**
+ * One row of the friend-request action log, exactly as the table stores it.
+ * The log is append-only and RLS-scoped to the pairs the reader belongs to, so
+ * a client holds every action it is entitled to see and can fold the
+ * relationship status locally — see `friendSummaries` in ./live.ts.
+ *
+ * `uid_less` / `uid_more` are nullable in the database but required here: they
+ * are the pair key the fold groups on, and every writer fills them in. A row
+ * without them would be its own relationship, invisible to both parties.
+ */
+export const FriendRequestActionSchema = z.object({
+	id: z.string().uuid(),
+	created_at: z.string(),
+	uid_by: z.string().uuid(),
+	uid_for: z.string().uuid(),
+	uid_less: z.string().uuid(),
+	uid_more: z.string().uuid(),
+	action_type: FriendRequestResponseEnumSchema,
+})
+
+export type FriendRequestActionType = z.infer<typeof FriendRequestActionSchema>
+
+/** The status each action type leaves the pair in. The whole fold, in one table. */
+export const STATUS_AFTER_ACTION: Record<
+	FriendRequestResponseType,
+	z.infer<typeof FriendStatusEnumSchema>
+> = {
+	accept: 'friends',
+	invite: 'pending',
+	decline: 'unconnected',
+	cancel: 'unconnected',
+	remove: 'unconnected',
+}
+
+/** What each action tells the person who took it, once the server stores it. */
+export const FRIEND_ACTION_TOAST: Record<
+	FriendRequestResponseType,
+	{ text: string; tone: 'success' | 'neutral' }
+> = {
+	invite: { text: 'Friend request sent 👍', tone: 'success' },
+	accept: {
+		text: 'Accepted invitation. You are now connected 👍',
+		tone: 'success',
+	},
+	decline: { text: 'Declined this invitation', tone: 'neutral' },
+	cancel: { text: 'Cancelled this invitation', tone: 'neutral' },
+	remove: { text: 'You are no longer friends', tone: 'neutral' },
+}
+
+/**
+ * The pair's current relationship, folded from its newest action. Keyed by
+ * `${uid_less}--${uid_more}`; `uid` is the other party, relative to the
+ * signed-in user. Derived, never fetched.
+ */
 export const FriendSummarySchema = z.object({
 	uid: z.string().uuid(),
 	uid_less: z.string().uuid(),

--- a/src/features/social/schemas.ts
+++ b/src/features/social/schemas.ts
@@ -60,25 +60,12 @@ export const STATUS_AFTER_ACTION: Record<
 	remove: 'unconnected',
 }
 
-/** What each action tells the person who took it, once the server stores it. */
-export const FRIEND_ACTION_TOAST: Record<
-	FriendRequestResponseType,
-	{ text: string; tone: 'success' | 'neutral' }
-> = {
-	invite: { text: 'Friend request sent 👍', tone: 'success' },
-	accept: {
-		text: 'Accepted invitation. You are now connected 👍',
-		tone: 'success',
-	},
-	decline: { text: 'Declined this invitation', tone: 'neutral' },
-	cancel: { text: 'Cancelled this invitation', tone: 'neutral' },
-	remove: { text: 'You are no longer friends', tone: 'neutral' },
-}
-
 /**
  * The pair's current relationship, folded from its newest action. Keyed by
  * `${uid_less}--${uid_more}`; `uid` is the other party, relative to the
- * signed-in user. Derived, never fetched.
+ * signed-in user. Derived on the client, never fetched — though the
+ * `friend_summary` view still exists, because `validate_friend_request_action`
+ * reads it.
  */
 export const FriendSummarySchema = z.object({
 	uid: z.string().uuid(),

--- a/src/hooks/use-user-realtime.ts
+++ b/src/hooks/use-user-realtime.ts
@@ -1,10 +1,7 @@
 import { useEffect } from 'react'
 import type { RealtimeChannel } from '@supabase/supabase-js'
 import supabase from '@/lib/supabase-client'
-import {
-	deleteSyncedRow,
-	writeRealtimeRow,
-} from '@/lib/collections/realtime-row'
+import { deleteSyncedRow, writeSyncedRow } from '@/lib/collections/realtime-row'
 import { useUserId } from '@/lib/use-auth'
 import {
 	PhraseRequestUpvoteSchema,
@@ -78,7 +75,7 @@ export const useUserRealtime = () => {
 			'request_id',
 			(row) => {
 				const upvote = PhraseRequestUpvoteSchema.parse(row)
-				writeRealtimeRow(
+				writeSyncedRow(
 					phraseRequestUpvotesCollection,
 					upvote.request_id,
 					upvote
@@ -93,7 +90,7 @@ export const useUserRealtime = () => {
 			'comment_id',
 			(row) => {
 				const upvote = CommentUpvoteSchema.parse(row)
-				writeRealtimeRow(commentUpvotesCollection, upvote.comment_id, upvote)
+				writeSyncedRow(commentUpvotesCollection, upvote.comment_id, upvote)
 			},
 			(key) => deleteSyncedRow(commentUpvotesCollection, key)
 		)
@@ -104,7 +101,7 @@ export const useUserRealtime = () => {
 			'playlist_id',
 			(row) => {
 				const upvote = PhrasePlaylistUpvoteSchema.parse(row)
-				writeRealtimeRow(
+				writeSyncedRow(
 					phrasePlaylistUpvotesCollection,
 					upvote.playlist_id,
 					upvote
@@ -138,7 +135,7 @@ export const useUserRealtime = () => {
 				{ event: 'INSERT', schema: 'public', table: 'user_card' },
 				(payload) => {
 					const row = CardSchema.parse(payload.new)
-					writeRealtimeRow(cardsCollection, row.id, row)
+					writeSyncedRow(cardsCollection, row.id, row)
 				}
 			)
 			.on(
@@ -146,7 +143,7 @@ export const useUserRealtime = () => {
 				{ event: 'UPDATE', schema: 'public', table: 'user_card' },
 				(payload) => {
 					const row = CardSchema.parse(payload.new)
-					writeRealtimeRow(cardsCollection, row.id, row)
+					writeSyncedRow(cardsCollection, row.id, row)
 				}
 			)
 

--- a/src/lib/auth-lifecycle.ts
+++ b/src/lib/auth-lifecycle.ts
@@ -2,7 +2,7 @@ import { failed } from '@scenetest/checks/react'
 import { queryClient } from '@/lib/query-client'
 import { myProfileCollection } from '@/features/profile/collections'
 import { decksCollection, cardsCollection } from '@/features/deck/collections'
-import { friendSummariesCollection } from '@/features/social/collections'
+import { friendRequestActionsCollection } from '@/features/social/collections'
 import { resetUiPrefs } from '@/lib/ui-prefs'
 import {
 	PERSISTED_COLLECTIONS,
@@ -90,7 +90,7 @@ class AuthLifecycle {
 	/**
 	 * _user route loader. Force-reloads what the shell renders with (profile,
 	 * decks) before it mounts. notifications loads itself when the navbar bell's
-	 * live query subscribes; friendSummaries gets a warm-up; the rest reload via
+	 * live query subscribes; friend requests get a warm-up; the rest reload via
 	 * their own route loaders. The failed()/throw is the contract: an empty
 	 * profile here means handle_new_user didn't run.
 	 */
@@ -114,7 +114,7 @@ class AuthLifecycle {
 			)
 		}
 
-		void friendSummariesCollection.preload()
+		void friendRequestActionsCollection.preload()
 		void cardsCollection.preload()
 	}
 }

--- a/src/lib/collections/realtime-row.ts
+++ b/src/lib/collections/realtime-row.ts
@@ -4,16 +4,18 @@ type RowCollection<T extends object> = {
 }
 
 /**
- * Apply a realtime INSERT or UPDATE frame to a collection's synced state.
+ * Put one server-supplied row into a collection's synced state — a realtime
+ * INSERT or UPDATE frame, or the row a persistence handler wrote back.
  *
- * Upserts rather than updates: if a frame arrives for a row this client hasn't
- * fetched, `writeUpdate` will throw on a key it cannot find.
+ * Upserts rather than inserts or updates, because the two callers race: a
+ * frame can arrive for a row this client never fetched (`writeUpdate` throws
+ * on a key it cannot find), and a frame for this client's own write can land
+ * before its handler resolves (`writeInsert` throws on a key already there).
  *
- * Skips the write when every field already matches — that is this client's own
- * mutation echoing back, and writing it would re-run every live query for
- * nothing.
+ * Skips the write when every field already matches — the same row arriving
+ * twice — because writing it would re-run every live query for nothing.
  */
-export function writeRealtimeRow<T extends object>(
+export function writeSyncedRow<T extends object>(
 	collection: RowCollection<T>,
 	key: string,
 	row: T

--- a/src/routes/_user/accept-invite.tsx
+++ b/src/routes/_user/accept-invite.tsx
@@ -1,6 +1,4 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { useMutation, type UseMutationResult } from '@tanstack/react-query'
-import { toastError, toastSuccess } from '@/components/ui/sonner'
 import * as z from 'zod'
 import { ArrowRightLeft } from 'lucide-react'
 
@@ -18,11 +16,14 @@ import {
 } from '@/components/ui/card'
 import { useUserId } from '@/lib/use-auth'
 import languages from '@/lib/languages'
-import supabase from '@/lib/supabase-client'
 import { useProfile } from '@/features/profile/hooks'
 import { Loader } from '@/components/ui/loader'
 import { avatarUrlify } from '@/lib/hooks'
 import { useOnePublicProfile } from '@/features/social/public-profile'
+import {
+	useFriendRequestAction,
+	type FriendRequestAction,
+} from '@/features/social/hooks'
 
 const SearchSchema = z.object({
 	uid_by: z.string().uuid(),
@@ -50,26 +51,10 @@ function AcceptInvitePage() {
 			'Something went wrong; you are not logged in, or this invite link is for a different user'
 		)
 
-	const acceptOrDeclineMutation = useMutation({
-		mutationKey: ['invite', 'accept-or-decline', search.uid_by],
-		mutationFn: async ({ action }: { action: 'decline' | 'accept' }) => {
-			const res = await supabase
-				.from('friend_request_action')
-				.insert({
-					uid_by: search.uid_by,
-					uid_for: userId,
-					action_type: action,
-				})
-				.throwOnError()
-				.select()
-			return res
-		},
-		onSuccess: () => toastSuccess('Response successful'), // now redirect somewhere?,
-		onError: (error) => {
-			toastError('An error has occurred')
-			console.log(`The error accepting the friend invite:`, error)
-		},
-	})
+	// The action is recorded by *this* user about the inviter, and it carries
+	// the sorted pair key the friend-summary fold groups on. Writing the row by
+	// hand here got both wrong, so it goes through the shared hook.
+	const friendRequest = useFriendRequestAction(search.uid_by)
 
 	return (
 		<main className="w-app flex h-screen flex-col justify-center p-2 pb-20">
@@ -88,18 +73,18 @@ function AcceptInvitePage() {
 						</CardDescription>
 					</CardHeader>
 					<CardContent className="space-y-4">
-						{acceptOrDeclineMutation.error ? (
+						{friendRequest.error ? (
 							<ShowAndLogError
-								error={acceptOrDeclineMutation.error}
+								error={friendRequest.error}
 								text="Something went wrong"
 							/>
-						) : !acceptOrDeclineMutation.isSuccess ? (
+						) : !friendRequest.lastAction ? (
 							<AcceptInviteForm
 								profile={profile}
 								friend={friend}
-								acceptOrDeclineMutation={acceptOrDeclineMutation}
+								friendRequest={friendRequest}
 							/>
-						) : acceptOrDeclineMutation.variables.action === 'accept' ? (
+						) : friendRequest.lastAction === 'accept' ? (
 							<ShowAccepted friend={friend} />
 						) : (
 							<ShowDeclined />
@@ -114,15 +99,11 @@ function AcceptInvitePage() {
 function AcceptInviteForm({
 	profile,
 	friend,
-	acceptOrDeclineMutation,
+	friendRequest,
 }: {
 	profile: { avatar_path: string | null } | null | undefined
 	friend: PublicProfileType | null | undefined
-	acceptOrDeclineMutation: UseMutationResult<
-		unknown,
-		Error,
-		{ action: 'decline' | 'accept' }
-	>
+	friendRequest: FriendRequestAction
 }) {
 	return (
 		<>
@@ -149,16 +130,16 @@ function AcceptInviteForm({
 			<div className="flex flex-row justify-center gap-4">
 				<Button
 					size="lg"
-					onClick={() => acceptOrDeclineMutation.mutate({ action: 'accept' })}
-					disabled={acceptOrDeclineMutation.isPending}
+					onClick={() => friendRequest.act('accept')}
+					disabled={friendRequest.isPending}
 				>
 					Accept invitation
 				</Button>
 				<Button
 					size="lg"
 					variant="neutral"
-					onClick={() => acceptOrDeclineMutation.mutate({ action: 'decline' })}
-					disabled={acceptOrDeclineMutation.isPending}
+					onClick={() => friendRequest.act('decline')}
+					disabled={friendRequest.isPending}
 				>
 					Ignore
 				</Button>

--- a/src/routes/_user/friends.tsx
+++ b/src/routes/_user/friends.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 import { publicProfilesCollection } from '@/features/profile/collections'
-import { friendSummariesCollection } from '@/features/social/collections'
+import { friendRequestActionsCollection } from '@/features/social/collections'
 import { RequireAuth } from '@/components/require-auth'
 
 export const Route = createFileRoute('/_user/friends')({
@@ -13,7 +13,7 @@ export const Route = createFileRoute('/_user/friends')({
 		// Only preload if authenticated
 		if (!context.auth.isAuth) return
 		await Promise.all([
-			friendSummariesCollection.preload(),
+			friendRequestActionsCollection.preload(),
 			publicProfilesCollection.preload(),
 		])
 	},

--- a/src/routes/_user/friends/$uid.tsx
+++ b/src/routes/_user/friends/$uid.tsx
@@ -29,7 +29,10 @@ function ProfilePage() {
 			'Something went wrong loading this profile... please contact administrator'
 		)
 	return (
-		<main className="mx-auto w-full space-y-6 px-2 py-6">
+		<main
+			data-testid="friend-profile-page"
+			className="mx-auto w-full space-y-6 px-2 py-6"
+		>
 			{isMine ? (
 				<p className="text-muted-foreground mb-1 text-center italic">
 					This is how your profile appears to others

--- a/src/routes/_user/friends/-relationship-actions.tsx
+++ b/src/routes/_user/friends/-relationship-actions.tsx
@@ -11,61 +11,79 @@ export function RelationshipActions({ uid_for }: { uid_for: uuid }) {
 	const userId = useUserId()
 	const action = useFriendRequestAction(uid_for)
 	const { data: relationship } = useOneRelation(uid_for)
-	return (
-		!userId ? null
-		: !relationship?.status || relationship.status === 'unconnected' ?
-			<Button onClick={() => action.mutate('invite')}>
-				Add friend{' '}
-				{action.isPending ?
-					<IconSizedLoader />
-				:	<ThumbsUp />}
+	return !userId ? null : !relationship?.status ||
+	  relationship.status === 'unconnected' ? (
+		<Button
+			data-testid="add-friend-button"
+			onClick={() => action.act('invite')}
+		>
+			Add friend {action.isPending ? <IconSizedLoader /> : <ThumbsUp />}
+		</Button>
+	) : relationship.status === 'friends' ? (
+		<ConfirmDestructiveActionDialog
+			title="Would you like to remove this friendship?"
+			description="You won't be able to see each other's decks or progress any more."
+		>
+			<Button
+				data-testid="friends-status-button"
+				variant="soft"
+				className="hover:bg-destructive/30"
+			>
+				<UserCheck />
+				Friends
 			</Button>
-		: relationship.status === 'friends' ?
-			<ConfirmDestructiveActionDialog
-				title="Would you like to remove this friendship?"
-				description="You won't be able to see each other's decks or progress any more."
+			<Button
+				data-testid="unfriend-button"
+				variant="red"
+				onClick={() => action.act('remove')}
 			>
-				<Button variant="soft" className="hover:bg-destructive/30">
-					<UserCheck />
-					Friends
+				<UserMinus />
+				Unfriend
+			</Button>
+		</ConfirmDestructiveActionDialog>
+	) : relationship.status === 'pending' && !relationship.isMostRecentByMe ? (
+		<div className="flex flex-row items-center justify-center gap-2">
+			<Button
+				data-testid="accept-friend-request-button"
+				onClick={() => action.act('accept')}
+			>
+				Confirm friends {action.isPending ? <IconSizedLoader /> : <ThumbsUp />}
+			</Button>
+			<ConfirmDestructiveActionDialog
+				title="Decline this friend request?"
+				description="You can still invite them to be friends later."
+			>
+				<Button data-testid="decline-friend-request-button" variant="neutral">
+					<X />
 				</Button>
-				<Button variant="red" onClick={() => action.mutate('remove')}>
-					<UserMinus />
-					Unfriend
-				</Button>
-			</ConfirmDestructiveActionDialog>
-		: relationship.status === 'pending' && !relationship.isMostRecentByMe ?
-			<div className="flex flex-row items-center justify-center gap-2">
-				<Button onClick={() => action.mutate('accept')}>
-					Confirm friends{' '}
-					{action.isPending ?
-						<IconSizedLoader />
-					:	<ThumbsUp />}
-				</Button>
-				<ConfirmDestructiveActionDialog
-					title="Decline this friend request?"
-					description="You can still invite them to be friends later."
+				<Button
+					data-testid="confirm-decline-friend-request-button"
+					variant="red"
+					onClick={() => action.act('decline')}
 				>
-					<Button variant="neutral">
-						<X />
-					</Button>
-					<Button variant="red" onClick={() => action.mutate('decline')}>
-						Confirm
-					</Button>
-				</ConfirmDestructiveActionDialog>
-			</div>
-		: relationship.status === 'pending' && relationship.isMostRecentByMe ?
-			<ConfirmDestructiveActionDialog
-				title="Cancel your friend request?"
-				description=""
-			>
-				<Button variant="soft" className="hover:bg-destructive/30">
-					<UserCheck /> Requested
-				</Button>
-				<Button variant="red" onClick={() => action.mutate('cancel')}>
-					Cancel request
+					Confirm
 				</Button>
 			</ConfirmDestructiveActionDialog>
-		:	null
-	)
+		</div>
+	) : relationship.status === 'pending' && relationship.isMostRecentByMe ? (
+		<ConfirmDestructiveActionDialog
+			title="Cancel your friend request?"
+			description=""
+		>
+			<Button
+				data-testid="requested-status-button"
+				variant="soft"
+				className="hover:bg-destructive/30"
+			>
+				<UserCheck /> Requested
+			</Button>
+			<Button
+				data-testid="cancel-friend-request-button"
+				variant="red"
+				onClick={() => action.act('cancel')}
+			>
+				Cancel request
+			</Button>
+		</ConfirmDestructiveActionDialog>
+	) : null
 }

--- a/src/routes/_user/friends/chats.$friendUid.recommend.tsx
+++ b/src/routes/_user/friends/chats.$friendUid.recommend.tsx
@@ -1,8 +1,12 @@
 import { useState, useMemo, useRef, useEffect } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useMutation } from '@tanstack/react-query'
 import { useLiveQuery } from '@tanstack/react-db'
 import { toastError, toastSuccess } from '@/components/ui/sonner'
+import {
+	sendToFriends,
+	SHARE_SUCCESS_TOAST,
+	type ShareableContent,
+} from '@/features/social/hooks'
 import {
 	Search,
 	Send,
@@ -13,8 +17,6 @@ import {
 	MessageCircleHeart,
 } from 'lucide-react'
 
-import type { TablesInsert } from '@/types/supabase'
-import supabase from '@/lib/supabase-client'
 import { useUserId } from '@/lib/use-auth'
 import { phrasesComposed } from '@/features/phrases/live'
 import { phraseRequestsActive } from '@/features/requests/live'
@@ -215,66 +217,41 @@ function RouteComponent() {
 		void navigate({ to: '/friends/chats/$friendUid', params })
 	}
 
-	const sendMessageMutation = useMutation({
-		mutationFn: async (newMessage: TablesInsert<'chat_message'>) => {
-			const { error } = await supabase.from('chat_message').insert(newMessage)
-			if (error) throw error
-		},
-		onSuccess: (_data, variables) => {
-			const label =
-				variables.message_type === 'recommendation'
-					? 'Phrase'
-					: variables.message_type === 'playlist'
-						? 'Playlist'
-						: 'Request'
-			closeDialog()
-			toastSuccess(`${label} sent!`)
-		},
-		onError: (error) => {
-			toastError(`Failed to send: ${error.message}`)
-		},
-	})
-
-	const handleSend = (result: SearchResult) => {
+	// The message lands in the thread on click, so the dialog can close on the
+	// same tick; `chatMessagesCollection` owns the write-back and the rollback.
+	const send = (lang: string, content: ShareableContent) => {
 		if (!userId) return
-		const base = {
-			sender_uid: userId,
-			recipient_uid: params.friendUid,
-			lang: result.lang,
-		}
-
-		if (result.type === 'phrase') {
-			void sendMessageMutation.mutate({
-				...base,
-				phrase_id: result.id,
-				message_type: 'recommendation',
-			})
-		} else if (result.type === 'playlist') {
-			void sendMessageMutation.mutate({
-				...base,
-				playlist_id: result.id,
-				message_type: 'playlist',
-			})
-		} else {
-			void sendMessageMutation.mutate({
-				...base,
-				request_id: result.id,
-				message_type: 'request',
-			})
-		}
+		const tx = sendToFriends({
+			senderUid: userId,
+			recipientUids: [params.friendUid],
+			lang,
+			content,
+		})
+		closeDialog()
+		tx.isPersisted.promise.then(
+			() => toastSuccess(SHARE_SUCCESS_TOAST[content.message_type]),
+			(error: unknown) => {
+				console.log(`Failed to send to this friend:`, error, content)
+				toastError('Something went wrong')
+			}
+		)
 	}
+
+	const handleSend = (result: SearchResult) =>
+		send(
+			result.lang,
+			result.type === 'phrase'
+				? { message_type: 'recommendation', phrase_id: result.id }
+				: result.type === 'playlist'
+					? { message_type: 'playlist', playlist_id: result.id }
+					: { message_type: 'request', request_id: result.id }
+		)
 
 	const handlePhraseCreated = (phraseId: string) => {
 		setShowCreator(false)
 		// Send the newly created phrase immediately
-		if (!userId || !lang) return
-		void sendMessageMutation.mutate({
-			sender_uid: userId,
-			recipient_uid: params.friendUid,
-			phrase_id: phraseId,
-			lang,
-			message_type: 'recommendation',
-		})
+		if (!lang) return
+		send(lang, { message_type: 'recommendation', phrase_id: phraseId })
 	}
 
 	return (
@@ -377,7 +354,6 @@ function RouteComponent() {
 									result={result}
 									showType={activeFilter === null}
 									onSend={() => handleSend(result)}
-									disabled={sendMessageMutation.isPending}
 								/>
 							))
 						)
@@ -432,12 +408,10 @@ function SendableResult({
 	result,
 	showType,
 	onSend,
-	disabled,
 }: {
 	result: SearchResult
 	showType: boolean
 	onSend: () => void
-	disabled: boolean
 }) {
 	const typeIcon =
 		result.type === 'phrase' ? (
@@ -454,7 +428,6 @@ function SendableResult({
 		<button
 			type="button"
 			onClick={onSend}
-			disabled={disabled}
 			data-testid={`send-${result.type}-${result.id}`}
 			className="flex w-full items-center gap-3 px-4 py-2.5 text-start transition-colors hover:bg-neutral-100 disabled:opacity-50"
 		>

--- a/src/routes/_user/friends/chats.$friendUid.recommend.tsx
+++ b/src/routes/_user/friends/chats.$friendUid.recommend.tsx
@@ -1,12 +1,7 @@
 import { useState, useMemo, useRef, useEffect } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useLiveQuery } from '@tanstack/react-db'
-import { toastError, toastSuccess } from '@/components/ui/sonner'
-import {
-	sendToFriends,
-	SHARE_SUCCESS_TOAST,
-	type ShareableContent,
-} from '@/features/social/hooks'
+import { useSendToFriends, type ShareableContent } from '@/features/social'
 import {
 	Search,
 	Send,
@@ -17,7 +12,6 @@ import {
 	MessageCircleHeart,
 } from 'lucide-react'
 
-import { useUserId } from '@/lib/use-auth'
 import { phrasesComposed } from '@/features/phrases/live'
 import { phraseRequestsActive } from '@/features/requests/live'
 import { phrasePlaylistsActive } from '@/features/playlists/live'
@@ -73,7 +67,6 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
 	const params = Route.useParams()
-	const userId = useUserId()
 	const navigate = useNavigate({ from: Route.fullPath })
 	const inputRef = useRef<HTMLInputElement>(null)
 
@@ -217,28 +210,16 @@ function RouteComponent() {
 		void navigate({ to: '/friends/chats/$friendUid', params })
 	}
 
-	// The message lands in the thread on click, so the dialog can close on the
+	// The message lands in the thread on click, so the dialog closes on the
 	// same tick; `chatMessagesCollection` owns the write-back and the rollback.
-	const send = (lang: string, content: ShareableContent) => {
-		if (!userId) return
-		const tx = sendToFriends({
-			senderUid: userId,
-			recipientUids: [params.friendUid],
-			lang,
-			content,
-		})
+	const send = useSendToFriends()
+	const sendAndClose = (messageLang: string, content: ShareableContent) => {
+		send({ recipientUids: [params.friendUid], lang: messageLang, content })
 		closeDialog()
-		tx.isPersisted.promise.then(
-			() => toastSuccess(SHARE_SUCCESS_TOAST[content.message_type]),
-			(error: unknown) => {
-				console.log(`Failed to send to this friend:`, error, content)
-				toastError('Something went wrong')
-			}
-		)
 	}
 
 	const handleSend = (result: SearchResult) =>
-		send(
+		sendAndClose(
 			result.lang,
 			result.type === 'phrase'
 				? { message_type: 'recommendation', phrase_id: result.id }
@@ -251,7 +232,7 @@ function RouteComponent() {
 		setShowCreator(false)
 		// Send the newly created phrase immediately
 		if (!lang) return
-		send(lang, { message_type: 'recommendation', phrase_id: phraseId })
+		sendAndClose(lang, { message_type: 'recommendation', phrase_id: phraseId })
 	}
 
 	return (


### PR DESCRIPTION
Closes the last open item on #723 and step 4 of #757 — the same slice. No migration, so this targets `main`.

## What changed

`friendSummariesCollection` read the `friend_summary` view, and every `friend_request_action` event triggered a full refetch of it. That was the last `utils.refetch()` in `src/`. The summary is a per-pair fold of the action log, and the client can do that fold itself.

**The rows collection.** `friendRequestActionsCollection` reads `friend_request_action` and owns the insert. `onInsert` writes the stored row into the synced layer; the realtime INSERT binding replaces the refetch.

**The fold** (`friend-summary-fold.ts`) runs in two steps, because the query compiler aggregates values rather than picking a row: group the log by pair and take `max()` of a sortable per-action key, then join that key back to the action carrying it. The key is `created_at|id` — `id` is a uuid, so two actions stamped in the same microsecond cannot both win and collide on the pair key.

`uid` is the other party relative to the reader, which the view got from `auth.uid()`. Here it comes from a join to `myProfileCollection` — the one row it holds — so `friendSummaries` stays a module-scope collection and every consumer keeps reading it as an ordinary live query. A pair whose profile row has not loaded yet folds to nothing rather than to a guess.

## The write waits for the server

`validate_friend_request_action` rejects several transitions, so a relationship that reads "friends" for a moment and then reads "unconnected" again is worse to show than a button that waits. `useFriendRequestAction` writes with `{ optimistic: false }` — the first use of that flag in the app — and holds its own pending state. The row appears when `onInsert` writes the server's row back, which is both what `refetch: false` promises and the only thing that puts the row in the collection.

`docs/mutations.md` gains a short section on the distinction, because it is easy to miss: every existing `await tx.isPersisted.promise` site already waits for the POST. `optimistic: false` does not change *what* you wait for, only whether the user sees the change during the wait.

## A bug this turned up

`accept-invite.tsx` wrote its row by hand, with the inviter as `uid_by` and no pair key. I built a Postgres database holding just the `friend_request_action` table, its two RLS policies, and the validation trigger, copied from the migrations, and ran the inserts as `authenticated` with a stubbed `auth.uid()`:

| Payload | Result |
| --- | --- |
| The old hand-written one | `ERROR: Cannot accept: no pending friend request` |
| Same payload, trigger disabled | `ERROR: new row violates row-level security policy` |
| Through `useFriendRequestAction` | succeeds; the pair flips to `friends` |

Accept and decline were both failing on that page. It now goes through the shared hook. The same run confirmed the mutual-invite transform the handler allows for: a second `invite` on a pending pair comes back stored as `accept`.

## Review notes

- **Indexes.** A live query collection cannot take `autoIndex`, which the old `friend_summary` collection had, so `friendSummaries` gets explicit `uid` and `status` indexes — without them the join in `useOnePublicProfile` falls back to a full scan per mounted profile.
- **Startup payload.** `friend_summary` returned one row per relationship; `friend_request_action` returns every action the user has been party to. The log is bounded by friend count and this is the inherent cost of the fold, but if it ever grows past a few hundred rows per user it will want an `.order().limit()`.
- **The view stays.** `validate_friend_request_action` still reads `friend_summary` server-side, so its status `CASE` is now a second copy of `STATUS_AFTER_ACTION` with nothing keeping the two in sync. Noted in the schema comment rather than restructured.

## Testing

`friend-summary-fold.test.ts` drives the shipped fold over collections it populates offline: one summary per pair, the state read off each pair's own newest action, the "no profile yet" case, live updates, and the same-timestamp tiebreak.

`social.spec.md` gains a scene walking a pair through all three statuses. `pnpm check`, `pnpm lint`, `pnpm test:unit` (289) and `pnpm build:test` all pass locally. **The scene is unverified locally** — Docker is unavailable in this environment, so Supabase and `pnpm scene` could not run. CI is the first real run of it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bai7ApE5qThtarKoLS35zK)_