### PR TITLE
Batch the last fan-out handlers, and drop the unreachable translation delete

### DIFF
--- a/src/features/phrases/collections.ts
+++ b/src/features/phrases/collections.ts
@@ -162,17 +162,12 @@ export const phraseTranslationsCollection = createCollection(
 			)
 			return { refetch: false }
 		},
-		onDelete: async ({ transaction }) => {
-			await supabase
-				.from('phrase_translation')
-				.delete()
-				.in(
-					'id',
-					transaction.mutations.map((m) => m.original.id)
-				)
-				.throwOnError()
-			return { refetch: false }
-		},
+		// No onDelete: `phrase_translation` carries no delete RLS policy, so a
+		// hard delete returns 0 rows and no error. Archiving is an update —
+		// `collection.update(id, (draft) => { draft.archived = true })` — which
+		// onUpdate above persists. Leaving the handler off makes a stray
+		// `.delete()` throw MissingDeleteHandlerError instead of silently
+		// dropping the row from the local collection until the next sync.
 	})
 )
 

--- a/src/features/phrases/collections.ts
+++ b/src/features/phrases/collections.ts
@@ -162,12 +162,6 @@ export const phraseTranslationsCollection = createCollection(
 			)
 			return { refetch: false }
 		},
-		// No onDelete: `phrase_translation` carries no delete RLS policy, so a
-		// hard delete returns 0 rows and no error. Archiving is an update —
-		// `collection.update(id, (draft) => { draft.archived = true })` — which
-		// onUpdate above persists. Leaving the handler off makes a stray
-		// `.delete()` throw MissingDeleteHandlerError instead of silently
-		// dropping the row from the local collection until the next sync.
 	})
 )
 

