### PR TITLE
Drop pgjwt extension and stub pgsodium for native dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _26 August, 2026_
 ### Improvements
 
 - **The deprecated `pgjwt` extension is dropped.** Nothing in the schema signs a JWT in SQL — the one outbound authenticated call forwards the caller's PostgREST authorization header — so the extension goes before Supabase removes it.
+- **`scripts/db-native.sh` stubs `pgsodium`, so a native reset loads `base.sql` again.** The regenerated dump creates the extension, which is enabled on production, and the script had no stub for it, so `reset` stopped at that line.
 
 ### Migrations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## v0.33 - Drop the Deprecated `pgjwt` Extension
+
+_26 August, 2026_
+
+### Improvements
+
+- **The deprecated `pgjwt` extension is dropped.** Nothing in the schema signs a JWT in SQL — the one outbound authenticated call forwards the caller's PostgREST authorization header — so the extension goes before Supabase removes it.
+
+### Migrations
+
+- `20260826120000_drop_pgjwt.sql` — drops the `pgjwt` extension, which Supabase deprecated and no function, view, policy or trigger in the schema ever called.
+
 ## v0.32 - Tailwind Palette Replaces OKLCH; Decks as Rows; Soft-Delete Upvotes
 
 _25 August, 2026_

--- a/scripts/db-native.sh
+++ b/scripts/db-native.sh
@@ -44,6 +44,8 @@ PGSOCK="${PG_HOME}/sock"
 PGPORT="54399"
 DBNAME="sunlo"
 PGVECTOR_VERSION="v0.8.0"      # apt ships 0.6.0; the dump needs halfvec/sparsevec (>=0.7)
+# Supabase extensions with no native build. See dev-native/extensions/README.md.
+FAKE_EXTENSIONS="pg_net supabase_vault pg_graphql pgjwt pg_cron pgsodium"
 DB_URL="postgresql://postgres@127.0.0.1:${PGPORT}/${DBNAME}"
 
 PGBIN="$(echo /usr/lib/postgresql/*/bin | tr ' ' '\n' | sort -V | tail -1)"
@@ -89,19 +91,29 @@ ensure_pgvector() {
 }
 
 install_fake_extensions() {
-  # Empty, relocatable stubs so `create extension <name>` succeeds. The objects a
-  # couple of functions actually reference live in bootstrap.sql, not here.
+  # Empty stubs so `create extension <name>` succeeds. The objects a couple of
+  # functions actually reference live in bootstrap.sql, not here.
   require_root install_fake_extensions
-  local n
-  for n in pg_net supabase_vault pg_graphql pgjwt pg_cron; do
+  local n placement
+  for n in ${FAKE_EXTENSIONS}; do
+    # pgsodium is the one stub that has to name a schema. base.sql creates it as
+    # a bare `create extension if not exists "pgsodium";`, and the dump runs with
+    # an empty search_path, so a relocatable stub has nowhere to land and the
+    # statement fails with "no schema has been selected to create in". The stub
+    # holds no objects, so the schema it names is nominal.
+    if [ "${n}" = "pgsodium" ]; then
+      placement="relocatable = false"$'\n'"schema = 'public'"
+    else
+      placement="relocatable = true"
+    fi
     cat > "${EXTDIR}/${n}.control" <<CTL
 comment = 'native-dev stub for ${n} (schema/migration/type work only, no runtime behaviour)'
 default_version = '1.0'
-relocatable = true
+${placement}
 CTL
     echo "-- native-dev stub: no objects (see supabase/dev-native/bootstrap.sql)" > "${EXTDIR}/${n}--1.0.sql"
   done
-  log "installed fake extension stubs: pg_net supabase_vault pg_graphql pgjwt pg_cron"
+  log "installed fake extension stubs: ${FAKE_EXTENSIONS}"
 }
 
 init_cluster() {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -278,11 +278,12 @@ verify_jwt = true
 [functions.embed-corpus-row]
 enabled = true
 # Internal-only: called by Postgres triggers (via pg_net) on source-table
-# changes. JWT verification rejects random internet callers — triggers
-# send the calling user's auth header (or a service-role JWT fallback
-# from vault) so legitimate trigger invocations pass; a raw POST from
-# the public internet without a Supabase-issued JWT gets a 401 from the
-# runtime before the function code runs.
+# changes. The trigger forwards the calling user's auth header, and with
+# no PostgREST session (a Studio or psql edit) it skips the dispatch
+# rather than send an unauthenticated request. A raw POST from the public
+# internet gets a 401 from the runtime before the function code runs, and
+# the function itself requires role = 'authenticated', so anon and
+# service-role tokens get a 403.
 verify_jwt = true
 
 [analytics]

--- a/supabase/dev-native/extensions/README.md
+++ b/supabase/dev-native/extensions/README.md
@@ -6,7 +6,7 @@ Supabase Postgres flavour. Most are real and available on a stock Postgres 16
 (`vector` / pgvector — built from source by `scripts/db-native.sh` because apt
 ships 0.6.0 and the dump needs the `halfvec`/`sparsevec` grants from ≥0.7).
 
-These five are **not** available on a native Postgres and aren't needed for
+These six are **not** available on a native Postgres and aren't needed for
 schema / migration / seed / type / dump work, so `scripts/db-native.sh` installs
 a tiny empty "extension" for each, purely so `create extension <name>` succeeds:
 
@@ -17,6 +17,15 @@ a tiny empty "extension" for each, purely so `create extension <name>` succeeds:
 | `pg_graphql`     | GraphQL API layer; never called by the schema             |
 | `pgjwt`          | JWT signing in SQL; never called by the schema            |
 | `pg_cron`        | job scheduler; no jobs are scheduled in the schema        |
+| `pgsodium`       | secret-key management; never called by the schema         |
+
+`pgsodium` is the one stub that names a schema. `base.sql` creates it as a
+bare `create extension if not exists "pgsodium";` and the dump runs with an
+empty `search_path`, so a relocatable stub has nowhere to land and the
+statement fails with "no schema has been selected to create in". Its stub
+pins `schema = 'public'`, which is nominal — the stub holds no objects. The
+extension is enabled on production, so every regenerated dump emits that
+line.
 
 `pgjwt` is dropped from the live schema by migration
 `20260826120000_drop_pgjwt.sql`, but the January 2025 baseline migration
@@ -29,5 +38,5 @@ The real objects a couple of functions reference (`net.http_post`,
 
 The stub `.control` + `--1.0.sql` files are written into Postgres's extension
 directory at runtime by `scripts/db-native.sh` (see `install_fake_extensions`),
-so there are no per-extension files checked in here — the list above is the
-source of truth.
+so there are no per-extension files checked in here. The names come from the
+script's `FAKE_EXTENSIONS` list; add a name there and a row above together.

--- a/supabase/dev-native/extensions/README.md
+++ b/supabase/dev-native/extensions/README.md
@@ -18,6 +18,11 @@ a tiny empty "extension" for each, purely so `create extension <name>` succeeds:
 | `pgjwt`          | JWT signing in SQL; never called by the schema            |
 | `pg_cron`        | job scheduler; no jobs are scheduled in the schema        |
 
+`pgjwt` is dropped from the live schema by migration
+`20260826120000_drop_pgjwt.sql`, but the January 2025 baseline migration
+still creates it, so the stub stays for anyone who replays that file with
+`scripts/db-native.sh apply`.
+
 The real objects a couple of functions reference (`net.http_post`,
 `vault.decrypted_secrets`) are created as plain objects in
 `supabase/dev-native/bootstrap.sql`, not by these extensions.

--- a/supabase/migrations/20260826120000_drop_pgjwt.sql
+++ b/supabase/migrations/20260826120000_drop_pgjwt.sql
@@ -1,0 +1,13 @@
+-- Drop pgjwt. Supabase deprecated the extension, and nothing in this schema
+-- calls it: no function, view, policy or trigger references sign(), verify(),
+-- url_encode(), url_decode() or algorithm_sign().
+--
+-- The one place the database makes an authenticated outbound call is
+-- trigger_notify_corpus_embed_change, and it forwards the caller's PostgREST
+-- authorization header to the embed-corpus-row edge function rather than
+-- signing a token in SQL. pgcrypto stays — pgjwt depended on it, not the
+-- reverse, and the schema uses it directly.
+--
+-- No `cascade`: if a dependency turns up that this audit missed, the migration
+-- fails here instead of dropping the dependent object.
+drop extension if exists "pgjwt";

--- a/supabase/schemas/base.sql
+++ b/supabase/schemas/base.sql
@@ -56,10 +56,6 @@ create extension if not exists "pgcrypto"
 with
 	schema "extensions";
 
-create extension if not exists "pgjwt"
-with
-	schema "extensions";
-
 create extension if not exists "supabase_vault"
 with
 	schema "vault";


### PR DESCRIPTION
Removes the deprecated `pgjwt` extension from the schema and adds `pgsodium` to the native dev stubs, allowing `scripts/db-native.sh reset` to load `base.sql` without stopping at the pgsodium creation line.

## Changes

- **Drop `pgjwt` extension** via new migration `20260826120000_drop_pgjwt.sql`. The extension was deprecated by Supabase and nothing in the schema calls it — the one authenticated outbound call forwards the caller's PostgREST auth header instead of signing a JWT in SQL.

- **Add `pgsodium` to native dev stubs.** The regenerated dump creates this extension (it's enabled on production), but `scripts/db-native.sh` had no stub for it, causing `reset` to fail. The stub pins `schema = 'public'` and `relocatable = false` because `base.sql` runs with an empty `search_path`, so a relocatable stub has nowhere to land.

- **Refactor `install_fake_extensions()` to use a `FAKE_EXTENSIONS` variable** for the list of stubs, making it easier to maintain and document. Updated the README to explain why `pgsodium` needs special handling and why `pgjwt` stays in the stub list (for replaying the January 2025 baseline migration).

- **Update `embed-corpus-row` function docs** in `config.toml` to clarify that the trigger forwards the calling user's auth header rather than signing a JWT, and explain the JWT verification strategy.

## Implementation notes

`pgsodium` is the only stub that cannot be relocatable. The dump creates it as a bare `create extension if not exists "pgsodium";` and runs with `search_path = ''`, so without an explicit schema, Postgres fails with "no schema has been selected to create in". The stub holds no objects, so the schema name is nominal — it just needs to exist for the statement to succeed.

https://claude.ai/code/session_01Eeem8GvM1CBr51NBg3fAh5