--- a/src/features/phrases/collections.ts
+++ b/src/features/phrases/collections.ts
@@ -45,30 +45,25 @@ export const phrasesCollection = createCollection(
 		autoIndex: 'eager',
 		defaultIndexType: BasicIndex,
 		onInsert: async ({ transaction }) => {
-			await Promise.all(
-				transaction.mutations.map(async (m) => {
-					const r = m.modified
-					const submitted = {
-						id: r.id,
-						lang: r.lang,
-						text: r.text,
-						only_reverse: r.only_reverse,
-						...(r.added_by ? { added_by: r.added_by } : {}),
-					}
-					const { data } = await supabase
-						.from('phrase')
-						.insert(submitted)
-						.select()
-						.throwOnError()
-					const row = data?.[0]
-					should(
-						`phrase ${r.id} insert returned the row it wrote`,
-						rowMatches(submitted, row),
-						{ submitted, returned: row }
-					)
-					if (row) writeSyncedRow(phrasesCollection, PhraseSchema.parse(row))
-				})
+			const submitted = transaction.mutations.map((m) => ({
+				id: m.modified.id,
+				lang: m.modified.lang,
+				text: m.modified.text,
+				only_reverse: m.modified.only_reverse,
+				...(m.modified.added_by ? { added_by: m.modified.added_by } : {}),
+			}))
+			const { data } = await supabase
+				.from('phrase')
+				.insert(submitted)
+				.select()
+				.throwOnError()
+			const returned = data?.map((row) => PhraseSchema.parse(row)) ?? []
+			should(
+				'phrase insert returned one row per phrase the optimistic insert added',
+				allRowsMatch(submitted, returned),
+				{ submitted, returned }
 			)
+			writeSyncedRows(phrasesCollection, returned)
 			return { refetch: false }
 		},
 		onUpdate: async ({ transaction }) => {
@@ -168,15 +163,14 @@ export const phraseTranslationsCollection = createCollection(
 			return { refetch: false }
 		},
 		onDelete: async ({ transaction }) => {
-			await Promise.all(
-				transaction.mutations.map(async (m) => {
-					await supabase
-						.from('phrase_translation')
-						.delete()
-						.eq('id', m.original.id)
-						.throwOnError()
-				})
-			)
+			await supabase
+				.from('phrase_translation')
+				.delete()
+				.in(
+					'id',
+					transaction.mutations.map((m) => m.original.id)
+				)
+				.throwOnError()
 			return { refetch: false }
 		},
 	})

--- a/src/features/requests/collections.ts
+++ b/src/features/requests/collections.ts
@@ -189,23 +189,22 @@ export const commentsCollection = createCollection(
 			return { refetch: false }
 		},
 		onDelete: async ({ transaction }) => {
-			await Promise.all(
-				transaction.mutations.map(async (m) => {
-					const { data } = await supabase
-						.from('request_comment')
-						.delete()
-						.eq('id', m.original.id)
-						.select()
-						.throwOnError()
-					// A delete with .select() returns the rows it removed; confirm
-					// we removed exactly the targeted comment. Stripped from
-					// production by the Vite plugin.
-					should(
-						`request_comment delete removed comment ${m.original.id}`,
-						data?.length === 1 && data[0].id === m.original.id,
-						{ targetId: m.original.id, returned: data }
-					)
-				})
+			const ids = transaction.mutations.map((m) => m.original.id)
+			const { data } = await supabase
+				.from('request_comment')
+				.delete()
+				.in('id', ids)
+				.select()
+				.throwOnError()
+			// A delete with .select() returns the rows it removed; confirm we
+			// removed exactly the targeted comments. Stripped from production
+			// by the Vite plugin.
+			const returned = data ?? []
+			should(
+				'request_comment delete removed one row per targeted comment',
+				returned.length === ids.length &&
+					ids.every((id) => returned.some((row) => row.id === id)),
+				{ submitted: ids, returned }
 			)
 			// Cascade-deleted replies and phrase links linger in the local
 			// collections until the next stale refetch, but they don't render
@@ -387,21 +386,21 @@ export const messageTagsCollection = createCollection(
 			return { refetch: false }
 		},
 		onDelete: async ({ transaction }) => {
-			await Promise.all(
-				transaction.mutations.map(async (m) => {
-					const { data } = await supabase
-						.from('message_tag')
-						.delete()
-						.eq('slug', m.original.slug)
-						.select()
-						.throwOnError()
-					if (!data || data.length === 0) {
-						throw new Error(
-							`Delete on message_tag "${m.original.slug}" affected no rows (permission denied or row removed).`
-						)
-					}
-				})
-			)
+			// .select() so we can count the rows actually removed: an RLS-blocked
+			// DELETE returns 0 rows with no PostgREST error. Throwing rolls the
+			// optimistic state back and surfaces the failure.
+			const slugs = transaction.mutations.map((m) => m.original.slug)
+			const { data } = await supabase
+				.from('message_tag')
+				.delete()
+				.in('slug', slugs)
+				.select()
+				.throwOnError()
+			if ((data?.length ?? 0) !== slugs.length) {
+				throw new Error(
+					`Delete on message_tag affected ${data?.length ?? 0} of ${slugs.length} rows (permission denied or row removed).`
+				)
+			}
 			return { refetch: false }
 		},
 	})

--- a/src/features/requests/collections.ts
+++ b/src/features/requests/collections.ts
@@ -196,9 +196,6 @@ export const commentsCollection = createCollection(
 				.in('id', ids)
 				.select()
 				.throwOnError()
-			// A delete with .select() returns the rows it removed; confirm we
-			// removed exactly the targeted comments. Stripped from production
-			// by the Vite plugin.
 			const returned = data ?? []
 			should(
 				'request_comment delete removed one row per targeted comment',
@@ -386,9 +383,6 @@ export const messageTagsCollection = createCollection(
 			return { refetch: false }
 		},
 		onDelete: async ({ transaction }) => {
-			// .select() so we can count the rows actually removed: an RLS-blocked
-			// DELETE returns 0 rows with no PostgREST error. Throwing rolls the
-			// optimistic state back and surfaces the failure.
 			const slugs = transaction.mutations.map((m) => m.original.slug)
 			const { data } = await supabase
 				.from('message_tag')


### PR DESCRIPTION
Closes #728.

Three commits, reviewable in order. The first is the mechanical batching the issue asks for. The second acts on one of the audit findings the issue asks me to surface. The third drops comments that restate the house pattern.

## 1. Batch the last four fan-out handlers

#784 batched five of the six inserts #728 listed, as a side effect of writing the server's rows back. Four sites still sent one round-trip per mutation through `Promise.all(transaction.mutations.map(...))`.

| Handler | File | Change |
|---|---|---|
| `phrasesCollection.onInsert` | `src/features/phrases/collections.ts` | batch + `writeSyncedRows` |
| `phraseTranslationsCollection.onDelete` | `src/features/phrases/collections.ts` | `.delete().in('id', ids)` |
| `commentsCollection.onDelete` | `src/features/requests/collections.ts` | `.in('id', ids)`, guard reshaped |
| `messageTagsCollection.onDelete` | `src/features/requests/collections.ts` | `.in('slug', slugs)`, guard reshaped |

`phrasesCollection.onInsert` is the one that needed more than a mechanical rewrite. #784 gave it a `.select()` and a per-row `writeSyncedRow`, but left it fanned out — the only insert in the file whose siblings `phraseTranslations` and `phraseTagLinks` both got the batched `allRowsMatch` + `writeSyncedRows` shape. Batching it meant converting the write-back too, not just the query. It now matches its siblings.

Both guards moved onto the batch rather than being dropped:

- `request_comment` delete asserts the returned row set covers every targeted id, replacing the per-row "removed exactly this comment" check.
- `message_tag` delete throws when the affected count misses the requested count, preserving the RLS-blocked-delete rollback.

Every fan-out site left in `src/features/*/collections.ts` is now an `onUpdate` handler or a composite-key delete. `.update()` applies one patch to every matched row, so it cannot carry per-row values, and `.in()` matches a column rather than a tuple. That covers `deck`, `playlists`, `profile` and `notifications` as well as the three files here.

## 2. Drop the unreachable hard-delete on phrase translations

This is the archive/hard-delete question the issue asks about, and the answer turned out to be concrete rather than a design debate.

`phrase_translation` has RLS enabled with select, insert and update policies, but **no delete policy**. PostgREST reports a denied delete as 0 rows and no error, so the handler resolved successfully while the server kept the row: the optimistic delete dropped it from the local collection, and the next sync brought it back.

Nothing called it. The UI archives a translation through `onUpdate` (`src/components/card-pieces/add-translations.tsx`), and migration `20260116130436_add_translation_edit_delete.sql` added the `archived` column for exactly that. That is the documented rule — `docs/mutations.md` says a removal is a soft delete that reaches the collection as an ordinary update, and the three upvote tables already carry no `onDelete` handler for the same reason.

Removing the handler rather than rewriting it is what makes a stray `.delete()` fail loudly, since TanStack DB throws `MissingDeleteHandlerError` when none is configured.

## 3. Drop three comments that restate the house pattern

A collection with no `onDelete`, and a `should()` assertion over a delete's `.select()` rows, are both ordinary here. The third comment repeated, on `messageTagsCollection.onDelete`, what the `onUpdate` handler twenty lines above already says about `.select()` and RLS.

## The other five hard deletes are unfinished work, not exceptions

An earlier draft of this description called the remaining `onDelete` handlers "legitimately reachable" because their tables carry delete policies. That reads the situation backwards. Every removal should be an update on both sides of the wire — that is what keeps a collection a 1-to-1 mirror of its table, which is most of what TanStack DB buys us. A table having a delete policy is not a reason to use it.

So `phrase_tag`, `playlist_phrase_link`, `request_comment`, `message_tag`, `message_tag_link` and the loose `.delete()` in `comment-dialog.tsx` are the tail of an unfinished migration. Filed as #786, with the per-table migration steps and the one real design question (`request_comment`'s cascade). This PR does not touch them.

`cardsCollection.onUpdate` (`src/features/deck/collections.ts`) remains the one ungrouped shared-payload update that the [2026-08-05 comment](https://github.com/mhsnook/sunlo/issues/728#issuecomment-5188831678) flagged. Separate scope again.

## Verification

- `pnpm check` — clean
- `pnpm lint` — exit 0, no findings in the changed files
- `pnpm test:unit` — 301 passed
- `oxfmt --check` — clean on the changed files

**I could not run the scenetests.** This container has no Docker and no Supabase CLI, so `pnpm scene` cannot start. The tags, translations and requests flows are unverified against a live database, and the translation-archive flow is the one most worth a look given commit 2.